### PR TITLE
Added name verification for composition templates 

### DIFF
--- a/code/tools/TemplateValidator/TemplateFolderVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateFolderVerifier.cs
@@ -75,6 +75,17 @@ namespace TemplateValidator
                             }
                         }
                     }
+                    else
+                    {
+                        if (allIdentities.ContainsKey(template.Name))
+                        {
+                            results.Add($"Duplicate Identity detected in: '{templateFilePath}' & '{allIdentities[template.Name]}'");
+                        }
+                        else
+                        {
+                            allIdentities.Add(template.Name, templateFilePath);
+                        }
+                    }
 
                     // Get list of dependencies while the file is open. These are all checked later
                     if (template.TemplateTags.ContainsKey("wts.dependencies"))

--- a/code/tools/TemplateValidator/TemplateJsonVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateJsonVerifier.cs
@@ -94,8 +94,12 @@ namespace TemplateValidator
                 {
                     EnsureAdequateDescription(template, results);
 
-                    // Composition templates don't need identities
-                    EnsureVisualBasicTemplatesAreIdentifiedAppropriately(template, filePath, results);
+                    // Composition templates don't need identities, but need unique names
+                    EnsureVisualBasicTemplatesAreIdentifiedAppropriately(template, filePath, results, false);
+                }
+                else
+                {
+                    EnsureVisualBasicTemplatesAreIdentifiedAppropriately(template, filePath, results, true);
                 }
 
                 EnsureClassificationAsExpected(template, results);
@@ -484,11 +488,11 @@ namespace TemplateValidator
             }
         }
 
-        private static void EnsureVisualBasicTemplatesAreIdentifiedAppropriately(ValidationTemplateInfo template, string filePath, List<string> results)
+        private static void EnsureVisualBasicTemplatesAreIdentifiedAppropriately(ValidationTemplateInfo template, string filePath, List<string> results, bool isCompositionTemplate)
         {
             var isVbTemplate = filePath.Contains("VB\\");
 
-            if (string.IsNullOrWhiteSpace(template.Identity))
+            if (!isCompositionTemplate && string.IsNullOrWhiteSpace(template.Identity))
             {
                 results.Add("The template is missing an identity.");
             }
@@ -496,16 +500,21 @@ namespace TemplateValidator
             {
                 if (isVbTemplate)
                 {
-                    if (!template.Identity.EndsWith("VB", StringComparison.CurrentCulture))
+                    if (isCompositionTemplate && !template.Name.EndsWith("VB", StringComparison.CurrentCulture))
+                    {
+                        results.Add("The name of templates for VisualBasic should end with 'VB'.");
+                    }
+
+                    if (!isCompositionTemplate && !template.Identity.EndsWith("VB", StringComparison.CurrentCulture))
                     {
                         results.Add("The identity of templates for VisualBasic should end with 'VB'.");
                     }
                 }
                 else
                 {
-                    if (template.Identity.EndsWith("VB", StringComparison.CurrentCulture))
+                    if ((isCompositionTemplate && template.Name.EndsWith("VB", StringComparison.CurrentCulture)) || (!isCompositionTemplate && template.Identity.EndsWith("VB", StringComparison.CurrentCulture)))
                     {
-                        results.Add("Only VisualBasic templates should end with 'VB'.");
+                        results.Add("Only VisualBasic templates identities and names should end with 'VB'.");
                     }
                 }
             }


### PR DESCRIPTION
Added name verification for composition templates as this can lead to duplicate identities too. 
If there is no identity specified, template engine retrieves identity from name.

- Which issue does this PR relate to?
#1395 
