### PR TITLE
Add v to version number to avoid conversion to int

### DIFF
--- a/code/src/UI/Generation/GenComposer.cs
+++ b/code/src/UI/Generation/GenComposer.cs
@@ -150,8 +150,8 @@ namespace Microsoft.Templates.UI
             var genProject = CreateGenInfo(GenContext.Current.ProjectName, projectTemplate, genQueue);
 
             genProject.Parameters.Add(GenParams.Username, Environment.UserName);
-            genProject.Parameters.Add(GenParams.WizardVersion, GenContext.ToolBox.WizardVersion);
-            genProject.Parameters.Add(GenParams.TemplatesVersion, GenContext.ToolBox.TemplatesVersion);
+            genProject.Parameters.Add(GenParams.WizardVersion, string.Concat("v", GenContext.ToolBox.WizardVersion));
+            genProject.Parameters.Add(GenParams.TemplatesVersion, string.Concat("v", GenContext.ToolBox.TemplatesVersion));
             genProject.Parameters.Add(GenParams.ProjectType, userSelection.ProjectType);
             genProject.Parameters.Add(GenParams.Framework, userSelection.Framework);
         }


### PR DESCRIPTION
Quick summary of changes
Add v to version number to avoid conversion to int
- Which issue does this PR relate to?
#1407 
