### PR TITLE
Feature #350 Including support for default Windows Theme

### DIFF
--- a/templates/Pages/Settings.CodeBehind/Services/ThemeSelectorService.cs
+++ b/templates/Pages/Settings.CodeBehind/Services/ThemeSelectorService.cs
@@ -13,6 +13,8 @@ namespace Param_RootNamespace.Services
         public static event EventHandler<ElementTheme> OnThemeChanged = delegate { };
 
         public static bool IsLightThemeEnabled => Theme == ElementTheme.Light;
+        public static bool IsDarkThemeEnabled => Theme == ElementTheme.Dark;
+        public static bool IsDefaultThemeEnabled => Theme == ElementTheme.Default;
         public static ElementTheme Theme { get; set; }
 
         public static async Task InitializeAsync()
@@ -20,16 +22,11 @@ namespace Param_RootNamespace.Services
             Theme = await LoadThemeFromSettingsAsync();
         }
 
-        public static async Task SwitchThemeAsync()
+        public static async Task SetThemeAsync(string themeName)
         {
-            if (Theme == ElementTheme.Dark)
-            {
-                await SetThemeAsync(ElementTheme.Light);
-            }
-            else
-            {
-                await SetThemeAsync(ElementTheme.Dark);
-            }
+            ElementTheme theme;
+            Enum.TryParse<ElementTheme>(themeName, out theme);
+            await SetThemeAsync(theme);
         }
 
         public static async Task SetThemeAsync(ElementTheme theme)
@@ -51,13 +48,9 @@ namespace Param_RootNamespace.Services
 
         private static async Task<ElementTheme> LoadThemeFromSettingsAsync()
         {
-            ElementTheme cacheTheme = ElementTheme.Light;
+            ElementTheme cacheTheme = ElementTheme.Default;
             string themeName = await ApplicationData.Current.LocalSettings.ReadAsync<string>(SettingsKey);
-            if (String.IsNullOrEmpty(themeName))
-            {
-                cacheTheme = Application.Current.RequestedTheme == ApplicationTheme.Dark ? ElementTheme.Dark : ElementTheme.Light;
-            }
-            else
+            if (!String.IsNullOrEmpty(themeName))
             {
                 Enum.TryParse<ElementTheme>(themeName, out cacheTheme);
             }

--- a/templates/Pages/Settings.CodeBehind/Strings/en-us/Resources_postaction.resw
+++ b/templates/Pages/Settings.CodeBehind/Strings/en-us/Resources_postaction.resw
@@ -7,11 +7,14 @@
   <data name="SettingsPage_Theme.Text" xml:space="preserve">
     <value>Theme</value>
   </data>
-  <data name="SettingsPage_ThemeToggle.OnContent" xml:space="preserve">  
+  <data name="SettingsPage_Theme_Light.Content" xml:space="preserve">  
     <value>Light</value>
   </data>
-  <data name="SettingsPage_ThemeToggle.OffContent" xml:space="preserve">    
+  <data name="SettingsPage_Theme_Dark.Content" xml:space="preserve">    
     <value>Dark</value>
+  </data>
+  <data name="SettingsPage_Theme_Default.Content" xml:space="preserve">    
+    <value>Windows default</value>
   </data>
   <data name="SettingsPage_About.Text" xml:space="preserve">    
     <value>About this application</value>

--- a/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml
@@ -23,13 +23,26 @@
             <StackPanel Grid.Row="1" Margin="0,16,0,0">
                 <TextBlock
                     x:Uid="SettingsPage_Theme"
-                    Style="{ThemeResource TitleTextBlockStyle}"/>
-                <ToggleSwitch
-                    x:Uid="SettingsPage_ThemeToggle"
-                    IsOn="{x:Bind IsLightThemeEnabled, Mode=OneWay}"
-                    Toggled="ThemeToggle_Toggled"
-                    Margin="0,4,0,0">
-                </ToggleSwitch>
+                    Style="{ThemeResource TitleTextBlockStyle}"
+                    Margin="0,0,0,4"/>
+                <RadioButton
+                    x:Uid="SettingsPage_Theme_Light"
+                    IsChecked="{x:Bind IsLightThemeEnabled, Mode=OneWay}"
+                    GroupName="AppTheme"
+                    Checked="Theme_Checked"
+                    Tag="Light"/>
+                <RadioButton
+                    x:Uid="SettingsPage_Theme_Dark"
+                    IsChecked="{x:Bind IsDarkThemeEnabled, Mode=OneWay}"
+                    GroupName="AppTheme"
+                    Checked="Theme_Checked"
+                    Tag="Dark"/>
+                <RadioButton
+                    x:Uid="SettingsPage_Theme_Default"
+                    IsChecked="{x:Bind IsDefaultThemeEnabled, Mode=OneWay}"
+                    GroupName="AppTheme"
+                    Checked="Theme_Checked"
+                    Tag="Default"/>
             </StackPanel>
 
             <StackPanel Grid.Row="2" Margin="0,16,0,0">

--- a/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml.cs
+++ b/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml.cs
@@ -16,6 +16,20 @@ namespace Param_ItemNamespace.Views
             set { Set(ref _isLightThemeEnabled, value); }
         }
 
