### PR TITLE
Split signing config

### DIFF
--- a/_build/templates.signconfig.xml
+++ b/_build/templates.signconfig.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
   <job platform="" configuration="release" dest="" jobname="WindowsTemplateStudio Sign" approvers="crutkas;ralarcon">
-    <file src="__INPATHROOT__\vsix\Microsoft.Templates.2017.vsix" signType="100040160" dest="__OUTPATHROOT__\vsix\Microsoft.Templates.2017.vsix" />
     <file src="__INPATHROOT__\templates\latest\Templates.mstx" signType="100040160" dest="__OUTPATHROOT__\templates\latest\Templates.mstx" />
   </job>
 </SignConfigXML>

--- a/_build/vsix.signconfig.xml
+++ b/_build/vsix.signconfig.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SignConfigXML>
+  <job platform="" configuration="release" dest="" jobname="WindowsTemplateStudio Sign" approvers="crutkas;ralarcon">
+    <file src="__INPATHROOT__\vsix\Microsoft.Templates.2017.vsix" signType="100040160" dest="__OUTPATHROOT__\vsix\Microsoft.Templates.2017.vsix" />
+  </job>
+</SignConfigXML>


### PR DESCRIPTION
Config splited to allow sign templates before the vsix 