### PR TITLE
Review test ExecutionSets

### DIFF
--- a/_build/Execute-LocalTestsInParallel.ps1
+++ b/_build/Execute-LocalTestsInParallel.ps1
@@ -1,0 +1,25 @@
+
+$rootPath = (Split-Path $PSScriptRoot)
+
+$scriptPath = Join-Path $rootPath \_build\ParallelTestExecution.ps1
+$testrunnerPath = Join-Path $rootPath \Code\packages\xunit.runner.console.2.2.0\tools\xunit.console.exe
+$templateTestLibraryPath = Join-Path $rootPath \Code\test\Templates.Test\bin\Analyze\Microsoft.Templates.Test.dll
+$coreTestLibraryPath = Join-Path $rootPath \Code\test\Core.Test\bin\Analyze\Microsoft.Templates.Core.Test.dll 
+$uiTestLibraryPath = Join-Path $rootPath \Code\test\UI.Test\bin\Analyze\Microsoft.UI.Test.dll 
+$traits = 'ExecutionSet=BuildCodeBehind', 'ExecutionSet=BuildMVVMBasic','ExecutionSet=BuildMVVMLight','ExecutionSet=BuildCaliburnMicro', 'ExecutionSet=BuildStyleCop', 'ExecutionSet=TemplateValidation', 'ExecutionSet=BuildRightClickWithLegacy'
+$outputDir = 'C:\temp\testresults'
+
+if (-not (Test-Path $outputDir))
+{
+    New-Item $outputDir -type Directory 
+}
+
+
+ . $testrunnerPath $coreTestLibraryPath 
+
+ . $testrunnerPath $uiTestLibraryPath 
+
+ . $scriptPath $testrunnerPath $testLibraryPath $traits $outputDir
+
+Write-Host $rootPath
+Write-Host $scriptPath

--- a/code/test/Core.Test/Naming/NamingTests.cs
+++ b/code/test/Core.Test/Naming/NamingTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Templates.Core.Test
 {
     [Collection("Unit Test Templates")]
     [Trait("ExecutionSet", "Minimum")]
-
     public class NamingTests
     {
         private TemplatesFixture _fixture;

--- a/code/test/Templates.Test/BuildCaliburnMicroTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildCaliburnMicroTests/BuildCaliburnMicroProjectTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Templates.Test
 {
     [Collection("BuildCaliburnMicroCollection")]
     [Trait("ExecutionSet", "BuildCaliburnMicro")]
-    [Trait("ExecutionSet", "Build")]
     public class BuildCaliburnMicroProjectTests : BaseGenAndBuildTests
     {
         public BuildCaliburnMicroProjectTests(BuildCaliburnMicroFixture fixture)

--- a/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindProjectsTests.cs
+++ b/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindProjectsTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Templates.Test
 {
     [Collection("BuildCodeBehindCollection")]
     [Trait("ExecutionSet", "BuildCodeBehind")]
-    [Trait("ExecutionSet", "Build")]
     public class BuildCodeBehindProjectTests : BaseGenAndBuildTests
     {
         public BuildCodeBehindProjectTests(BuildCodeBehindFixture fixture)

--- a/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicProjectsTests.cs
+++ b/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicProjectsTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Templates.Test
 {
     [Collection("BuildMVVMBasicCollection")]
     [Trait("ExecutionSet", "BuildMVVMBasic")]
-    [Trait("ExecutionSet", "Build")]
     public class BuildMVVMBasicProjectTests : BaseGenAndBuildTests
     {
         public BuildMVVMBasicProjectTests(BuildMVVMBasicFixture fixture)

--- a/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightProjectsTests.cs
+++ b/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightProjectsTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Templates.Test
 {
     [Collection("BuildMVVMLightCollection")]
     [Trait("ExecutionSet", "BuildMVVMLight")]
-    [Trait("ExecutionSet", "Build")]
     public class BuildMVVMLightProjectTests : BaseGenAndBuildTests
     {
         public BuildMVVMLightProjectTests(BuildMVVMLightFixture fixture)
@@ -73,7 +72,6 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimum")]
-
         public async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string language)
         {
             Func<ITemplateInfo, bool> selector =

--- a/code/test/Templates.Test/WindowsAppCertKitTests.cs
+++ b/code/test/Templates.Test/WindowsAppCertKitTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Microsoft.Templates.Test
 {
     [Collection("BuildCollection")]
-    [Trait("ExecutionSet", "ManualOnly")]
+    [Trait("ExecutionSet", "LongRunning")]
     public class WindowsAppCertKitTests : BaseGenAndBuildTests
     {
         public WindowsAppCertKitTests(BuildFixture fixture)

--- a/docs/getting-started-developers.md
+++ b/docs/getting-started-developers.md
@@ -102,7 +102,7 @@ The following list shows which tests are executed in which build. Within the Tem
 
 * VSO 'Templates.Test.Wack'	Build (Wack Tests):
   * Templates.Test
-    * ExecutionSet=ManualOnly
+    * ExecutionSet=LongRunning
 
 To shorten test execution time traits in Templates.Test are run parallel using this [script](../_build/ParallelTestExecution.ps1).
 To execute this script locally use the following powershell command:


### PR DESCRIPTION
Quick summary of changes
Changed wack tests ExecutionSet to longrunning.
Removed ExecutionSet Build as not used.
Added script to execute tests locally in parallel
- Which issue does this PR relate to?
#1235 

