### PR TITLE
Issue350: Switching default theme from RadioButton to ComboBox

### DIFF
--- a/templates/Pages/Settings.CodeBehind/Services/ThemeSelectorService.cs
+++ b/templates/Pages/Settings.CodeBehind/Services/ThemeSelectorService.cs
@@ -14,7 +14,7 @@ namespace Param_RootNamespace.Services
 
         public static bool IsLightThemeEnabled => Theme == ElementTheme.Light;
         public static bool IsDarkThemeEnabled => Theme == ElementTheme.Dark;
-        public static bool IsDefaultThemeEnabled => Theme == ElementTheme.Default;
+        
         public static ElementTheme Theme { get; set; }
 
         public static async Task InitializeAsync()
@@ -22,11 +22,38 @@ namespace Param_RootNamespace.Services
             Theme = await LoadThemeFromSettingsAsync();
         }
 
-        public static async Task SetThemeAsync(string themeName)
+        public static async Task SetThemeAsync(int themeId)
         {
             ElementTheme theme;
-            Enum.TryParse<ElementTheme>(themeName, out theme);
+            switch (themeId)
+            {
+                case 0:
+                    theme = ElementTheme.Light;
+                    break;
+                case 1:
+                    theme = ElementTheme.Dark;
+                    break;
+                case 2:
+                default:
+                    theme = ElementTheme.Default;
+                    break;
+            }
+
             await SetThemeAsync(theme);
+        }
+
+        public static int GetTheme()
+        {
+            switch (Theme)
+            {
+                case ElementTheme.Light:
+                    return 0;
+                case ElementTheme.Dark:
+                    return 1;
+                case ElementTheme.Default:
+                default:
+                    return 2;
+            }
         }
 
         public static async Task SetThemeAsync(ElementTheme theme)

--- a/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml
@@ -25,24 +25,13 @@
                     x:Uid="SettingsPage_Theme"
                     Style="{ThemeResource TitleTextBlockStyle}"
                     Margin="0,0,0,4"/>
-                <RadioButton
-                    x:Uid="SettingsPage_Theme_Light"
-                    IsChecked="{x:Bind IsLightThemeEnabled, Mode=OneWay}"
-                    GroupName="AppTheme"
-                    Checked="Theme_Checked"
-                    Tag="Light"/>
-                <RadioButton
-                    x:Uid="SettingsPage_Theme_Dark"
-                    IsChecked="{x:Bind IsDarkThemeEnabled, Mode=OneWay}"
-                    GroupName="AppTheme"
-                    Checked="Theme_Checked"
-                    Tag="Dark"/>
-                <RadioButton
-                    x:Uid="SettingsPage_Theme_Default"
-                    IsChecked="{x:Bind IsDefaultThemeEnabled, Mode=OneWay}"
-                    GroupName="AppTheme"
-                    Checked="Theme_Checked"
-                    Tag="Default"/>
+                <ComboBox MinWidth="200" 
+                          SelectedIndex="{x:Bind SelectedTheme, Mode=TwoWay}" 
+                          SelectionChanged="Theme_Changed">
+                    <ComboBoxItem x:Uid="SettingsPage_Theme_Light" />
+                    <ComboBoxItem x:Uid="SettingsPage_Theme_Dark" />
+                    <ComboBoxItem x:Uid="SettingsPage_Theme_Default" />
+              </ComboBox>
             </StackPanel>
 
             <StackPanel Grid.Row="2" Margin="0,16,0,0">

--- a/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml.cs
+++ b/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml.cs
@@ -9,25 +9,11 @@ namespace Param_ItemNamespace.Views
         // TODO UWPTemplates: Add other settings as necessary. For help see https://github.com/Microsoft/WindowsTemplateStudio/blob/master/docs/pages/settings.md
         // TODO UWPTemplates: Setup your privacy web in your Resource File, currently set to https://YourPrivacyUrlGoesHere
 
-        private bool _isLightThemeEnabled;
-        public bool IsLightThemeEnabled
+        private int _selectedTheme;
+        public int SelectedTheme
         {
-            get { return _isLightThemeEnabled; }
-            set { Set(ref _isLightThemeEnabled, value); }
-        }
-
-        private bool _isDarkThemeEnabled;
-        public bool IsDarkThemeEnabled
-        {
-            get { return _isDarkThemeEnabled; }
-            set { Set(ref _isDarkThemeEnabled, value); }
-        }
-
-        private bool _isDefaultThemeEnabled;
-        public bool IsDefaultThemeEnabled
-        {
-            get { return _isDefaultThemeEnabled; }
-            set { Set(ref _isDefaultThemeEnabled, value); }
+            get { return _selectedTheme; }
+            set { Set(ref _selectedTheme, value); }
         }
 
         private string _appDescription;
