### PR TITLE
Extend minimum test execution set

### DIFF
--- a/code/src/Core/ProgrammingLanguages.cs
+++ b/code/src/Core/ProgrammingLanguages.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Templates.Core
         public static IEnumerable<string> GetAllLanguages()
         {
             yield return ProgrammingLanguages.CSharp;
-            yield return ProgrammingLanguages.VisualBasic;  // This is currently disabled until full VB support is enabled
+            // yield return ProgrammingLanguages.VisualBasic;  // This is currently disabled until full VB support is enabled
         }
     }
 }

--- a/code/test/Templates.Test/BuildProjectsTests.cs
+++ b/code/test/Templates.Test/BuildProjectsTests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Templates.Test
         [Theory]
         [MemberData("GetProjectTemplatesAsync")]
         [Trait("Type", "BuildRandomNames")]
+        [Trait("ExecutionSet", "Minimum")]
         public async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string language)
         {
             Func<ITemplateInfo, bool> selector =


### PR DESCRIPTION
Included the Generation+Build of all project combinations (Frameworks and Project Types) with all features and pages in the Minimum execution set. This will increase the generation+build tests surface to catch more issues within the CI

- Which issue does this PR relate to?
#1104

- Anything that requires particular review or attention?
The build time for CI will be increased to run the minimum execution set (expected 10-15 mins now).

- Do all automated tests pass?
Yes
