### PR TITLE
Include seconds to avoid collision when multiple tests run

### DIFF
--- a/code/src/Core/Diagnostics/AppHealth.cs
+++ b/code/src/Core/Diagnostics/AppHealth.cs
@@ -50,9 +50,12 @@ namespace Microsoft.Templates.Core.Diagnostics
 
         public void AddWriter(IHealthWriter newWriter)
         {
-            if (newWriter.AllowMultipleInstances() || !HealthWriters.Available.Where(w => w.GetType() == newWriter.GetType()).Any())
+            if (newWriter != null)
             {
-                HealthWriters.Available.Add(newWriter);
+                if (newWriter.AllowMultipleInstances() || !HealthWriters.Available.Where(w => w.GetType() == newWriter.GetType()).Any())
+                {
+                    HealthWriters.Available.Add(newWriter);
+                }
             }
         }
 

--- a/code/src/Core/Extensions/DateTimeExtensions.cs
+++ b/code/src/Core/Extensions/DateTimeExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Templates.Core
 
         public static string FormatAsDateHoursMinutes(this DateTime date)
         {
-            return date.ToString("dd_HHmm");
+            return date.ToString("ddHHmmss");
         }
     }
 }


### PR DESCRIPTION
Avoid side by side test execution issues