### PR TITLE
Ensure folder is created to avoid warning on first sync

### DIFF
--- a/code/src/Core/Locations/TemplatesSynchronization.cs
+++ b/code/src/Core/Locations/TemplatesSynchronization.cs
@@ -329,6 +329,7 @@ namespace Microsoft.Templates.Core.Locations
                 {
                     fileInfo.Delete();
                 }
+                Fs.EnsureFolder(CurrentTemplatesFolder);
                 File.WriteAllText(fileInfo.FullName, "Instance syncing");
             }
             catch (Exception ex)


### PR DESCRIPTION
Quick summary of changes
Ensure folder is created to avoid warning on first sync
- Which issue does this PR relate to?
#1249
