### PR TITLE
Include explicit Fluent Design features in Webview and M/D templates

### DIFF
--- a/docs/Fluent_PerspectiveParallax.md
+++ b/docs/Fluent_PerspectiveParallax.md
@@ -1,0 +1,99 @@
+# Perspective Parllax
+
+## Overview and Purpose
+
+This page describes how to enable Fluent Design parallax features in a
+Windows Template Studio enabled application.
+
+## Prerequisites
+
+Perspective Parallax as a control is available as of the Fall Creators Update,
+which enables all of the new Fluent features. This method also utilizes
+conditional XAML, a Creators update feature, which allows the selective
+enabling or disabling of features at runtime which aren't available on the
+target computer.
+
+This tutorial requires and assumes the following of your project and development environment
+- An updated Visual Studio 2017 development environment
+- The most current (Fall Creators Update) Windows 10 SDK
+- Project Max Version set to Fall Creators Update or above (Release XXXXX)
+- Project Min Version set to Creators Update (Release 15063)
+
+## Conditional XAML
+
+### What and Why
+Conditional XAML is a set of directives for the XAML parser that allow you to selectively instantiate objects in markup at runtime based on if the relevant API exists on the target machine. As long as the project is compiled using a recent enough SDK that the "newest" controls exist in that API, then you as a developer can enable backwards compatability as far back at the Creators Update.
+
+### How to Enable
+
+The equivalent of the if statement is the conditional namespace.
+``` XML
+xmlns:myNamespace="schema?conditionalMethod(parameter)
+```
+The delimiter `?` separates the namespace on the left and the conditional on the right. At runtime, the namespace is evaluated as true or false based on the condition. By prefixing XAML objects with this namespace, if at runtime, it evaluates to true, the object is instantiated and if it evaluates to false, it is ignored.
+
+In our case, the ParallaxView control is new for the Fall Creators Update. This update introduces the 5th version of the Universal API Contract. The condition to check for such a version is as follows
+
+``` XML
+IsApiContractPresent(ContractName, VersionNumber)
+```
+
+Therefore, we could create a namespace that checks for the 5th version of the contract in the following way. It would be added to our page in the following way
+
+``` XML
+xmlns:FCU="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+
+<UserControl
+    x:Class="XXXXX"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    ...
+    xmlns:FCU="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+
+```
+
+We can then conditionally instantiate controls based on the API contract as follows. In this example, the ColorPicker (a control only introduced in the Fall Creators Update) is only created at runtime when the machine it is running on has the right APIs.
+
+``` XML
+<FCU:ColorPicker x:Name="colorPicker" Grid.Column="1"/>
+```
+
+## Parallax Controls
+
+### What is Parallax
+
+Parallax is a visual effect where items closer to the viewer move faster than items in the background. Parallax creates a feeling of depth, perspective, and movement. In a UWP app, you can use the ParallaxView control to create a parallax effect. Parallax is a Fluent Design System component that adds motion, depth, and scale to your app.
+
+ParallaxView becomes generally available starting in the Fall Creator's Update
+
+### Appropriate Use
+
+Microsoft gives the following general recommendations for where Parallax is appropriate for use.
++ Use parallax in lists with a background image
++ Consider using parallax in ListViewItems when ListViewItems contain an image
++ Don’t use it everywhere, overuse can diminish its impact
+
+### How to Enable
+
+To create a parallax effect, you use the ParallaxView control. This control ties the scroll position of a foreground element, such as a list, to a background element, such as an image. As you scroll through the foreground element, it animates the background element to create a parallax effect.
+To use the ParallaxView control, you provide a Source element and a background element.
+
+As in the above section, we are going to selectively create a ParallaxView control only when the APIs exist.
+
+``` XML
+<Grid>
+  <FCU:ParallaxView Source="{x:Bind ForegroundElement}">
+    <FCU:Image x:Name="BackgroundImage" Source="/Assets/XXXX.jpg"/>
+  </FCU:ParallaxView>
+
+  <ScrollViewer Name="ForegroundElement".../>
+  ...
+</Grid>
+
+```
+Add the above snippet of code into the Content grid at the root level. Ensure the content you want to be captured inside the parallax (ie the scrollviewer) is named ForegroundElement and is also at the root of the grid.
+
+## Further Reading
+
+1. [Parallax and the Fluent Design System](https://docs.microsoft.com/en-us/windows/uwp/style/parallax)
+2. [Conditional XAML](https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/conditional-xaml)
+3. [Further reading on ParallaxView](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.Parallaxview)

--- a/templates/Features/SampleData/Models/Order.cs
+++ b/templates/Features/SampleData/Models/Order.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Windows.UI.Xaml.Controls;
 
 namespace Param_ItemNamespace.Models
 {
@@ -16,5 +17,22 @@ namespace Param_ItemNamespace.Models
         public double OrderTotal { get; set; }
 
         public string Status { get; set; }
+
+        public Symbol Symbol { get; set; }
+
+        public char SymbolAsChar
+        {
+            get { return (char)Symbol; }
+        }
+
+        public string HashIdentIcon
+        {
+            get { return GetHashCode().ToString() + "-icon"; }
+        }
+        
+        public string HashIdentTitle
+        {
+            get { return GetHashCode().ToString() + "-title"; }
+        }
     }
 }