+        private bool _isDarkThemeEnabled;
+        public bool IsDarkThemeEnabled
+        {
+            get { return _isDarkThemeEnabled; }
+            set { Set(ref _isDarkThemeEnabled, value); }
+        }
+
+        private bool _isDefaultThemeEnabled;
+        public bool IsDefaultThemeEnabled
+        {
+            get { return _isDefaultThemeEnabled; }
+            set { Set(ref _isDefaultThemeEnabled, value); }
+        }
+
         private string _appDescription;
         public string AppDescription
         {
@@ -31,6 +45,8 @@ namespace Param_ItemNamespace.Views
         private void Initialize()
         {
             IsLightThemeEnabled = ThemeSelectorService.IsLightThemeEnabled;
+            IsDarkThemeEnabled = ThemeSelectorService.IsDarkThemeEnabled;
+            IsDefaultThemeEnabled = ThemeSelectorService.IsDefaultThemeEnabled;
             AppDescription = GetAppDescription();
         }
 
@@ -43,16 +59,13 @@ namespace Param_ItemNamespace.Views
             return $"{package.DisplayName} - {version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
         }
 
-        private async void ThemeToggle_Toggled(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private async void Theme_Checked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            //Only switch theme if value has changed (not on initialization)
-            var toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
+            var radioButton = sender as RadioButton;
+            if (radioButton != null)
             {
-                if (toggleSwitch.IsOn != ThemeSelectorService.IsLightThemeEnabled)
-                {
-                    await ThemeSelectorService.SwitchThemeAsync();
-                }
+                string themeName = radioButton.Tag.ToString();
+                await ThemeSelectorService.SetThemeAsync(themeName);
             }
         }
     }

--- a/templates/Pages/Settings/Services/ThemeSelectorService.cs
+++ b/templates/Pages/Settings/Services/ThemeSelectorService.cs
@@ -13,6 +13,9 @@ namespace Param_RootNamespace.Services
         public static event EventHandler<ElementTheme> OnThemeChanged = delegate { };
 
         public static bool IsLightThemeEnabled => Theme == ElementTheme.Light;
+        public static bool IsDarkThemeEnabled => Theme == ElementTheme.Dark;
+        public static bool IsDefaultThemeEnabled => Theme == ElementTheme.Default;
+
         public static ElementTheme Theme { get; set; }
 
         public static async Task InitializeAsync()
@@ -20,16 +23,11 @@ namespace Param_RootNamespace.Services
             Theme = await LoadThemeFromSettingsAsync();
         }
 
