### PR TITLE
Fix Issue #1291. Review the use of lock {} in NavigationServiceEx

### DIFF
--- a/templates/_composition/MVVMLight/Project/Services/NavigationServiceEx.cs
+++ b/templates/_composition/MVVMLight/Project/Services/NavigationServiceEx.cs
@@ -51,16 +51,16 @@ namespace Param_RootNamespace.Services
 
         public bool Navigate(string pageKey, object parameter = null, NavigationTransitionInfo infoOverride = null)
         {
+            Type page;
             lock (_pages)
             {
-                if (!_pages.ContainsKey(pageKey))
+                if (!_pages.TryGetValue(pageKey, out page))
                 {
-                    throw new ArgumentException(string.Format("ExceptionNavigationServiceExPageNotFound".GetLocalized(), pageKey), nameof(pageKey));
+                    throw new ArgumentException($"Page not found: {pageKey}. Did you forget to call NavigationService.Configure?", "pageKey");
                 }
-
-                var navigationResult = Frame.Navigate(_pages[pageKey], parameter, infoOverride);
-                return navigationResult;
             }
+            var navigationResult = Frame.Navigate(page, parameter, infoOverride);
+            return navigationResult;
         }
 
         public void Configure(string key, Type pageType)

--- a/templates/_composition/MVVMLight/ProjectVB/Services/NavigationServiceEx.vb
+++ b/templates/_composition/MVVMLight/ProjectVB/Services/NavigationServiceEx.vb
@@ -46,14 +46,16 @@ Namespace Services
         End Sub
 
         Public Function Navigate(pageKey As String, Optional parameter As Object = Nothing, Optional infoOverride As NavigationTransitionInfo = Nothing) As Boolean
+            Dim page As Type
             SyncLock _pages
-                If Not _pages.ContainsKey(pageKey) Then
-                    Throw New ArgumentException("Page not found: {pageKey}. Did you forget to call NavigationService.Configure?", NameOf(pageKey))
+                If Not _pages.TryGetValue(pageKey, page) Then
+                    Throw New ArgumentException("Page not found: {pageKey}. Did you forget to call NavigationService.Configure?", "pageKey")
                 End If
-                Dim navigationResult = Frame.Navigate(_pages(pageKey), parameter, infoOverride)
-                Return navigationResult
             End SyncLock
+            Dim navigationResult = Frame.Navigate(page, parameter, infoOverride)
+            Return navigationResult
         End Function
+
 
         Public Sub Configure(key As String, pageType As Type)
             SyncLock _pages


### PR DESCRIPTION
Issue #1291 

Changes in files NavigationServiceEx.cs and NavigationServiceEx.vb.

All automated tests passed.

