### PR TITLE
Adjust NewItem Telemetry properties

### DIFF
--- a/code/src/Core/Diagnostics/TelemetryService.cs
+++ b/code/src/Core/Diagnostics/TelemetryService.cs
@@ -303,8 +303,8 @@ namespace Microsoft.Templates.Core.Diagnostics
                     e.Properties[renamedKey] = properties[key];
                 }
             }
-            properties.Add(VsTelemetryProperties.Pages, pageIdentities);
-            properties.Add(VsTelemetryProperties.Features, featureIdentities);
+            e.Properties.Add(VsTelemetryProperties.Pages, pageIdentities);
+            e.Properties.Add(VsTelemetryProperties.Features, featureIdentities);
 
             foreach (var key in metrics.Keys)
             {

--- a/code/src/Core/Diagnostics/VsTelemetryProperties.cs
+++ b/code/src/Core/Diagnostics/VsTelemetryProperties.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Templates.Core.Diagnostics
     public class VsTelemetryProperties
     {
         public const string Prefix = "Wts.";
-        public static string Pages { get; private set; } = TelemetryEvents.Prefix + "Pages";
-        public static string Features { get; private set; } = TelemetryEvents.Prefix + "Features";
+        public static string Pages { get; private set; } = Prefix + "Pages";
+        public static string Features { get; private set; } = Prefix + "Features";
     }
 }


### PR DESCRIPTION
Only add list of pages and fetaures to VSTelemetry not to our own (as logged seperately)

Fixed VSTelemetryPrefix

Fixes issue #708 