-        public static async Task SwitchThemeAsync()
+        public static async Task SetThemeAsync(string themeName)
         {
-            if (Theme == ElementTheme.Dark)
-            {
-                await SetThemeAsync(ElementTheme.Light);
-            }
-            else
-            {
-                await SetThemeAsync(ElementTheme.Dark);
-            }
+            ElementTheme theme;
+            Enum.TryParse<ElementTheme>(themeName, out theme);
+            await SetThemeAsync(theme);
         }
 
         public static async Task SetThemeAsync(ElementTheme theme)
@@ -51,13 +49,9 @@ namespace Param_RootNamespace.Services
 
         private static async Task<ElementTheme> LoadThemeFromSettingsAsync()
         {
-            ElementTheme cacheTheme = ElementTheme.Light;
+            ElementTheme cacheTheme = ElementTheme.Default;
             string themeName = await ApplicationData.Current.LocalSettings.ReadAsync<string>(SettingsKey);
-            if (String.IsNullOrEmpty(themeName))
-            {
-                cacheTheme = Application.Current.RequestedTheme == ApplicationTheme.Dark ? ElementTheme.Dark : ElementTheme.Light;
-            }
-            else
+            if (!String.IsNullOrEmpty(themeName))
             {
                 Enum.TryParse<ElementTheme>(themeName, out cacheTheme);
             }

--- a/templates/Pages/Settings/Strings/en-us/Resources_postaction.resw
+++ b/templates/Pages/Settings/Strings/en-us/Resources_postaction.resw
@@ -7,11 +7,14 @@
   <data name="SettingsPage_Theme.Text" xml:space="preserve">
     <value>Theme</value>
   </data>
-  <data name="SettingsPage_ThemeToggle.OnContent" xml:space="preserve">  
+  <data name="SettingsPage_Theme_Light.Content" xml:space="preserve">  
     <value>Light</value>
   </data>
-  <data name="SettingsPage_ThemeToggle.OffContent" xml:space="preserve">    
+  <data name="SettingsPage_Theme_Dark.Content" xml:space="preserve">    
     <value>Dark</value>
+  </data>
+  <data name="SettingsPage_Theme_Default.Content" xml:space="preserve">    
+    <value>Windows default</value>
   </data>
   <data name="SettingsPage_About.Text" xml:space="preserve">    
     <value>About this application</value>

--- a/templates/Pages/Settings/ViewModels/SettingsPageViewModel.cs
+++ b/templates/Pages/Settings/ViewModels/SettingsPageViewModel.cs
@@ -15,6 +15,20 @@ namespace Param_ItemNamespace.ViewModels
             set { Set(ref _isLightThemeEnabled, value); }
         }
 
+        private bool _isDarkThemeEnabled;
+        public bool IsDarkThemeEnabled
+        {
+            get { return _isDarkThemeEnabled; }
+            set { Set(ref _isDarkThemeEnabled, value); }
+        }
+
+        private bool _isDefaultThemeEnabled;
+        public bool IsDefaultThemeEnabled
+        {
+            get { return _isDefaultThemeEnabled; }
+            set { Set(ref _isDefaultThemeEnabled, value); }
+        }
+
         private string _appDescription;
         public string AppDescription
         {
@@ -22,16 +36,18 @@ namespace Param_ItemNamespace.ViewModels
             set { Set(ref _appDescription, value); }
         }
 
-        public ICommand SwitchThemeCommand { get; private set; }
+        public ICommand SelectThemeCommand { get; private set; }
 
         public SettingsPageViewModel()
         {
-            SwitchThemeCommand = new RelayCommand(async () => { await ThemeSelectorService.SwitchThemeAsync(); });
+            SelectThemeCommand = new RelayCommand<string>(async (string themeName) => { await ThemeSelectorService.SetThemeAsync(themeName); });
         }
 
         public void Initialize()
         {
             IsLightThemeEnabled = ThemeSelectorService.IsLightThemeEnabled;
+            IsDarkThemeEnabled = ThemeSelectorService.IsDarkThemeEnabled;
+            IsDefaultThemeEnabled = ThemeSelectorService.IsDefaultThemeEnabled;
             AppDescription = GetAppDescription();
         }
 

