### PR TITLE
Fixed generation tests

### DIFF
--- a/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightCollection.cs
+++ b/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightCollection.cs
@@ -4,7 +4,7 @@
 
 using Xunit;
 
-namespace Microsoft.Templates.Test.BuildMVVMLightTests
+namespace Microsoft.Templates.Test
 {
     [CollectionDefinition("BuildMVVMLightCollection")]
     public class BuildMVVMLightCollection : ICollectionFixture<BuildMVVMLightFixture>

--- a/code/test/Templates.Test/GenTests/GenerationCollection.cs
+++ b/code/test/Templates.Test/GenTests/GenerationCollection.cs
@@ -6,8 +6,8 @@ using Xunit;
 
 namespace Microsoft.Templates.Test
 {
-    [CollectionDefinition("BuildMVVMBasicCollection")]
-    public class BuildMVVMBasicCollection : ICollectionFixture<BuildMVVMBasicFixture>
+    [CollectionDefinition("GenerationCollection")]
+    public class GenerationCollection : ICollectionFixture<GenerationFixture>
     {
     }
 }

--- a/code/test/Templates.Test/Templates.Test.csproj
+++ b/code/test/Templates.Test/Templates.Test.csproj
@@ -133,6 +133,7 @@
     <Compile Include="BuildCodeBehindTests\BuildCodeBehindFixture.cs" />
     <Compile Include="BuildFixture.cs" />
     <Compile Include="BuildTestsTemplateSource.cs" />
+    <Compile Include="GenTests\GenerationCollection.cs" />
     <Compile Include="GenTests\GenTestsTemplateSource.cs" />
     <Compile Include="BuildCodeBehindTests\BuildCodeBehindTestsTemplateSource.cs" />
     <Compile Include="GenTests\GenProjectsTests.cs" />


### PR DESCRIPTION
Fix for failing gen tests. I missed the generation collection when splitting up classes. 