### PR TITLE
bugfix for sort-usings exception

### DIFF
--- a/code/src/Core/PostActions/Catalog/SortUsings/IEnumerableExtensions.cs
+++ b/code/src/Core/PostActions/Catalog/SortUsings/IEnumerableExtensions.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.SortUsings
             {
                 if (!expression(skipContent[i]))
                 {
-                    return i;
+                    return i + startIndex;
                 }
             }
 

--- a/code/test/Core.Test/PostActions/Catalog/SortUsingsTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/SortUsingsTest.cs
@@ -169,5 +169,57 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             Assert.True(result);
             Assert.Equal(expected, factData);
         }
+
+        [Fact]
+        public void Sort_UsingsNotAtTopOfFile()
+        {
+            var factData = new List<string>
+            {
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "",
+                "using System.Text;",
+                "using Microsoft.Templates;",
+                "",
+                "using System;",
+                "using Microsoft.Templates.Core;",
+                "",
+                "namespace Microsoft.Templates",
+                "{",
+                "}"
+            };
+
+            var expected = new List<string>
+            {
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "// comment",
+                "",
+                "using System;",
+                "using System.Text;",
+                "",
+                "using Microsoft.Templates;",
+                "using Microsoft.Templates.Core;",
+                "",
+                "namespace Microsoft.Templates",
+                "{",
+                "}"
+            };
+
+            var result = factData.SortUsings();
+
+            Assert.True(result);
+            Assert.Equal(expected, factData);
+        }
+
     }
 }


### PR DESCRIPTION
Small fix for an exception that appears only when a template file has content before its using statements (e.g. comments). In that case, LastIndexOfWhile can return a value that is less than startIndex, causing problems in the caller. (For existing templates, startIndex is always 0, so this problem doesn't arise). 