### PR TITLE
Include  "Universal Windows" in VS Project Template name

### DIFF
--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.vstemplate
@@ -3,7 +3,7 @@
             Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" 
             xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>Windows Template Studio (local)</Name>
+    <Name>Windows Template Studio (Universal Windows; local)</Name>
     <Description>Windows Template Studio quickly builds a UWP app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>


### PR DESCRIPTION
The Project Template name is replaced at build time in order to change it for each environment (loca, dev-nightly, pre-release and pro).

Updated the name in the local template and changed the builds variables to include "Universal Windows" as part of the name.