--- a/templates/Pages/Settings/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings/Views/SettingsPagePage.xaml
@@ -25,17 +25,26 @@
             <StackPanel Grid.Row="1" Margin="0,16,0,0">
                 <TextBlock
                     x:Uid="SettingsPage_Theme"
-                    Style="{ThemeResource TitleTextBlockStyle}"/>
-                <ToggleSwitch
-                    x:Uid="SettingsPage_ThemeToggle"
-                    IsOn="{x:Bind ViewModel.IsLightThemeEnabled, Mode=OneWay}"
-                    Margin="0,4,0,0">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="Toggled">
-                            <ic:InvokeCommandAction Command="{x:Bind ViewModel.SwitchThemeCommand}"/>
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </ToggleSwitch>
+                    Style="{ThemeResource TitleTextBlockStyle}"
+                    Margin="0,0,0,4"/>
+                <RadioButton
+                    x:Uid="SettingsPage_Theme_Light"
+                    IsChecked="{x:Bind ViewModel.IsLightThemeEnabled, Mode=OneWay}"
+                    GroupName="AppTheme"
+                    Command="{x:Bind ViewModel.SelectThemeCommand}"
+                    CommandParameter="Light"/>
+                <RadioButton
+                    x:Uid="SettingsPage_Theme_Dark"
+                    IsChecked="{x:Bind ViewModel.IsDarkThemeEnabled, Mode=OneWay}"
+                    GroupName="AppTheme" 
+                    Command="{x:Bind ViewModel.SelectThemeCommand}"
+                    CommandParameter="Dark"/>
+                <RadioButton
+                    x:Uid="SettingsPage_Theme_Default"
+                    IsChecked="{x:Bind ViewModel.IsDefaultThemeEnabled, Mode=OneWay}"
+                    GroupName="AppTheme"
+                    Command="{x:Bind ViewModel.SelectThemeCommand}"
+                    CommandParameter="Default"/>
             </StackPanel>
 
             <StackPanel Grid.Row="2" Margin="0,16,0,0">

--- a/templates/Projects/Blank/App.xaml
+++ b/templates/Projects/Blank/App.xaml
@@ -2,7 +2,7 @@
     x:Class="wts.BlankProject.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    RequestedTheme="Light">
+    >
 
     <Application.Resources>
         <ResourceDictionary>

--- a/templates/Projects/SplitView/App.xaml
+++ b/templates/Projects/SplitView/App.xaml
@@ -2,7 +2,7 @@
     x:Class="wts.SplitViewProject.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    RequestedTheme="Light">
+    >
 
     <Application.Resources>
         <ResourceDictionary>

--- a/templates/Projects/TabbedPivot/App.xaml
+++ b/templates/Projects/TabbedPivot/App.xaml
@@ -2,7 +2,7 @@
     x:Class="wts.TabbedPivotProject.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    RequestedTheme="Light">
+    >
 
     <Application.Resources>
         <ResourceDictionary>

--- a/templates/_composition/CodeBehind/Page.Settings.AddShellThemeSupport_SplitView/Views/ShellNavigationItem_postaction.cs
+++ b/templates/_composition/CodeBehind/Page.Settings.AddShellThemeSupport_SplitView/Views/ShellNavigationItem_postaction.cs
@@ -5,9 +5,13 @@
             var result = Application.Current.Resources["SystemControlForegroundBaseHighBrush"] as SolidColorBrush;
 
             //{[{
