### PR TITLE
Added share options to extract templates

### DIFF
--- a/code/src/Core/Fs.cs
+++ b/code/src/Core/Fs.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Templates.Core
             }
         }
 
-        public static void SafeDeleteDirectory(string dir)
+        public static void SafeDeleteDirectory(string dir, bool warnOnFailure = true)
         {
             try
             {
@@ -116,7 +116,10 @@ namespace Microsoft.Templates.Core
             }
             catch (Exception ex)
             {
-                AppHealth.Current.Warning.TrackAsync(string.Format(StringRes.FsSafeDeleteDirectoryMessage, dir, ex.Message), ex).FireAndForget();
+                if (warnOnFailure)
+                {
+                    AppHealth.Current.Warning.TrackAsync(string.Format(StringRes.FsSafeDeleteDirectoryMessage, dir, ex.Message), ex).FireAndForget();
+                }
             }
         }
     }

--- a/code/src/Core/Locations/TemplatesContent.cs
+++ b/code/src/Core/Locations/TemplatesContent.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Templates.Core.Locations
 
                     if (!v.IsZero() && v < GetVersionFromFolder(currentContent))
                     {
-                        Fs.SafeDeleteDirectory(sdi.FullName);
+                        Fs.SafeDeleteDirectory(sdi.FullName, false);
                     }
                 }
             }

--- a/code/src/Core/Packaging/Templatex.cs
+++ b/code/src/Core/Packaging/Templatex.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Templates.Core.Packaging
 
             EnsureDirectory(outDir);
 
-            using (Package package = Package.Open(inFilePack, FileMode.Open, FileAccess.Read))
+            using (Package package = Package.Open(inFilePack, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 bool isSignatureValid = false;
 

--- a/code/test/Core.Test/Packaging/TemplatexTests.cs
+++ b/code/test/Core.Test/Packaging/TemplatexTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Mime;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 using Microsoft.Templates.Core.Locations;
 
@@ -259,6 +260,25 @@ namespace Microsoft.Templates.Core.Test.Locations
         }
 
         [Fact]
+        public async Task ExtractConcurrentReadAsync()
+        {
+            var inFile = @"Packaging\MsSigned\Templates.mstx";
+            var outDir1 = @"C:\Temp\OutFolder\Concurrent1";
+            var outDir2 = @"C:\Temp\OutFolder\Concurrent2";
+
+            Task t1 = new Task(() => TemplatePackage.Extract(inFile, outDir1));
+            Task t2 = new Task(() => TemplatePackage.Extract(inFile, outDir2));
+
+            t1.Start();
+            t2.Start();
+
+            await Task.WhenAll(t1, t2);
+
+            Directory.Delete(outDir1, true);
+            Directory.Delete(outDir2, true);
+        }
+
+        [Fact]
         public void ExtractFileTampered()
         {
             var certPass = GetTestCertPassword();
@@ -351,6 +371,7 @@ namespace Microsoft.Templates.Core.Test.Locations
                 }
             }
         }
+
         private void ModifyContent(string signedPack, string contentFile)
         {
             using (ZipArchive zip = ZipFile.Open(signedPack, ZipArchiveMode.Update))


### PR DESCRIPTION
Added share option when opening the package to allow concurrent read.

- Which issue does this PR relate to?
#1004

- Anything that requires particular review or attention?
Nop.

- Do all automated tests pass?
Yes.

- Have automated tests been added for new features?
Yes.