--- a/templates/Features/SampleData/Services/SampleDataService.cs
+++ b/templates/Features/SampleData/Services/SampleDataService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Windows.UI.Xaml.Controls;
 
 namespace Param_ItemNamespace.Services
 {
@@ -21,7 +22,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company F",
                     ShipTo = "Francisco Pérez-Olaeta",
                     OrderTotal = 2490.00,
-                    Status = "Closed"
+                    Status = "Closed",
+                    Symbol = Symbol.Globe
                 },
                 new Order
                 {
@@ -30,7 +32,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company CC",
                     ShipTo = "Soo Jung Lee",
                     OrderTotal = 1760.00,
-                    Status = "Closed"
+                    Status = "Closed",
+                    Symbol = Symbol.Audio
                 },
                 new Order
                 {
@@ -39,7 +42,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company Z",
                     ShipTo = "Run Liu",
                     OrderTotal = 2310.00,
-                    Status = "Closed"
+                    Status = "Closed",
+                    Symbol = Symbol.Calendar
                 },
                 new Order
                 {
@@ -48,7 +52,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company Y",
                     ShipTo = "John Rodman",
                     OrderTotal = 665.00,
-                    Status = "Closed"
+                    Status = "Closed",
+                    Symbol = Symbol.Camera
                 },
                 new Order
                 {
@@ -57,7 +62,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company H",
                     ShipTo = "Elizabeth Andersen",
                     OrderTotal = 560.00,
-                    Status = "Shipped"
+                    Status = "Shipped",
+                    Symbol = Symbol.Clock
                 },
                 new Order
                 {
@@ -66,7 +72,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company F",
                     ShipTo = "Francisco Pérez-Olaeta",
                     OrderTotal = 810.00,
-                    Status = "Shipped"
+                    Status = "Shipped",
+                    Symbol = Symbol.Contact
                 },
                 new Order
                 {
@@ -75,7 +82,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company I",
                     ShipTo = "Sven Mortensen",
                     OrderTotal = 196.50,
-                    Status = "Shipped"
+                    Status = "Shipped",
+                    Symbol = Symbol.Favorite
                 },
                 new Order
                 {
@@ -84,7 +92,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company BB",
                     ShipTo = "Amritansh Raghav",
                     OrderTotal = 270.00,
-                    Status = "New"
+                    Status = "New",
+                    Symbol = Symbol.Home
                 },
                 new Order
                 {
@@ -93,7 +102,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company A",
                     ShipTo = "Anna Bedecs",
                     OrderTotal = 736.00,
-                    Status = "New"
+                    Status = "New",
+                    Symbol = Symbol.Mail
                 },
                 new Order
                 {
@@ -102,7 +112,8 @@ namespace Param_ItemNamespace.Services
                     Company = "Company K",
                     ShipTo = "Peter Krschne",
                     OrderTotal = 800.00,
-                    Status = "New"
+                    Status = "New",
+                    Symbol = Symbol.OutlineStar
                 },
             };
 

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml
@@ -28,11 +28,24 @@
             <Grid Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
 
                 <!--Replate this StackPanel with your detail content.-->
-                <StackPanel Orientation="Vertical" Margin="{StaticResource MediumLeftTopRightBottomMargin}">
+                <StackPanel Orientation="Vertical" VerticalAlignment="Top" Margin="{StaticResource MediumLeftTopRightBottomMargin}">
+                    <Border BorderThickness="0,0,0,1" BorderBrush="Gray">
+                        <StackPanel Orientation="Horizontal" MaxHeight="200" HorizontalAlignment="Center" >
+                            <TextBlock
+                            Name="destTitle"
+                            Text="{x:Bind MasterMenuItem.Company, Mode=OneWay}"
+                            FontSize="50" FontWeight="Normal" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
+                            VerticalAlignment="Center" HorizontalAlignment="Left" />
+                            <FontIcon 
+                            Name="destIcon"
+                            FontSize="100" 
+                            Glyph="{x:Bind MasterMenuItem.SymbolAsChar, Mode=OneWay}"
+                            VerticalAlignment="Center" Margin="100,0,0,10"
+                            HorizontalAlignment="Right"/>
+                        </StackPanel>
+                    </Border>
                     <TextBlock Text="Order Date" Style="{StaticResource CaptionTextBlockStyle}" />
                     <TextBlock Text="{x:Bind MasterMenuItem.OrderDate, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
-                    <TextBlock Text="Company" Style="{StaticResource CaptionTextBlockStyle}" />
-                    <TextBlock Text="{x:Bind MasterMenuItem.Company, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
                     <TextBlock Text="Ship to" Style="{StaticResource CaptionTextBlockStyle}" />
                     <TextBlock Text="{x:Bind MasterMenuItem.ShipTo, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
                     <TextBlock Text="Order Total" Style="{StaticResource CaptionTextBlockStyle}" />

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml
@@ -15,7 +15,7 @@
 
         <TextBlock
             x:Name="TitlePage"
-            Text="{x:Bind MasterMenuItem.OrderId, Mode=OneWay}"
+            Text="Orders"
             Style="{StaticResource PageTitleStyle}" />
 
         <ScrollViewer

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml
@@ -4,56 +4,67 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:rs3="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+    xmlns:rs2="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
+
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="48"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <TextBlock
-            x:Name="TitlePage"
-            Text="Orders"
-            Style="{StaticResource PageTitleStyle}" />
+        <!--The SystemControlPageBackgroundChromeLowBrush background represents where you should place your detail content.-->
+        <Grid Grid.Row="1">
+            <!--             <rs3:ParallaxView VerticalAlignment="Stretch" Source="{x:Bind ForegroundElement}" VerticalShift="100" >
+                    <rs3:Image Opacity=".1" x:Name="BackgroundImage" Source="/Assets/crtest.jpg" Stretch="UniformToFill"/>
+                </rs3:ParallaxView> -->
 
-        <ScrollViewer
-            Grid.Row="1"
-            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-            ScrollViewer.VerticalScrollBarVisibility="Auto"
-            ScrollViewer.VerticalScrollMode="Auto">
-
-            <!--The SystemControlPageBackgroundChromeLowBrush background represents where you should place your detail content.-->
-            <Grid Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-
-                <!--Replate this StackPanel with your detail content.-->
-                <StackPanel Orientation="Vertical" VerticalAlignment="Top" Margin="{StaticResource MediumLeftTopRightBottomMargin}">
-                    <Border BorderThickness="0,0,0,1" BorderBrush="Gray">
-                        <StackPanel Orientation="Horizontal" MaxHeight="200" HorizontalAlignment="Center" >
+                <ScrollViewer Name="ForegroundElement" VerticalScrollMode="Enabled" HorizontalAlignment="Stretch" Padding="24,48,0,0" >
+                <StackPanel HorizontalAlignment="Left">
+                    <Border BorderThickness="0,0,0,0" BorderBrush="Gray">
+                        <StackPanel Name="destPanel" Orientation="Horizontal" MaxHeight="200" HorizontalAlignment="Stretch">
+                            <FontIcon
+                            Name="destIcon"
+                            FontSize="46" 
+                            Glyph="{x:Bind MasterMenuItem.SymbolAsChar, Mode=OneWay}"
+                            VerticalAlignment="Center" Margin="0,0,30,0"
+                            HorizontalAlignment="Center"/>
                             <TextBlock
                             Name="destTitle"
                             Text="{x:Bind MasterMenuItem.Company, Mode=OneWay}"