-            if (!Services.ThemeSelectorService.IsLightThemeEnabled)
+            if (Services.ThemeSelectorService.IsLightThemeEnabled)
             {
-                result = Application.Current.Resources["SystemControlForegroundAltHighBrush"] as SolidColorBrush;
+                result = new SolidColorBrush(Windows.UI.Colors.Black);
+            }
+            else if (Services.ThemeSelectorService.IsDarkThemeEnabled)
+            {
+                result = new SolidColorBrush(Windows.UI.Colors.White);
             }
             //}]}
             return result;

--- a/templates/_composition/MVVMBasic/Page.Settings.AddShellThemeSupport_SplitView/ViewModels/ShellNavigationItem_postaction.cs
+++ b/templates/_composition/MVVMBasic/Page.Settings.AddShellThemeSupport_SplitView/ViewModels/ShellNavigationItem_postaction.cs
@@ -3,9 +3,13 @@
             var result = Application.Current.Resources["SystemControlForegroundBaseHighBrush"] as SolidColorBrush;
 
             //{[{
-            if (!Services.ThemeSelectorService.IsLightThemeEnabled)
+            if (Services.ThemeSelectorService.IsLightThemeEnabled)
             {
-                result = Application.Current.Resources["SystemControlForegroundAltHighBrush"] as SolidColorBrush;
+                result = new SolidColorBrush(Windows.UI.Colors.Black);
+            }
+            else if (Services.ThemeSelectorService.IsDarkThemeEnabled)
+            {
+                result = new SolidColorBrush(Windows.UI.Colors.White);
             }
             //}]}
             return result;

--- a/templates/_composition/MVVMLight/Page.Settings.AddShellThemeSupport_SplitView/ViewModels/ShellNavigationItem_postaction.cs
+++ b/templates/_composition/MVVMLight/Page.Settings.AddShellThemeSupport_SplitView/ViewModels/ShellNavigationItem_postaction.cs
@@ -3,9 +3,13 @@
             var result = Application.Current.Resources["SystemControlForegroundBaseHighBrush"] as SolidColorBrush;
 
             //{[{
-            if (!Services.ThemeSelectorService.IsLightThemeEnabled)
+            if (Services.ThemeSelectorService.IsLightThemeEnabled)
             {
-                result = Application.Current.Resources["SystemControlForegroundAltHighBrush"] as SolidColorBrush;
+                result = new SolidColorBrush(Windows.UI.Colors.Black);
+            }
+            else if (Services.ThemeSelectorService.IsDarkThemeEnabled)
+            {
+                result = new SolidColorBrush(Windows.UI.Colors.White);
             }
             //}]}
             return result;

--- a/templates/_composition/MVVMLight/Project/App_postaction.xaml
+++ b/templates/_composition/MVVMLight/Project/App_postaction.xaml
@@ -1,7 +1,7 @@
 <Application
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:vms="using:Param_RootNamespace.ViewModels"
-    RequestedTheme="Light">
+    >
     <Application.Resources>
         <ResourceDictionary>
             <vms:ViewModelLocator x:Key="Locator" />


### PR DESCRIPTION
PR for feature #350 to support **Windows Default theme** in addition to Light and Dark themes. This mode will set the app's theme as the default windows theme which can be controlled directly from 'Color Settings'. 

- Switching to `RadioButton` instead of `ToggleSwitch` since we have 3 modes: Light, Dark and Windows default
- Removed `RequestedTheme='Light'` from Application tag in `App.xaml` since XAML doesn't support a default mode so to respect the system's theme, this has to be removed.
- In `ShellNavigationItem`, brushes `SystemControlForegroundAltHighBrush` and `SystemControlForegroundBaseHighBrush` now behave based on the default windows setting since `RequestedTheme` isn't set to Light in the App.xaml. As a result, they can't be used when the theme is set to Light or Dark _in the app_. So manually setting them to `White` and `Black` (File: `ShellNavigationItem_postaction.cs`). Couldn't find a better approach for this

Screenshot:
<img src="https://cloud.githubusercontent.com/assets/6065982/26178462/d57e9a44-3b7b-11e7-973b-20ed391f64a0.png" width="400">