@@ -40,13 +26,11 @@ namespace Param_ItemNamespace.Views
         public SettingsPagePage()
         {
             InitializeComponent();
+            SelectedTheme = ThemeSelectorService.GetTheme();
         }
 
         private void Initialize()
         {
-            IsLightThemeEnabled = ThemeSelectorService.IsLightThemeEnabled;
-            IsDarkThemeEnabled = ThemeSelectorService.IsDarkThemeEnabled;
-            IsDefaultThemeEnabled = ThemeSelectorService.IsDefaultThemeEnabled;
             AppDescription = GetAppDescription();
         }
 
@@ -59,13 +43,12 @@ namespace Param_ItemNamespace.Views
             return $"{package.DisplayName} - {version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
         }
 
-        private async void Theme_Checked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private async void Theme_Changed(object sender, SelectionChangedEventArgs e)
         {
-            var radioButton = sender as RadioButton;
-            if (radioButton != null)
+            var comboBox = sender as ComboBox;
+            if (comboBox != null)
             {
-                string themeName = radioButton.Tag.ToString();
-                await ThemeSelectorService.SetThemeAsync(themeName);
+                await ThemeSelectorService.SetThemeAsync(comboBox.SelectedIndex);
             }
         }
     }

--- a/templates/Pages/Settings/Services/ThemeSelectorService.cs
+++ b/templates/Pages/Settings/Services/ThemeSelectorService.cs
@@ -14,7 +14,6 @@ namespace Param_RootNamespace.Services
 
         public static bool IsLightThemeEnabled => Theme == ElementTheme.Light;
         public static bool IsDarkThemeEnabled => Theme == ElementTheme.Dark;
-        public static bool IsDefaultThemeEnabled => Theme == ElementTheme.Default;
 
         public static ElementTheme Theme { get; set; }
 
@@ -23,11 +22,38 @@ namespace Param_RootNamespace.Services
             Theme = await LoadThemeFromSettingsAsync();
         }
 
-        public static async Task SetThemeAsync(string themeName)
+        public static async Task SetThemeAsync(int themeId)
         {
             ElementTheme theme;
-            Enum.TryParse<ElementTheme>(themeName, out theme);
+            switch (themeId)
+            {
+                case 0:
+                    theme = ElementTheme.Light;
+                    break;
+                case 1:
+                    theme = ElementTheme.Dark;
+                    break;
+                case 2:
+                default:
+                    theme = ElementTheme.Default;
+                    break;
+            }
+
             await SetThemeAsync(theme);
+        }
+
+        public static int GetTheme()
+        {
+            switch (Theme)
+            {
+                case ElementTheme.Light:
+                    return 0;
+                case ElementTheme.Dark:
+                    return 1;
+                case ElementTheme.Default:
+                default:
+                    return 2;
+            }
         }
 
         public static async Task SetThemeAsync(ElementTheme theme)

--- a/templates/Pages/Settings/ViewModels/SettingsPageViewModel.cs
+++ b/templates/Pages/Settings/ViewModels/SettingsPageViewModel.cs
@@ -8,25 +8,11 @@ namespace Param_ItemNamespace.ViewModels
     public class SettingsPageViewModel : System.ComponentModel.INotifyPropertyChanged
     {
         // TODO UWPTemplates: Add other settings as necessary. For help see https://github.com/Microsoft/WindowsTemplateStudio/blob/master/docs/pages/settings.md
-        private bool _isLightThemeEnabled;
-        public bool IsLightThemeEnabled
+        private int _selectedTheme;
+        public int SelectedTheme
         {
-            get { return _isLightThemeEnabled; }
-            set { Set(ref _isLightThemeEnabled, value); }
-        }
-
-        private bool _isDarkThemeEnabled;
-        public bool IsDarkThemeEnabled
-        {
-            get { return _isDarkThemeEnabled; }
-            set { Set(ref _isDarkThemeEnabled, value); }
-        }
-
-        private bool _isDefaultThemeEnabled;
-        public bool IsDefaultThemeEnabled
-        {
-            get { return _isDefaultThemeEnabled; }
-            set { Set(ref _isDefaultThemeEnabled, value); }
+            get { return _selectedTheme; }
+            set { Set(ref _selectedTheme, value); }
         }
 
         private string _appDescription;
@@ -36,18 +22,16 @@ namespace Param_ItemNamespace.ViewModels
             set { Set(ref _appDescription, value); }
         }
 