-                            FontSize="50" FontWeight="Normal" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
-                            VerticalAlignment="Center" HorizontalAlignment="Left" />
-                            <FontIcon 
-                            Name="destIcon"
-                            FontSize="100" 
-                            Glyph="{x:Bind MasterMenuItem.SymbolAsChar, Mode=OneWay}"
-                            VerticalAlignment="Center" Margin="100,0,0,10"
-                            HorizontalAlignment="Right"/>
+                            FontSize="46" FontWeight="Light" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
+                            VerticalAlignment="Center" HorizontalAlignment="Center" />
                         </StackPanel>
                     </Border>
-                    <TextBlock Text="Order Date" Style="{StaticResource CaptionTextBlockStyle}" />
-                    <TextBlock Text="{x:Bind MasterMenuItem.OrderDate, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
-                    <TextBlock Text="Ship to" Style="{StaticResource CaptionTextBlockStyle}" />
-                    <TextBlock Text="{x:Bind MasterMenuItem.ShipTo, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
-                    <TextBlock Text="Order Total" Style="{StaticResource CaptionTextBlockStyle}" />
-                    <TextBlock Text="{x:Bind MasterMenuItem.OrderTotal, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
-                    <TextBlock Text="Status" Style="{StaticResource CaptionTextBlockStyle}" />
-                    <TextBlock Text="{x:Bind MasterMenuItem.Status, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
+                    <StackPanel Name="block" Padding="0,15,0,0">
+                        <TextBlock Text="Status" FontSize="20" FontWeight="SemiLight" />
+                        <TextBlock Text="{x:Bind MasterMenuItem.Status, Mode=OneWay}" FontSize="15" Padding="0,0,0,6" />
+                        <TextBlock Text="Order date" Style="{StaticResource CaptionTextBlockStyle}" FontSize="20" FontWeight="SemiLight"  />
+                        <TextBlock Text="{x:Bind MasterMenuItem.OrderDate, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" FontSize="15" Padding="0,0,0,6" />
+                        <TextBlock Text="Company" Style="{StaticResource CaptionTextBlockStyle}" FontSize="20" FontWeight="SemiLight"  />
+                        <TextBlock Text="{x:Bind MasterMenuItem.Company, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" FontSize="15" Padding="0,0,0,6" />
+                        <TextBlock Text="Ship to" Style="{StaticResource CaptionTextBlockStyle}" FontSize="20" FontWeight="SemiLight"  />
+                        <TextBlock Text="{x:Bind MasterMenuItem.ShipTo, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" FontSize="15" Padding="0,0,0,6" />
+                        <TextBlock Text="Order total" Style="{StaticResource CaptionTextBlockStyle}" FontSize="20" FontWeight="SemiLight"  />
+                        <TextBlock Text="{x:Bind MasterMenuItem.OrderTotal, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" FontSize="15" Padding="0,0,0,6" />
+
+                        <TextBlock FontSize="20" FontWeight="SemiLight" Text="Note 1" Style="{StaticResource CaptionTextBlockStyle}" />
+                        <TextBlock FontSize="15" Padding="0,0,0,6"  MaxWidth="1000" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis quis hendrerit nulla, vel molestie libero. In nec ultricies magna, ultricies molestie ipsum. Mauris non dignissim velit. Etiam malesuada blandit mauris eu maximus. Quisque ornare, felis nec scelerisque mollis, risus dolor posuere magna, in gravida quam mi id nisi. Nullam mattis consequat ex. Cras nulla neque, dictum ac urna et, vestibulum feugiat ex. Pellentesque malesuada accumsan ligula, vel fringilla lacus facilisis sit amet. Proin convallis tempor arcu, ac placerat libero pretium ut. Praesent hendrerit nisl at lobortis viverra. Fusce vitae velit odio. Nam ut tortor sed purus finibus sollicitudin quis at ante. Ut sodales dolor vel eros mollis suscipit. Donec eu nulla id urna ultricies consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;" Style="{StaticResource BodyTextStyle}" />
+
+                        <TextBlock FontSize="20" FontWeight="SemiLight" Text="Note 2" Style="{StaticResource CaptionTextBlockStyle}" />
+                        <TextBlock FontSize="15" Padding="0,0,0,6" MaxWidth="1000" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis quis hendrerit nulla, vel molestie libero. In nec ultricies magna, ultricies molestie ipsum. Mauris non dignissim velit. Etiam malesuada blandit mauris eu maximus. Quisque ornare, felis nec scelerisque mollis, risus dolor posuere magna, in gravida quam mi id nisi. Nullam mattis consequat ex. Cras nulla neque, dictum ac urna et, vestibulum feugiat ex. Pellentesque malesuada accumsan ligula, vel fringilla lacus facilisis sit amet. Proin convallis tempor arcu, ac placerat libero pretium ut. Praesent hendrerit nisl at lobortis viverra. Fusce vitae velit odio. Nam ut tortor sed purus finibus sollicitudin quis at ante. Ut sodales dolor vel eros mollis suscipit. Donec eu nulla id urna ultricies consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;" Style="{StaticResource BodyTextStyle}" />
+
+                        <TextBlock FontSize="20" FontWeight="SemiLight" Text="Note 3" Style="{StaticResource CaptionTextBlockStyle}" />
+                        <TextBlock FontSize="15" Padding="0,0,0,6" MaxWidth="1000" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis quis hendrerit nulla, vel molestie libero. In nec ultricies magna, ultricies molestie ipsum. Mauris non dignissim velit. Etiam malesuada blandit mauris eu maximus. Quisque ornare, felis nec scelerisque mollis, risus dolor posuere magna, in gravida quam mi id nisi. Nullam mattis consequat ex. Cras nulla neque, dictum ac urna et, vestibulum feugiat ex. Pellentesque malesuada accumsan ligula, vel fringilla lacus facilisis sit amet. Proin convallis tempor arcu, ac placerat libero pretium ut. Praesent hendrerit nisl at lobortis viverra. Fusce vitae velit odio. Nam ut tortor sed purus finibus sollicitudin quis at ante. Ut sodales dolor vel eros mollis suscipit. Donec eu nulla id urna ultricies consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;" Style="{StaticResource BodyTextStyle}" />
+
+                        <TextBlock FontSize="20" FontWeight="SemiLight" Text="Note 4" Style="{StaticResource CaptionTextBlockStyle}" />
+                        <TextBlock FontSize="15" Padding="0,0,0,6" MaxWidth="1000" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis quis hendrerit nulla, vel molestie libero. In nec ultricies magna, ultricies molestie ipsum. Mauris non dignissim velit. Etiam malesuada blandit mauris eu maximus. Quisque ornare, felis nec scelerisque mollis, risus dolor posuere magna, in gravida quam mi id nisi. Nullam mattis consequat ex. Cras nulla neque, dictum ac urna et, vestibulum feugiat ex. Pellentesque malesuada accumsan ligula, vel fringilla lacus facilisis sit amet. Proin convallis tempor arcu, ac placerat libero pretium ut. Praesent hendrerit nisl at lobortis viverra. Fusce vitae velit odio. Nam ut tortor sed purus finibus sollicitudin quis at ante. Ut sodales dolor vel eros mollis suscipit. Donec eu nulla id urna ultricies consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;" Style="{StaticResource BodyTextStyle}" />
+
+                    </StackPanel>
                 </StackPanel>
