### PR TITLE
Fix ViewModel name usage

### DIFF
--- a/templates/_composition/MVVMLight/Feature.UriSchemeExamplePage_Activation_Blank_SplitView/Activation/SchemeActivationHandler_postaction.cs
+++ b/templates/_composition/MVVMLight/Feature.UriSchemeExamplePage_Activation_Blank_SplitView/Activation/SchemeActivationHandler_postaction.cs
@@ -43,7 +43,7 @@ namespace Param_ItemNamespace.Activation
             else if (args.PreviousExecutionState != ApplicationExecutionState.Running)
             {
                 // If the app isn't running and not navigating to a specific page based on the URI, navigate to the home page
-                NavigationService.Navigate(typeof(ViewModels.MainViewModel).FullName);
+                NavigationService.Navigate(typeof(ViewModels.Param_HomeNameViewModel).FullName);
             }
 
             await Task.CompletedTask;


### PR DESCRIPTION
#1104

Fix bug where changes to the main/home page name were not respected by the UriScheme templates for SplitView + MvvmLight
