### PR TITLE
Issue798 configure right click per env

### DIFF
--- a/_build/Extension-SetIdentityAndVersion.ps1
+++ b/_build/Extension-SetIdentityAndVersion.ps1
@@ -26,10 +26,10 @@ Param(
   [string]$targetVsixCommandMenuName = "Windows Template Studio (local)",
 
   [Parameter(Mandatory=$False,Position=9)]
-  [string]$targetPackageGuid = "995f080c-9f70-4550-8a21-b3ffeeff17eb",
+  [string]$targetPackageGuid = "ae1b4c32-9c93-45b8-a36b-8734f4b120dd",
 
   [Parameter(Mandatory=$False,Position=8)]
-  [string]$targetCmdSetGuid = "dec1ebd7-fb6b-49e7-b562-b46af0d419d1",
+  [string]$targetCmdSetGuid = "caa4fb82-0dca-40fe-bae0-081e0f96226f",
   
   [Parameter(Mandatory=$False,Position=10)]
   [string]$publicKeyToken = "e4ef4cc7a47ae0c5" #TestKey.snk

--- a/code/src/Installer.2017/Commands/PackageIds.cs
+++ b/code/src/Installer.2017/Commands/PackageIds.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Templates.Extension.Commands
         /// <summary>
         /// RelayCommandPackage GUID string.
         /// </summary>
-        public const string PackageGuidString = "995f080c-9f70-4550-8a21-b3ffeeff17eb";
-        public static Guid GuidRelayCommandPackageCmdSet = Guid.Parse("dec1ebd7-fb6b-49e7-b562-b46af0d419d1");
+        public const string PackageGuidString = "ae1b4c32-9c93-45b8-a36b-8734f4b120dd";
+        public static Guid GuidRelayCommandPackageCmdSet = Guid.Parse("caa4fb82-0dca-40fe-bae0-081e0f96226f");
     }
 }

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.cs-CZ.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.cs-CZ.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.cs-CZ.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.cs-CZ.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.de-DE.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.de-DE.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.de-DE.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.de-DE.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.en-US.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.en-US.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.en-US.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.en-US.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.es-ES.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.es-ES.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.es-ES.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.es-ES.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.fr-FR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.fr-FR.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.fr-FR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.fr-FR.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.it-IT.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.it-IT.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.it-IT.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.it-IT.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.ja-JP.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.ja-JP.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.ja-JP.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.ja-JP.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.ko-KR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.ko-KR.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.ko-KR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.ko-KR.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.pl-PL.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.pl-PL.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.pl-PL.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.pl-PL.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.pt-BR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.pt-BR.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.pt-BR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.pt-BR.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.ru-RU.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.ru-RU.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.ru-RU.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.ru-RU.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.tr-TR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.tr-TR.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.tr-TR.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.tr-TR.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.zh-CN.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.zh-CN.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.zh-CN.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.zh-CN.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.zh-TW.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.zh-TW.vsct
@@ -90,9 +90,9 @@
   </CommandPlacements>
 
   <Symbols>
-    <GuidSymbol name="guidRelayCommandPackage" value="{995f080c-9f70-4550-8a21-b3ffeeff17eb}" />
+    <GuidSymbol name="guidRelayCommandPackage" value="{ae1b4c32-9c93-45b8-a36b-8734f4b120dd}" />
 
-    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{dec1ebd7-fb6b-49e7-b562-b46af0d419d1}">
+    <GuidSymbol name="guidRelayCommandPackageCmdSet" value="{caa4fb82-0dca-40fe-bae0-081e0f96226f}">
       <IDSymbol name="AddItemContextGroup" value="0x0100" />
       <IDSymbol name="AddItemContextMenu" value="0x0200" />
       <IDSymbol name="AddItemContextMenuGroup" value="0x0300" />

--- a/code/src/Installer.2017/Commands/RelayCommandPackage.zh-TW.vsct
+++ b/code/src/Installer.2017/Commands/RelayCommandPackage.zh-TW.vsct
@@ -17,10 +17,10 @@
     <Menus>
       <Menu guid="guidRelayCommandPackageCmdSet" id="AddItemContextMenu" type="Context" priority="0x0100">
         <Strings>
-          <CommandName>Windows Template Studio</CommandName>
-          <ButtonText>Windows Template Studio</ButtonText>
-          <MenuText>Windows Template Studio</MenuText>
-          <ToolTipText>Windows Template Studio</ToolTipText>
+          <CommandName>Windows Template Studio (local)</CommandName>
+          <ButtonText>Windows Template Studio (local)</ButtonText>
+          <MenuText>Windows Template Studio (local)</MenuText>
+          <ToolTipText>Windows Template Studio (local)</ToolTipText>
         </Strings>
       </Menu>
     </Menus>

--- a/code/src/Installer.2017/Properties/AssemblyInfo.cs
+++ b/code/src/Installer.2017/Properties/AssemblyInfo.cs
@@ -10,11 +10,12 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using Microsoft.VisualStudio.Shell;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.Shell;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information


### PR DESCRIPTION
With this PR we allow to have installed by environment the extension. Basically, allows to have multiple Right-Click menu.

#798 should remain open targeting 1.3 where we can review and solve the isolation issues.

Known issue having 2 extensions side by side (f.ex. local & nightly) and running it with in the same VS Instance: 
* The WTS extension wizard executed first will "win" and the other instance will not load the wizard xaml windows. 
* Would appear exceptions trying to delete temp folders in the output window.

With this workarround we at least will be able to have installed and differetiate between differente extension environment versions (f.ex. production & niglthly & local).

The solution implies to modify the guids at build time.