+            </ScrollViewer>
             </Grid>
-        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml.cs
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml.cs
@@ -1,5 +1,8 @@
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Hosting;
+using Windows.UI.Composition;
 using Windows.UI.Xaml.Media.Animation;
 using Param_ItemNamespace.Models;
 
@@ -13,23 +16,52 @@ namespace Param_ItemNamespace.Views
             get { return GetValue(MasterMenuItemProperty) as Order; }
             set
             {
-                SetValue(MasterMenuItemProperty, value);
-                ConnectedAnimationService.GetForCurrentView().DefaultDuration = System.TimeSpan.FromSeconds(.25);
+                block.Visibility = Visibility.Collapsed;
                 ConnectedAnimation iconAnim = ConnectedAnimationService.GetForCurrentView().GetAnimation("companyIcon");
                 ConnectedAnimation titleAnim = ConnectedAnimationService.GetForCurrentView().GetAnimation("companyTitle");
+                var a = value;
                 if (!(iconAnim == null) && !(titleAnim == null))
                 {
+                    
+                    iconAnim.Completed += (sender_, e_) =>
+                    {
+                        destPanel.Opacity = 1;
+                        block.Visibility = Visibility.Visible;
+
+                    };
                     iconAnim.TryStart(destIcon);
                     titleAnim.TryStart(destTitle);
+                    destPanel.Opacity = .005;
+                    
                 }
+                else
+                {
+                    destPanel.Opacity = 1;
+                    block.Visibility = Visibility.Visible;
+                }
+                SetValue(MasterMenuItemProperty, value);
             }
         }
 
         public static DependencyProperty MasterMenuItemProperty = DependencyProperty.Register("MasterMenuItem",typeof(Order),typeof(MasterDetailDetailControl),new PropertyMetadata(null));
+        private Compositor _compositor;
 
         public MasterDetailDetailControl()
         {
             InitializeComponent();
+            _compositor = ElementCompositionPreview.GetElementVisual(this).Compositor;
+
+            // Add a translation animation that will play when this element is shown
+            var topBorderOffsetAnimation = _compositor.CreateScalarKeyFrameAnimation();
+            topBorderOffsetAnimation.Duration = TimeSpan.FromMilliseconds(200);
+            topBorderOffsetAnimation.Target = "Translation.Y";
+            topBorderOffsetAnimation.InsertKeyFrame(0, 1000.0f);
+            topBorderOffsetAnimation.InsertKeyFrame(1, 0);
+
+            ElementCompositionPreview.SetIsTranslationEnabled(block, true);
+            // Call GetElementVisual() to work around a bug in Insider Build 15025
+            ElementCompositionPreview.GetElementVisual(block);
+            ElementCompositionPreview.SetImplicitShowAnimation(block, topBorderOffsetAnimation);
         }
     }
 }

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml.cs
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailControl.xaml.cs
@@ -1,6 +1,8 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
 using Param_ItemNamespace.Models;
