### PR TITLE
Avoid stylecop warnings caused by merge postactions

### DIFF
--- a/code/test/Core.Test/PostActions/Catalog/HandleRemovalsTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/HandleRemovalsTest.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
                 "public void SomeMethod()",
                 "{",
                 "    // Merge2",
+                string.Empty,
                 "    // Merge1",
                 "}"
             };
@@ -269,6 +270,7 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             {
                 "Public Sub SomeMethod()",
                 "    ' Merge2",
+                string.Empty,
                 "    ' Merge1",
                 "End Sub"
             };


### PR DESCRIPTION
Quick summary of changes
Remove extra whitelines before/after closing/opening braces and add extra whiteline before comments where necessary

- Which issue does this PR relate to?
#1380 

