### PR TITLE
Removed extra whitespaces in vbproj file

### DIFF
--- a/templates/Projects/DefaultVB/wts.DefaultProject.vbproj
+++ b/templates/Projects/DefaultVB/wts.DefaultProject.vbproj
@@ -107,7 +107,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.0.1</Version>
     </PackageReference>
 	  <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">


### PR DESCRIPTION
## PR checklist

Quick summary of changes
Reviewing issue 1360 I noticed some extra whitespaces in .vbproj file. 
This is not causing any issues currently, still I'll correct this to avoid possible future issues. 
In _postaction files extra whitespaces can cause references to be added two times, as indentation is corrected when refreshing the project. 

- Which issue does this PR relate to?
#1360