+
 
 namespace Param_ItemNamespace.Views
 {
@@ -9,10 +11,21 @@ namespace Param_ItemNamespace.Views
         public Order MasterMenuItem
         {
             get { return GetValue(MasterMenuItemProperty) as Order; }
-            set { SetValue(MasterMenuItemProperty, value); }
+            set
+            {
+                SetValue(MasterMenuItemProperty, value);
+                ConnectedAnimationService.GetForCurrentView().DefaultDuration = System.TimeSpan.FromSeconds(.25);
+                ConnectedAnimation iconAnim = ConnectedAnimationService.GetForCurrentView().GetAnimation("companyIcon");
+                ConnectedAnimation titleAnim = ConnectedAnimationService.GetForCurrentView().GetAnimation("companyTitle");
+                if (!(iconAnim == null) && !(titleAnim == null))
+                {
+                    iconAnim.TryStart(destIcon);
+                    titleAnim.TryStart(destTitle);
+                }
+            }
         }
 
-        public static readonly DependencyProperty MasterMenuItemProperty = DependencyProperty.Register("MasterMenuItem", typeof(Order), typeof(MasterDetailDetailControl), new PropertyMetadata(null));
+        public static DependencyProperty MasterMenuItemProperty = DependencyProperty.Register("MasterMenuItem",typeof(Order),typeof(MasterDetailDetailControl),new PropertyMetadata(null));
 
         public MasterDetailDetailControl()
         {

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailPage.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailDetailPage.xaml
@@ -10,8 +10,7 @@
     mc:Ignorable="d">
 
     <Grid
-        x:Name="ContentArea"
-        Background="{ThemeResource SystemControlBackgroundAltHighBrush}">
+        x:Name="ContentArea">
 
         <views:MasterDetailDetailControl
             Margin="{StaticResource MediumLeftRightMargin}"

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
@@ -7,41 +7,42 @@
     xmlns:model="using:Param_ItemNamespace.Models"
     xmlns:views="using:Param_ItemNamespace.Views"
     mc:Ignorable="d">
+    <Page.Transitions>
+        <TransitionCollection>
+            <NavigationThemeTransition />
+        </TransitionCollection>
+    </Page.Transitions>
     <Page.Resources>
         <DataTemplate x:Key="MasterListViewItemTemplate" x:DataType="model:Order">
-            <Grid Margin="{StaticResource MediumLeftTopRightBottomMargin}">
+            <Grid Margin="{StaticResource MediumLeftTopRightBottomMargin}"
+                  >
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <StackPanel Orientation="Vertical" VerticalAlignment="Top" HorizontalAlignment="Left">
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
-                        <FontIcon
-	                        Tag="{x:Bind HashIdentIcon}"
-	                        FontSize="20"
-	                        Glyph="{x:Bind SymbolAsChar}" HorizontalAlignment="Left"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Left">
+                    <FontIcon
+                        Tag="{x:Bind HashIdentIcon}"
+                        FontSize="35"
+                        Glyph="{x:Bind SymbolAsChar}" VerticalAlignment="Top" />
+                    <StackPanel Orientation="Vertical" Padding="24,0,0,0">
                         <TextBlock 
-	                        Tag="{x:Bind HashIdentTitle}"
-	                        FontSize="20"
-	                        Text="{x:Bind Company}" 
-	                        Style="{StaticResource ListTitleStyle}" HorizontalAlignment="Left" Margin="20,0,0,0"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock 
-                            Text="Status: " 
-                            Style="{StaticResource ListSubTitleStyle}" Padding="0,0,5,0" />
+                        Tag="{x:Bind HashIdentTitle}"
+                        FontSize="24"
+                        Text="{x:Bind Company}" FontWeight="SemiLight"
+                        Style="{StaticResource ListTitleStyle}"/>
                         <TextBlock
-                            Text="{x:Bind Status}"
-                            Style="{StaticResource ListSubTitleStyle}" />
+                        Text="{x:Bind Status}"
+                        FontSize="18" FontWeight="Light"
+                        Style="{StaticResource ListSubTitleStyle}" />
                     </StackPanel>
                 </StackPanel>
-                
             </Grid>
         </DataTemplate>
     </Page.Resources>
 
-    <Grid
+    <Grid 
         x:Name="ContentArea"
         Padding="12,0,12,0">
 
@@ -82,10 +83,10 @@
                 Grid.Row="1"
                 ItemsSource="{x:Bind SampleItems, Mode=OneWay}"
                 SelectedItem="{x:Bind Selected, Mode=OneWay}"
+                Loaded="ListView_Loaded"
                 ItemContainerTransitions="{x:Null}"
                 ItemTemplate="{StaticResource MasterListViewItemTemplate}"
                 IsItemClickEnabled="True"
-                Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}"
                 ItemClick="MasterListView_ItemClick">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
@@ -124,6 +125,7 @@
                         <AdaptiveTrigger MinWindowWidth="0"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
+                        <Setter Target="TitlePage.Margin" Value="48,0,12,7"/>
                         <Setter Target="TitleRow.Height" Value="48"/>
                         <Setter Target="MasterRow.Height" Value="Auto"/>
                         <Setter Target="TitlePage.Visibility" Value="Visible"/>

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
@@ -20,9 +20,15 @@
                     Style="{StaticResource ListTitleStyle}" />
 
                 <TextBlock
+                	Tag="{x:Bind HashIdentTitle}"
                     Grid.Row="1"
                     Text="{x:Bind Company}"
                     Style="{StaticResource ListSubTitleStyle}" />
+
+                <FontIcon 
+                    Tag="{x:Bind HashIdentIcon}"
+                    FontSize="16"
+                    Glyph="{x:Bind SymbolAsChar}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
             </Grid>
         </DataTemplate>
     </Page.Resources>

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
@@ -15,20 +15,28 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <TextBlock 
-                    Text="{x:Bind OrderId}" 
-                    Style="{StaticResource ListTitleStyle}" />
-
-                <TextBlock
-                	Tag="{x:Bind HashIdentTitle}"
-                    Grid.Row="1"
-                    Text="{x:Bind Company}"
-                    Style="{StaticResource ListSubTitleStyle}" />
-
-                <FontIcon 
-                    Tag="{x:Bind HashIdentIcon}"
-                    FontSize="16"
-                    Glyph="{x:Bind SymbolAsChar}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                <StackPanel Orientation="Vertical" VerticalAlignment="Top" HorizontalAlignment="Left">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                        <FontIcon
+	                        Tag="{x:Bind HashIdentIcon}"
+	                        FontSize="20"
+	                        Glyph="{x:Bind SymbolAsChar}" HorizontalAlignment="Left"/>
+                        <TextBlock 
+	                        Tag="{x:Bind HashIdentTitle}"
+	                        FontSize="20"
+	                        Text="{x:Bind Company}" 
+	                        Style="{StaticResource ListTitleStyle}" HorizontalAlignment="Left" Margin="20,0,0,0"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock 
+                            Text="Status: " 
+                            Style="{StaticResource ListSubTitleStyle}" Padding="0,0,5,0" />
+                        <TextBlock
+                            Text="{x:Bind Status}"
+                            Style="{StaticResource ListSubTitleStyle}" />
+                    </StackPanel>
+                </StackPanel>
+                
             </Grid>
         </DataTemplate>
     </Page.Resources>

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml
@@ -12,31 +12,41 @@
             <NavigationThemeTransition />
         </TransitionCollection>
     </Page.Transitions>
-    <Page.Resources>
+        <Page.Resources>
         <DataTemplate x:Key="MasterListViewItemTemplate" x:DataType="model:Order">
-            <Grid Margin="{StaticResource MediumLeftTopRightBottomMargin}"
-                  >
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+            <Grid Margin="{StaticResource MediumLeftTopRightBottomMargin}" >
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Left" Grid.Row="1">
+                    <RelativePanel>
+                        <Rectangle Stroke="Gray"
+                             Fill="LightGray"
+                             Width="48"
+                             Height="48"
+                             StrokeThickness="0" 
+                             Name="border"
+                             RelativePanel.AlignVerticalCenterWithPanel="True"/>
+                        <FontIcon
+                            Name="icon"
+                            Tag="{x:Bind HashIdentIcon}"
+                            FontSize="35"
+                            Glyph="{x:Bind SymbolAsChar}" VerticalAlignment="Top" 
+                            RelativePanel.AlignVerticalCenterWith="border"
+                            RelativePanel.AlignHorizontalCenterWith="border"/>
 
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Left">
-                    <FontIcon
-                        Tag="{x:Bind HashIdentIcon}"
-                        FontSize="35"
-                        Glyph="{x:Bind SymbolAsChar}" VerticalAlignment="Top" />
-                    <StackPanel Orientation="Vertical" Padding="24,0,0,0">
-                        <TextBlock 
-                        Tag="{x:Bind HashIdentTitle}"
-                        FontSize="24"
-                        Text="{x:Bind Company}" FontWeight="SemiLight"
-                        Style="{StaticResource ListTitleStyle}"/>
-                        <TextBlock
-                        Text="{x:Bind Status}"
-                        FontSize="18" FontWeight="Light"
-                        Style="{StaticResource ListSubTitleStyle}" />
-                    </StackPanel>
+                        <StackPanel RelativePanel.AlignVerticalCenterWithPanel="True" Margin="12,0,0,0" RelativePanel.RightOf="border">
+                            <TextBlock
+                                Name="title"
+                                RelativePanel.RightOf="border"
+                                Text="{x:Bind Company}"
+                                Tag="{x:Bind HashIdentTitle}"
+                                Style="{StaticResource BaseTextBlockStyle}"/>
+                            <TextBlock
+                                Name="subtitle"
+                                RelativePanel.Below="title"
+                                RelativePanel.AlignLeftWith="title"
+                                Text="{x:Bind Status}"
+                                Style="{StaticResource BodyTextBlockStyle}"/>
+                        </StackPanel>
+                    </RelativePanel>
                 </StackPanel>
             </Grid>
         </DataTemplate>

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml.cs
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml.cs
@@ -14,6 +14,7 @@ namespace Param_ItemNamespace.Views
     public sealed partial class MasterDetailPage : Page, System.ComponentModel.INotifyPropertyChanged
     {
         private Order _selected;
+        private Dictionary<string, UIElement> dict = new Dictionary<string, UIElement>();
 
         public Order Selected
         {
@@ -44,22 +45,29 @@ namespace Param_ItemNamespace.Views
 
         private void MasterListView_ItemClick(object sender, ItemClickEventArgs e)
         {
+            
             var item = e?.ClickedItem as Order;
             if (item != null)
             {
+                if (WindowStates.CurrentState.Name != "NarrowState")
+                {
+                    ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyIcon", dict[item.HashIdentIcon]);
+                    ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyTitle", dict[item.HashIdentTitle]);
+
+                }
+
                 if (WindowStates.CurrentState == NarrowState)
                 {
                     NavigationService.Navigate<Views.MasterDetailDetailPage>(item);
                 }
                 else
                 {
-                	ProcessVisualTreeAndAnimateItem(MasterListView, item);
                     Selected = item;
                 }
             }
         }
 
-        private void ProcessVisualTreeAndAnimateItem(DependencyObject root, Order item) 
+        private void registerAllElemens(DependencyObject root)
         {
             int childCount = VisualTreeHelper.GetChildrenCount(root);
             for (int i = 0; i < childCount; i++)
@@ -68,29 +76,32 @@ namespace Param_ItemNamespace.Views
                 if (child != null && child is FontIcon)
                 {
                     FontIcon elem = (FontIcon)child;
-                    bool foundIcon = (item.HashIdentIcon == (string)elem.Tag);
-                    if (foundIcon)
+                    if (elem.Tag != null && !dict.ContainsKey((string)elem.Tag))
                     {
-                        ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyIcon", elem);
+                        dict.Add((string)elem.Tag, elem);
                     }
                 }
                 else if (child != null && child is TextBlock)
                 {
                     TextBlock elem = (TextBlock)child;
-                    bool foundTitle = (item.HashIdentTitle == (string)elem.Tag);
-                    if (foundTitle)
+                    if (elem.Tag != null && !dict.ContainsKey((string)elem.Tag))
                     {
-                        ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyTitle", elem);
+                        dict.Add((string)elem.Tag, elem);
                     }
                 }
                 else
                 {
                     for (int j = 0; j < childCount; j++)
                     {
-                        ProcessVisualTreeAndAnimateItem(child, item);
+                        registerAllElemens(child);
                     }
                 }
             }
+        }
+
+        private void ListView_Loaded(object sender, RoutedEventArgs e)
+        {
+            registerAllElemens(MasterListView);
         }
     }
 }

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml.cs
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml.cs
@@ -47,56 +47,47 @@ namespace Param_ItemNamespace.Views
             var item = e?.ClickedItem as Order;
             if (item != null)
             {
-                if (WindowStates.CurrentState.Name != "NarrowState")
-                {
-                	foreach (var fonticon in GetAllVisualChildrenOfType<FontIcon>(MasterListView))
-                    {
-                        var element = (UIElement)fonticon;
-                        bool foundIcon = (item.HashIdentIcon == (string)fonticon.Tag);
-                        if (foundIcon)
-                        {
-                            ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyIcon", element);
-                        }
-                    }
-
-                    foreach (var textblock in GetAllVisualChildrenOfType<TextBlock>(MasterListView))
-                    {
-                        var element = (UIElement)textblock;
-                        bool foundTitle = (item.HashIdentTitle == (string)textblock.Tag);
-                        if (foundTitle)
-                        {
-                            ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyTitle", element);
-                        }
-                    }
-                }
-
                 if (WindowStates.CurrentState == NarrowState)
                 {
                     NavigationService.Navigate<Views.MasterDetailDetailPage>(item);
                 }
                 else
                 {
+                	ProcessVisualTreeAndAnimateItem(MasterListView, item);
                     Selected = item;
                 }
             }
         }
 
