### PR TITLE
Allow for custom AI Endpoint in config file + tagged AI key GUID

### DIFF
--- a/code/src/Core/Configuration/Configuration.cs
+++ b/code/src/Core/Configuration/Configuration.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Templates.Core
         public int DaysToKeepDiagnosticsLogs { get; set; } = 5;
         public int VersionCheckingExpirationMinutes { get; set; } = 0;
         public List<string> AllowedPublicKeysPins { get; set; } = new List<string>() { };
+        public string CustomTelemetryEndpoint { get; set; } = string.Empty;
 
         public static string LoadedConfigFile { get; private set; }
 

--- a/code/src/Core/Configuration/WindowsTemplateStudio.tokenized.config.json
+++ b/code/src/Core/Configuration/WindowsTemplateStudio.tokenized.config.json
@@ -3,6 +3,7 @@
   "CdnUrl": "###CdnUrl###",
   "RemoteTelemetryKey": "###RemoteTelemetryKey###",
   "LogFileFolderPath": "WindowsTemplateStudio\\Logs",
+  "CustomTelemetryEndpoint": "###CustomTelemetryEndpoint###",
   "RepositoryFolderName": "WindowsTemplateStudio",
   "DiagnosticsTraceLevel": "###DiagnosticsTraceLevel###",
   "DaysToKeepDiagnosticsLogs": 5,

--- a/code/src/Core/Diagnostics/TelemetryService.cs
+++ b/code/src/Core/Diagnostics/TelemetryService.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Templates.Core.Diagnostics
 
                 if (VsTelemetryIsOptedIn() && RemoteKeyAvailable())
                 {
+                    if (!string.IsNullOrEmpty(_currentConfig.CustomTelemetryEndpoint))
+                    {
+                        TelemetryConfiguration.Active.TelemetryChannel.EndpointAddress = _currentConfig.CustomTelemetryEndpoint;
+                    }
+
                     SetSessionData();
 
                     _client.TrackEvent(TelemetryEvents.SessionStart);
@@ -315,7 +320,10 @@ namespace Microsoft.Templates.Core.Diagnostics
 
         private bool RemoteKeyAvailable()
         {
-            return Guid.TryParse(_currentConfig.RemoteTelemetryKey, out var aux);
+            // Returns true if a valid AI key or tagged AI key exists
+            bool validGuid = Guid.TryParse(_currentConfig.RemoteTelemetryKey, out var auxA);
+            bool taggedGuid = Guid.TryParse(_currentConfig.RemoteTelemetryKey.Substring(4), out var auxB);
+            return validGuid || taggedGuid;
         }
 
         private static string GetVersion()


### PR DESCRIPTION
Provides for optional custom telemetry endpoint in config file
Tagged AI iKeys won't fail parsing and report as unavailable or invalid
