### PR TITLE
Issue #341 Formatting hyperlink in Tabbed Page Wizard

### DIFF
--- a/templates/Pages/TabbedPivot/.template.config/description.md
+++ b/templates/Pages/TabbedPivot/.template.config/description.md
@@ -1,3 +1,3 @@
 The tabbed page is used for navigating frequently accessed, distinct content categories. Pivots allow for navigation between two or more content panes and relies on text headers to articulate the different sections of content.
 
-To find out more if this is a good solution for you, head to https://docs.microsoft.com/en-us/windows/uwp/controls-and-patterns/tabs-pivot.
+To find out more if this is a good solution for you, head to [docs.microsoft.com](https://docs.microsoft.com/en-us/windows/uwp/controls-and-patterns/tabs-pivot).


### PR DESCRIPTION
Fix for issue #341.
Formatting the hyperlink in the Tabbed page correctly inline with other pages.