-        public ICommand SelectThemeCommand { get; private set; }
+        public ICommand SelectionChangeCommand { get; private set; }
 
         public SettingsPageViewModel()
         {
-            SelectThemeCommand = new RelayCommand<string>(async (string themeName) => { await ThemeSelectorService.SetThemeAsync(themeName); });
+            SelectionChangeCommand = new RelayCommand(async () => { await ThemeSelectorService.SetThemeAsync(SelectedTheme); });
         }
 
         public void Initialize()
         {
-            IsLightThemeEnabled = ThemeSelectorService.IsLightThemeEnabled;
-            IsDarkThemeEnabled = ThemeSelectorService.IsDarkThemeEnabled;
-            IsDefaultThemeEnabled = ThemeSelectorService.IsDefaultThemeEnabled;
+            SelectedTheme = ThemeSelectorService.GetTheme();
             AppDescription = GetAppDescription();
         }
 

--- a/templates/Pages/Settings/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings/Views/SettingsPagePage.xaml
@@ -27,24 +27,17 @@
                     x:Uid="SettingsPage_Theme"
                     Style="{ThemeResource TitleTextBlockStyle}"
                     Margin="0,0,0,4"/>
-                <RadioButton
-                    x:Uid="SettingsPage_Theme_Light"
-                    IsChecked="{x:Bind ViewModel.IsLightThemeEnabled, Mode=OneWay}"
-                    GroupName="AppTheme"
-                    Command="{x:Bind ViewModel.SelectThemeCommand}"
-                    CommandParameter="Light"/>
-                <RadioButton
-                    x:Uid="SettingsPage_Theme_Dark"
-                    IsChecked="{x:Bind ViewModel.IsDarkThemeEnabled, Mode=OneWay}"
-                    GroupName="AppTheme" 
-                    Command="{x:Bind ViewModel.SelectThemeCommand}"
-                    CommandParameter="Dark"/>
-                <RadioButton
-                    x:Uid="SettingsPage_Theme_Default"
-                    IsChecked="{x:Bind ViewModel.IsDefaultThemeEnabled, Mode=OneWay}"
-                    GroupName="AppTheme"
-                    Command="{x:Bind ViewModel.SelectThemeCommand}"
-                    CommandParameter="Default"/>
+                <ComboBox MinWidth="200" 
+                          SelectedIndex="{x:Bind ViewModel.SelectedTheme, Mode=TwoWay}">
+                    <i:Interaction.Behaviors>
+                        <ic:EventTriggerBehavior EventName="SelectionChanged">
+                            <ic:InvokeCommandAction Command="{x:Bind ViewModel.SelectionChangeCommand}"/>
+                        </ic:EventTriggerBehavior>
+                    </i:Interaction.Behaviors>
+                    <ComboBoxItem x:Uid="SettingsPage_Theme_Light" />
+                    <ComboBoxItem x:Uid="SettingsPage_Theme_Dark" />
+                    <ComboBoxItem x:Uid="SettingsPage_Theme_Default" />
+                </ComboBox>
             </StackPanel>
 
             <StackPanel Grid.Row="2" Margin="0,16,0,0">


### PR DESCRIPTION
As per the discussion and comments on #360 by @crutkas and @mrlacey, changing to a drop-down instead of radio buttons. 

- Using `SelectedIndex` from `ComboBox` and converting that into `ElementTheme` and vice-versa while setting the theme. So there needs to be mapping to determine which index corresponds to which theme. Also the XAML needs to be in the same order. i.e since the drop-down is expected to have `Light`, `Dark` and then `Default`, index 0 should match with `ElementTheme.Light` and so on. Please take a look at `GetTheme()` and `SetThemeAsync(int themeId)` in `ThemeSelectorService.cs`

**Questions:**
- To avoid the above, could consider using a collection of theme class, where each theme class will have an order. The same class can then be used populate the xaml `ItemsSource` instead of manually adding each item. Additionally the mapping (`SelectedIndex` to `ElementTheme`) won't be needed since each item from the combo box would already have the details.

Adding few screenshots from current implementation:
<img src="https://cloud.githubusercontent.com/assets/6065982/26502452/83f685b6-425a-11e7-9ccf-8863f1ffc94a.png" width="300px">

<img src="https://cloud.githubusercontent.com/assets/6065982/26502482/91221a7a-425a-11e7-9334-20c461b1326a.png" width="300px">
