### PR TITLE
Delete empty folder created by Visual Studio when cancelling wizard 

### DIFF
--- a/code/src/UI/VisualStudio/SolutionWizard.cs
+++ b/code/src/UI/VisualStudio/SolutionWizard.cs
@@ -78,13 +78,27 @@ namespace Microsoft.Templates.UI.VisualStudio
 
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
         {
-            if (runKind == WizardRunKind.AsNewProject || runKind == WizardRunKind.AsMultiProject)
+            var solutionDirectory = replacementsDictionary["$solutiondirectory$"];
+
+            try
             {
-                _replacementsDictionary = replacementsDictionary;
+                if (runKind == WizardRunKind.AsNewProject || runKind == WizardRunKind.AsMultiProject)
+                {
+                    _replacementsDictionary = replacementsDictionary;
 
-                GenContext.Current = this;
+                    GenContext.Current = this;
 
-                _userSelection = GenController.GetUserSelection();
+                    _userSelection = GenController.GetUserSelection();
+                }
+            }
+            catch (Exception)
+            {
+                if (Directory.Exists(solutionDirectory))
+                {
+                    Directory.Delete(solutionDirectory, true);
+                }
+
+                throw;
             }
         }
 


### PR DESCRIPTION
 Delete empty folder created by Visual Studio when cancelling wizard  without project creation #84