-        private IEnumerable<T> GetAllVisualChildrenOfType<T>(DependencyObject obj) where T : DependencyObject
+        private void ProcessVisualTreeAndAnimateItem(DependencyObject root, Order item) 
         {
-            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
+            int childCount = VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < childCount; i++)
             {
-                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
-                if (child != null && child is T)
-                    yield return (T)child;
+                DependencyObject child = VisualTreeHelper.GetChild(root, i);
+                if (child != null && child is FontIcon)
+                {
+                    FontIcon elem = (FontIcon)child;
+                    bool foundIcon = (item.HashIdentIcon == (string)elem.Tag);
+                    if (foundIcon)
+                    {
+                        ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyIcon", elem);
+                    }
+                }
+                else if (child != null && child is TextBlock)
+                {
+                    TextBlock elem = (TextBlock)child;
+                    bool foundTitle = (item.HashIdentTitle == (string)elem.Tag);
+                    if (foundTitle)
+                    {
+                        ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyTitle", elem);
+                    }
+                }
                 else
                 {
-                    for (int j = 0; j < VisualTreeHelper.GetChildrenCount(child); j++)
+                    for (int j = 0; j < childCount; j++)
                     {
-                        IEnumerable<T> childrenOfChild = GetAllVisualChildrenOfType<T>(child);
-                        foreach (T subChild in childrenOfChild)
-                        {
-                            yield return subChild;
-                        }
+                        ProcessVisualTreeAndAnimateItem(child, item);
                     }
                 }
             }

