### PR TITLE
Remove BoolToVisibilityConverter from Camera Page

### DIFF
--- a/_build/Execute-LocalTestsInParallel.ps1
+++ b/_build/Execute-LocalTestsInParallel.ps1
@@ -14,12 +14,11 @@ if (-not (Test-Path $outputDir))
     New-Item $outputDir -type Directory 
 }
 
-
  . $testrunnerPath $coreTestLibraryPath 
 
  . $testrunnerPath $uiTestLibraryPath 
 
- . $scriptPath $testrunnerPath $testLibraryPath $traits $outputDir
+ . $scriptPath $testrunnerPath $templateTestLibraryPath $traits $outputDir
 
 Write-Host $rootPath
 Write-Host $scriptPath

--- a/code/test/Core.Test/Core.Test.csproj
+++ b/code/test/Core.Test/Core.Test.csproj
@@ -282,7 +282,7 @@
     <None Include="TestData\Merge\Style_postaction.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
@@ -23,8 +23,10 @@ namespace Microsoft.Templates.Test
     [Collection("BuildRightClickWithLegacyCollection")]
     public class BuildRightClickWithLegacyTests : BaseGenAndBuildTests
     {
-        // Excluded wts.Page.WebView from this test as webview requires creator update as min target version
-        private string[] excludedTemplates = { "wts.Page.WebView" };
+        // Excluded wts.Page.WebView from this test as webview requires creator update as min target version due to conditional xaml
+        // Excluded wts.Page.Camera from this test as Camera requires anniversary update as min target version due to binding a boolean property to Visibility
+
+        private string[] excludedTemplates = { "wts.Page.WebView", "wts.Page.Camera" };
 
         public BuildRightClickWithLegacyTests(BuildRightClickWithLegacyFixture fixture)
         {

--- a/templates/Pages/Camera.CodeBehind/Views/CameraViewPage.xaml
+++ b/templates/Pages/Camera.CodeBehind/Views/CameraViewPage.xaml
@@ -5,12 +5,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Param_ItemNamespace.Controls"
-    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d">
-    <Page.Resources>
-        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
-    </Page.Resources>
-            
+
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
@@ -26,8 +22,8 @@
             Style="{StaticResource PageTitleStyle}" />
 
         <Grid Grid.Row="1" Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-          <controls:CameraControl 
-                x:Uid="CameraViewPage_CameraControl" 
+          <controls:CameraControl
+                x:Uid="CameraViewPage_CameraControl"
                 PhotoTaken="CameraControl_PhotoTaken" />
 
           <Image
@@ -39,6 +35,6 @@
               HorizontalAlignment="Right"
               VerticalAlignment="Bottom"/>
         </Grid>
-        
+
     </Grid>
 </Page>

--- a/templates/Pages/Camera/Views/CameraViewPage.xaml
+++ b/templates/Pages/Camera/Views/CameraViewPage.xaml
@@ -7,11 +7,7 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:controls="using:Param_ItemNamespace.Controls"
-    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d">
-    <Page.Resources>
-        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
-    </Page.Resources>
     
     <Grid
         x:Name="ContentArea"

--- a/templates/_composition/_shared/Page.Camera.AddResource/Controls/CameraControl.xaml
+++ b/templates/_composition/_shared/Page.Camera.AddResource/Controls/CameraControl.xaml
@@ -3,12 +3,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d">
 
     <UserControl.Resources>
         <ResourceDictionary>
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>            
             <Style x:Key="CameraButtonStyle" TargetType="Button">
                 <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundAltHighBrush}"/>
                 <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
@@ -143,7 +141,7 @@
                 FontSize="18"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"/>
-        
+
         <Button x:Uid="CameraControl_CameraButton"
             Click="CaptureButton_Click"
             IsEnabled="{x:Bind IsInitialized, Mode=OneWay}"
@@ -151,7 +149,7 @@
 
         <Button x:Uid="CameraControl_SwitchCameraButton"
         Click="SwitchButton_Click"
-        Visibility="{x:Bind CanSwitch, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+        Visibility="{x:Bind CanSwitch, Mode=OneWay}"
         Style="{x:Bind SwitchCameraButtonStyle}"/>
     </Grid>
 </UserControl>

--- a/templates/_composition/_shared/Page.Camera.AddResource/_postaction.csproj
+++ b/templates/_composition/_shared/Page.Camera.AddResource/_postaction.csproj
@@ -1,6 +1,0 @@
-﻿<!-- Nuget package references -->
-<!--{[{-->
-<PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>1.5.0</Version>
-</PackageReference>
-<!--}]}-->


### PR DESCRIPTION
Quick summary of changes
Removed BoolToVisibilityConverter from Camera Page and dependency con UWP Community Toolkit
- Which issue does this PR relate to?
#1251 

