### PR TITLE
Reduce SourceId names in tests to avoid path too long

### DIFF
--- a/code/test/Templates.Test/BuildCaliburnMicroTests/BuildCaliburnMicroFixture.cs
+++ b/code/test/Templates.Test/BuildCaliburnMicroTests/BuildCaliburnMicroFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Templates.Test
         private string testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
         public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\CM\\{testExecutionTimeStamp}\\";
 
-        public TemplatesSource Source => new LocalTemplatesSource("TestBuildCaliburnMicro");
+        public TemplatesSource Source => new LocalTemplatesSource("TstBldCaliburn");
 
         private static bool syncExecuted;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildCaliburnMicro"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldCaliburn"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);
@@ -65,7 +65,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildCaliburnMicro"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldCaliburn"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);

--- a/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindFixture.cs
+++ b/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Templates.Test
         private string testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
         public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\CB\\{testExecutionTimeStamp}\\";
 
-        public TemplatesSource Source => new LocalTemplatesSource("TestBuildCodeBehind");
+        public TemplatesSource Source => new LocalTemplatesSource("TstBldCodeBehind");
 
         private static bool syncExecuted;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildCodeBehind"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldCodeBehind"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);
@@ -65,7 +65,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildCodeBehind"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldCodeBehind"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);

--- a/code/test/Templates.Test/BuildFixture.cs
+++ b/code/test/Templates.Test/BuildFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Templates.Test
         private string testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
         public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\Build\\{testExecutionTimeStamp}\\";
 
-        public TemplatesSource Source => new LocalTemplatesSource("TestBuild");
+        public TemplatesSource Source => new LocalTemplatesSource("TstBld");
 
         private static bool syncExecuted;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuild"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBld"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);
@@ -65,7 +65,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuild"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBld"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);

--- a/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicFixture.cs
+++ b/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Templates.Test
         private string testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
         public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\MB\\{testExecutionTimeStamp}\\";
 
-        public TemplatesSource Source => new LocalTemplatesSource("TestBuildMVVMBasic");
+        public TemplatesSource Source => new LocalTemplatesSource("TstBldMVVMB");
 
         private static bool syncExecuted;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildMVVMBasic"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldMVVMB"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);
@@ -65,7 +65,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildMVVMBasic"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldMVVMB"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);

--- a/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightFixture.cs
+++ b/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Templates.Test
         private string testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
         public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\ML\\{testExecutionTimeStamp}\\";
 
-        public TemplatesSource Source => new LocalTemplatesSource("TestBuildMVVMLight");
+        public TemplatesSource Source => new LocalTemplatesSource("TstBldMVVML");
 
         private static bool syncExecuted;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildMVVMLight"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldMVVML"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);
@@ -65,7 +65,7 @@ namespace Microsoft.Templates.Test
             List<object[]> result = new List<object[]>();
             foreach (var language in ProgrammingLanguages.GetAllLanguages())
             {
-                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TestBuildMVVMLight"), language);
+                await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldMVVML"), language);
 
                 var projectTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                          && t.GetLanguage() == language);

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyFixture.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyFixture.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Templates.Test
         public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\LEG\\{testExecutionTimeStamp}\\";
 
         public TemplatesSource Source => new LegacyTemplatesSource();
-        public TemplatesSource LocalSource => new LocalTemplatesSource("BuildRightClickWithLegacy");
+        public TemplatesSource LocalSource => new LocalTemplatesSource("BldRClickLegacy");
 
         private static bool syncExecuted;
 

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSource.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSource.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Templates.Test
 
         public override bool ForcedAcquisition => true;
 
-        public override string Id => "TestBuildLegacy" + GetAgentName();
+        public override string Id => "TestLegacy" + GetAgentName();
 
         protected override string AcquireMstx()
         {

--- a/code/test/Templates.Test/StyleCopPlusLocalTemplatesSource.cs
+++ b/code/test/Templates.Test/StyleCopPlusLocalTemplatesSource.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Templates.Test
     public class StyleCopPlusLocalTemplatesSource : LocalTemplatesSource
     {
         public StyleCopPlusLocalTemplatesSource()
-            : base("BuildStyleCop")
+            : base("BldStyleCop")
         {
         }
 


### PR DESCRIPTION
Some VSTS have source id created to loog for path combination.

- Anything that requires particular review or attention?
No
- Do all automated tests pass?
Yes