--- a/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml.cs
+++ b/templates/Pages/MasterDetail.CodeBehind/Views/MasterDetailPage.xaml.cs
@@ -1,6 +1,10 @@
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 using Param_ItemNamespace.Models;
 using Param_ItemNamespace.Services;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Linq;
@@ -43,6 +47,29 @@ namespace Param_ItemNamespace.Views
             var item = e?.ClickedItem as Order;
             if (item != null)
             {
+                if (WindowStates.CurrentState.Name != "NarrowState")
+                {
+                	foreach (var fonticon in GetAllVisualChildrenOfType<FontIcon>(MasterListView))
+                    {
+                        var element = (UIElement)fonticon;
+                        bool foundIcon = (item.HashIdentIcon == (string)fonticon.Tag);
+                        if (foundIcon)
+                        {
+                            ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyIcon", element);
+                        }
+                    }
+
+                    foreach (var textblock in GetAllVisualChildrenOfType<TextBlock>(MasterListView))
+                    {
+                        var element = (UIElement)textblock;
+                        bool foundTitle = (item.HashIdentTitle == (string)textblock.Tag);
+                        if (foundTitle)
+                        {
+                            ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyTitle", element);
+                        }
+                    }
+                }
+
                 if (WindowStates.CurrentState == NarrowState)
                 {
                     NavigationService.Navigate<Views.MasterDetailDetailPage>(item);
@@ -50,6 +77,27 @@ namespace Param_ItemNamespace.Views
                 else
                 {
                     Selected = item;
+                }
+            }
+        }
+
+        private IEnumerable<T> GetAllVisualChildrenOfType<T>(DependencyObject obj) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
+                if (child != null && child is T)
+                    yield return (T)child;
+                else
+                {
+                    for (int j = 0; j < VisualTreeHelper.GetChildrenCount(child); j++)
+                    {
+                        IEnumerable<T> childrenOfChild = GetAllVisualChildrenOfType<T>(child);
+                        foreach (T subChild in childrenOfChild)
+                        {
+                            yield return subChild;
+                        }
+                    }
                 }
             }
         }

--- a/templates/Pages/MasterDetail/Views/MasterDetailDetailControl.xaml
+++ b/templates/Pages/MasterDetail/Views/MasterDetailDetailControl.xaml
@@ -28,11 +28,24 @@
             <Grid Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
             
                 <!--Replate this StackPanel with your detail content.-->
-                <StackPanel Orientation="Vertical" Margin="{StaticResource MediumLeftTopRightBottomMargin}">
+                <StackPanel Orientation="Vertical" VerticalAlignment="Top" Margin="{StaticResource MediumLeftTopRightBottomMargin}">
+                    <Border BorderThickness="0,0,0,1" BorderBrush="Gray">
+                        <StackPanel Orientation="Horizontal" MaxHeight="200" HorizontalAlignment="Center" >
+                            <TextBlock
+                            Name="destTitle"
+                            Text="{x:Bind MasterMenuItem.Company, Mode=OneWay}"
+                            FontSize="50" FontWeight="Normal" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
+                            VerticalAlignment="Center" HorizontalAlignment="Left" />
+                            <FontIcon 
+                            Name="destIcon"
+                            FontSize="100" 
+                            Glyph="{x:Bind MasterMenuItem.SymbolAsChar, Mode=OneWay}"
+                            VerticalAlignment="Center" Margin="100,0,0,10"
+                            HorizontalAlignment="Right"/>
+                        </StackPanel>
+                    </Border>
                     <TextBlock Text="Order Date" Style="{StaticResource CaptionTextBlockStyle}" />
                     <TextBlock Text="{x:Bind MasterMenuItem.OrderDate, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
-                    <TextBlock Text="Company" Style="{StaticResource CaptionTextBlockStyle}" />
-                    <TextBlock Text="{x:Bind MasterMenuItem.Company, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
                     <TextBlock Text="Ship to" Style="{StaticResource CaptionTextBlockStyle}" />
                     <TextBlock Text="{x:Bind MasterMenuItem.ShipTo, Mode=OneWay}" Style="{StaticResource BodyTextStyle}" />
                     <TextBlock Text="Order Total" Style="{StaticResource CaptionTextBlockStyle}" />

--- a/templates/Pages/MasterDetail/Views/MasterDetailDetailControl.xaml.cs
+++ b/templates/Pages/MasterDetail/Views/MasterDetailDetailControl.xaml.cs
@@ -1,5 +1,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
 
 using Param_ItemNamespace.Models;
 
@@ -10,7 +11,18 @@ namespace Param_ItemNamespace.Views
         public Order MasterMenuItem
         {
             get { return GetValue(MasterMenuItemProperty) as Order; }
-            set { SetValue(MasterMenuItemProperty, value); }
+            set
+            {
+                SetValue(MasterMenuItemProperty, value);
+                ConnectedAnimationService.GetForCurrentView().DefaultDuration = System.TimeSpan.FromSeconds(.25);
+                ConnectedAnimation iconAnim = ConnectedAnimationService.GetForCurrentView().GetAnimation("companyIcon");
+                ConnectedAnimation titleAnim = ConnectedAnimationService.GetForCurrentView().GetAnimation("companyTitle");
+                if (!(iconAnim == null) && !(titleAnim == null))
+                {
+                    iconAnim.TryStart(destIcon);
+                    titleAnim.TryStart(destTitle);
+                }
+            }
         }
 
         public static readonly DependencyProperty MasterMenuItemProperty = DependencyProperty.Register("MasterMenuItem", typeof(Order), typeof(MasterDetailDetailControl), new PropertyMetadata(null));

