### PR TITLE
Fix for #328

### DIFF
--- a/code/src/Core/Core.csproj
+++ b/code/src/Core/Core.csproj
@@ -56,7 +56,7 @@
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.3.0-beta1\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.TemplateEngine.Abstractions.1.0.0-beta2-20170405-182\lib\net45\Microsoft.TemplateEngine.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.TemplateEngine.Abstractions.1.0.0-beta2-20170505-222\lib\net45\Microsoft.TemplateEngine.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.TemplateEngine.Core.1.0.0-beta2-20170405-182\lib\net45\Microsoft.TemplateEngine.Core.dll</HintPath>
@@ -65,13 +65,13 @@
       <HintPath>..\..\packages\Microsoft.TemplateEngine.Core.Contracts.1.0.0-beta2-20170405-182\lib\net45\Microsoft.TemplateEngine.Core.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Edge, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.TemplateEngine.Edge.1.0.0-beta2-20170405-182\lib\net45\Microsoft.TemplateEngine.Edge.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.TemplateEngine.Edge.1.0.0-beta2-20170505-222\lib\net45\Microsoft.TemplateEngine.Edge.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.1.0.0-beta2-20170405-182\lib\net45\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Utils, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.TemplateEngine.Utils.1.0.0-beta2-20170405-182\lib\net45\Microsoft.TemplateEngine.Utils.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.TemplateEngine.Utils.1.0.0-beta2-20170505-222\lib\net45\Microsoft.TemplateEngine.Utils.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/code/src/Core/app.config
+++ b/code/src/Core/app.config
@@ -23,6 +23,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/code/src/Core/packages.config
+++ b/code/src/Core/packages.config
@@ -6,12 +6,12 @@
   <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.3.0-beta1" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.3.0-beta1" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.3.0-beta1" targetFramework="net452" />
-  <package id="Microsoft.TemplateEngine.Abstractions" version="1.0.0-beta2-20170405-182" targetFramework="net462" />
+  <package id="Microsoft.TemplateEngine.Abstractions" version="1.0.0-beta2-20170505-222" targetFramework="net462" />
   <package id="Microsoft.TemplateEngine.Core" version="1.0.0-beta2-20170405-182" targetFramework="net462" />
   <package id="Microsoft.TemplateEngine.Core.Contracts" version="1.0.0-beta2-20170405-182" targetFramework="net462" />
-  <package id="Microsoft.TemplateEngine.Edge" version="1.0.0-beta2-20170405-182" targetFramework="net462" />
+  <package id="Microsoft.TemplateEngine.Edge" version="1.0.0-beta2-20170505-222" targetFramework="net462" />
   <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta2-20170405-182" targetFramework="net462" />
-  <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta2-20170405-182" targetFramework="net462" />
+  <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta2-20170505-222" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net462" />
   <package id="System.Collections" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net462" />

--- a/code/test/Artifacts/app.config
+++ b/code/test/Artifacts/app.config
@@ -18,6 +18,10 @@
         <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/code/test/Core.Test/App.config
+++ b/code/test/Core.Test/App.config
@@ -31,6 +31,10 @@
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/code/test/Templates.Test/App.config
+++ b/code/test/Templates.Test/App.config
@@ -30,6 +30,10 @@
         <assemblyIdentity name="Microsoft.VisualStudio.ComponentModelHost" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Fix for #328 for VS Preview.  Newer NuGet reference fixed it.  Unit tests didn't seem to catch this however.  Only release mode seemed to trigger it.