### PR TITLE
Avoid acquire exception preventing load existing content.

### DIFF
--- a/code/src/Core/Resources/StringRes.Designer.cs
+++ b/code/src/Core/Resources/StringRes.Designer.cs
@@ -658,6 +658,15 @@ namespace Microsoft.Templates.Core.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error acquiring content..
+        /// </summary>
+        internal static string TemplatesSynchronizationErrorAcquiring {
+            get {
+                return ResourceManager.GetString("TemplatesSynchronizationErrorAcquiring", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to purge old content..
         /// </summary>
         internal static string TemplatesSynchronizationPurgeContentAsyncMessage {

--- a/code/src/Core/Resources/StringRes.resx
+++ b/code/src/Core/Resources/StringRes.resx
@@ -387,4 +387,7 @@ The following changes could not be integrated: {2}
   <data name="FailedMergePostActionKeyAlreadyDefined" xml:space="preserve">
     <value>The style with key '{0}' is already defined with different value or elements in this file. Please review the styles to include the changes manually where required in your project.</value>
   </data>
+  <data name="TemplatesSynchronizationErrorAcquiring" xml:space="preserve">
+    <value>Error acquiring content.</value>
+  </data>
 </root>

--- a/code/src/UI/ViewModels/Common/BaseMainViewModel.cs
+++ b/code/src/UI/ViewModels/Common/BaseMainViewModel.cs
@@ -197,12 +197,21 @@ namespace Microsoft.Templates.UI.ViewModels.Common
                 UpdateCanCheckUpdates(true);
             }
 
-            if (status.Status == SyncStatus.OverVersionNoContent)
+            if (status.Status == SyncStatus.OverVersion)
             {
                 SafeThreading.JoinableTaskFactory.Run(async () =>
                 {
                     await SafeThreading.JoinableTaskFactory.SwitchToMainThreadAsync();
                     UpdateTemplatesAvailable(true);
+                });
+            }
+
+            if (status.Status == SyncStatus.OverVersionNoContent)
+            {
+                SafeThreading.JoinableTaskFactory.Run(async () =>
+                {
+                    await SafeThreading.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    UpdateTemplatesAvailable(false);
                 });
             }
 


### PR DESCRIPTION
Quick summary of changes
Handle and track if there is an exception acquiring content to avoid existing content to be loaded.

- Which issue does this PR relate to?
#1321 

- Anything that requires particular review or attention?
Download and extract content (Templates Sources) will require a review as some of the intially assumptions are no longer valid (we distribute now content with each version. Issue #1376 reflect this.
- Do all automated tests pass?
Yes.
- Have you raised issues for any needed follow-on work?
Yes, #1376