--- a/templates/Pages/MasterDetail/Views/MasterDetailPage.xaml
+++ b/templates/Pages/MasterDetail/Views/MasterDetailPage.xaml
@@ -23,8 +23,14 @@
 
                 <TextBlock
                     Grid.Row="1"
+                    Tag="{x:Bind HashIdentTitle}"
                     Text="{x:Bind Company}"
                     Style="{StaticResource ListSubTitleStyle}" />
+
+                <FontIcon 
+                    Tag="{x:Bind HashIdentIcon}"
+                    FontSize="16"
+                    Glyph="{x:Bind SymbolAsChar}" VerticalAlignment="Center" HorizontalAlignment="Right"/>
             </Grid>
         </DataTemplate>
     </Page.Resources>
@@ -73,6 +79,7 @@
                 ItemContainerTransitions="{x:Null}"
                 ItemTemplate="{StaticResource MasterListViewItemTemplate}"
                 IsItemClickEnabled="True"
+                ItemClick="MasterListView_ItemClick"
                 Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
                 <i:Interaction.Behaviors>
                     <ic:EventTriggerBehavior EventName="ItemClick">

--- a/templates/Pages/MasterDetail/Views/MasterDetailPage.xaml.cs
+++ b/templates/Pages/MasterDetail/Views/MasterDetailPage.xaml.cs
@@ -1,4 +1,12 @@
+using Param_ItemNamespace.Services;
+using Param_ItemNamespace.ViewModels;
+using Param_ItemNamespace.Models;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Navigation;
+using System.Collections.Generic;
 
 namespace Param_ItemNamespace.Views
 {
@@ -7,6 +15,57 @@ namespace Param_ItemNamespace.Views
         public MasterDetailPage()
         {
             InitializeComponent();
+        }
+
+         private void MasterListView_ItemClick(object sender, ItemClickEventArgs e)
+        {
+
+            var item = e?.ClickedItem as Order;
+            if (item != null)
+            {
+            	if (WindowStates.CurrentState.Name != "NarrowState")
+                {
+	                foreach (var fonticon in GetAllVisualChildrenOfType<FontIcon>(MasterListView))
+	                {
+	                    var element = (UIElement)fonticon;
+	                    bool foundIcon = (item.HashIdentIcon == (string)fonticon.Tag);
+                        if (foundIcon)
+                        {
+                            ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyIcon", element);
+                        }
+	                }
+
+	                foreach (var textblock in GetAllVisualChildrenOfType<TextBlock>(MasterListView))
+	                {
+	                    var element = (UIElement)textblock;
+	                    bool foundTitle = (item.HashIdentTitle == (string)textblock.Tag);
+                        if (foundTitle)
+                        {
+                            ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("companyTitle", element);
+                        }
+	                }
+	            }
+            }
+        }
+        private IEnumerable<T> GetAllVisualChildrenOfType<T>(DependencyObject obj) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
+                if (child != null && child is T)
+                    yield return (T)child;
+                else
+                {
+                    for (int j = 0; j < VisualTreeHelper.GetChildrenCount(child); j++)
+                    {
+                        IEnumerable<T> childrenOfChild = GetAllVisualChildrenOfType<T>(child);
+                        foreach (T subChild in childrenOfChild)
+                        {
+                            yield return subChild;
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/templates/Pages/WebView.CodeBehind/Views/WebViewPagePage.xaml
+++ b/templates/Pages/WebView.CodeBehind/Views/WebViewPagePage.xaml
@@ -4,6 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:rs3="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+    xmlns:rs2="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
     mc:Ignorable="d">
     <Page.Resources>
         <Style x:Key="BrowserButtonStyle" TargetType="Button">
@@ -94,7 +96,7 @@
             <HyperlinkButton Click="OnRetry" x:Uid="WebViewPage_Retry" HorizontalAlignment="Center" />
         </StackPanel>
 
-        <Grid Grid.Row="1" Background="{ThemeResource SystemControlBackgroundBaseLowBrush}">
+        <Grid rs3:VerticalAlignment="Bottom" rs2:Grid.Row="1" rs2:Background="{ThemeResource SystemControlBackgroundBaseLowBrush}" rs3:Background="{ThemeResource SystemControlChromeHighAcrylicElementMediumBrush }">
             <StackPanel Orientation="Horizontal">
                 <Button IsEnabled="{x:Bind IsBackEnabled, Mode=OneWay}" Style="{StaticResource BrowserButtonStyle}" Click="OnGoBack" x:Uid="WebViewPage_BrowserBackButton">
                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE72B;" />

--- a/templates/Pages/WebView.CodeBehind/Views/WebViewPagePage.xaml.cs
+++ b/templates/Pages/WebView.CodeBehind/Views/WebViewPagePage.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Param_ItemNamespace.Views
 {
@@ -75,11 +77,13 @@ namespace Param_ItemNamespace.Views
             set { Set(ref _failedMesageVisibility, value); }
         }
 
-        private void OnNavigationCompleted(WebView sender, WebViewNavigationCompletedEventArgs args)
+        private async void OnNavigationCompleted(WebView sender, WebViewNavigationCompletedEventArgs args)
         {
             IsLoading = false;
             OnPropertyChanged(nameof(IsBackEnabled));
             OnPropertyChanged(nameof(IsForwardEnabled));
+            string insertBreakString = String.Format("document.body.appendChild(document.createElement(\"BR\"));");
+            String s = await sender.InvokeScriptAsync("eval", new string[] { insertBreakString, insertBreakString });
         }
 
         private void OnNavigationFailed(object sender, WebViewNavigationFailedEventArgs e)


### PR DESCRIPTION
This PR serves to introduce fluent features in the WTS default templates for inclusion in the FCU update. 

1) It updates the Webview template with an acrylic control bar and the Master/Detail template with connected animation and an implicit show animation.
2) It adds new fields to the Order model in the SampleDataService so each order has a unique icon.
3) It serves to update the Master/Detail template closer to a Design reviewed style. 
4) It adds a documentation page detailing how to add Perspective Parallax to a template. 

Because this is utilizing features (Conditional XAML) that only become available in RS2 and later, compiled projects from these templates will not work in any version of Windows below RS2. There is also additional design review internally that should be done to verify that the M/D template is correct and fits redlines for our purposes and that the use of Acrylic in Webview is warranted. 

