### PR TITLE
Issue1409 avoid culture conflicts

### DIFF
--- a/code/Big.sln
+++ b/code/Big.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{481CC407-92E7-42A9-AD6E-AA157E5D40C3}"
 EndProject
@@ -34,6 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		GlobalSuppressions.cs = GlobalSuppressions.cs
 		StyleCop.json = StyleCop.json
 		TestCert.pfx = TestCert.pfx
+		WtsRules.ruleset = WtsRules.ruleset
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fakes", "test\Fakes\Fakes.csproj", "{FB3C81AD-823E-409C-BF6D-27534B84A8AF}"

--- a/code/WtsRules.ruleset
+++ b/code/WtsRules.ruleset
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Wts Rules" Description="Based on Microsoft Minimum Recomended Rules and customized to include other required rules. These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="15.0">
-  <!--Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
-    <Name Resource="MinimumRecommendedRules_Name" />
-    <Description Resource="MinimumRecommendedRules_Description" />
-  </Localization-->
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />
@@ -16,6 +12,8 @@
     <Rule Id="CA1065" Action="Warning" />
     <Rule Id="CA1301" Action="Warning" />
     <Rule Id="CA1304" Action="Warning" />
+    <Rule Id="CA1306" Action="Warning" />
+    <Rule Id="CA1307" Action="Warning" />
     <Rule Id="CA1400" Action="Warning" />
     <Rule Id="CA1401" Action="Warning" />
     <Rule Id="CA1403" Action="Warning" />

--- a/code/WtsRules.ruleset
+++ b/code/WtsRules.ruleset
@@ -14,6 +14,7 @@
     <Rule Id="CA1304" Action="Warning" />
     <Rule Id="CA1306" Action="Warning" />
     <Rule Id="CA1307" Action="Warning" />
+    <Rule Id="CA1309" Action="Warning" />
     <Rule Id="CA1400" Action="Warning" />
     <Rule Id="CA1401" Action="Warning" />
     <Rule Id="CA1403" Action="Warning" />

--- a/code/WtsRules.ruleset
+++ b/code/WtsRules.ruleset
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for UI.Test" Description="Code analysis rules for UI.Test.csproj." ToolsVersion="15.0">
+<RuleSet Name="Wts Rules" Description="Based on Microsoft Minimum Recomended Rules and customized to include other required rules. These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="15.0">
+  <!--Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization-->
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />

--- a/code/src/Core/CodeGen.cs
+++ b/code/src/Core/CodeGen.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Templates.Core
 
             foreach (var mp in Instance?.Settings.SettingsLoader.MountPoints)
             {
-                if (mp != null && Directory.Exists(mp.Place) && IsHigherVersion(result, mp.Place) && (mp.Place.IndexOf(sourceId, StringComparison.InvariantCultureIgnoreCase) != -1))
+                if (mp != null && Directory.Exists(mp.Place) && IsHigherVersion(result, mp.Place) && (mp.Place.IndexOf(sourceId, StringComparison.OrdinalIgnoreCase) != -1))
                 {
                     result = mp.Place;
                 }

--- a/code/src/Core/Composition/QueryNode.cs
+++ b/code/src/Core/Composition/QueryNode.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Templates.Core.Composition
 
         public QueryNode(string field, string @operator, string value)
         {
-            IsContext = field.StartsWith(ContextPrefix, StringComparison.InvariantCulture);
+            IsContext = field.StartsWith(ContextPrefix, StringComparison.Ordinal);
             Field = field?.Replace(ContextPrefix, string.Empty);
             Operator = ParseOperator(@operator);
             Value = value;

--- a/code/src/Core/Composition/QueryNode.cs
+++ b/code/src/Core/Composition/QueryNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Templates.Core.Composition
 {
     public class QueryNode
@@ -18,7 +20,7 @@ namespace Microsoft.Templates.Core.Composition
 
         public QueryNode(string field, string @operator, string value)
         {
-            IsContext = field.StartsWith(ContextPrefix);
+            IsContext = field.StartsWith(ContextPrefix, StringComparison.InvariantCulture);
             Field = field?.Replace(ContextPrefix, string.Empty);
             Operator = ParseOperator(@operator);
             Value = value;

--- a/code/src/Core/Core.csproj
+++ b/code/src/Core/Core.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -43,7 +45,8 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/code/src/Core/Diagnostics/TelemetryService.cs
+++ b/code/src/Core/Diagnostics/TelemetryService.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Templates.Core.Diagnostics
 
             foreach (var key in metrics.Keys)
             {
-                string renamedKey = key.Replace(TelemetryEvents.Prefix, TelemetryEvents.Prefix.ToUpper() + ".");
+                string renamedKey = key.Replace(TelemetryEvents.Prefix, TelemetryEvents.Prefix.ToUpperInvariant() + ".");
                 e.Properties[renamedKey] = new VsTelem.TelemetryMetricProperty(metrics[key]);
             }
 
@@ -318,7 +318,7 @@ namespace Microsoft.Templates.Core.Diagnostics
 
             foreach (var key in metrics.Keys)
             {
-                string renamedKey = key.Replace(TelemetryEvents.Prefix, TelemetryEvents.Prefix.ToUpper() + ".");
+                string renamedKey = key.Replace(TelemetryEvents.Prefix, TelemetryEvents.Prefix.ToUpperInvariant() + ".");
                 e.Properties[renamedKey] = new VsTelem.TelemetryMetricProperty(metrics[key]);
             }
 

--- a/code/src/Core/Extensions/StringExtensions.cs
+++ b/code/src/Core/Extensions/StringExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Templates.Core
                 result = GetHash(md5Hash, b64data);
             }
 
-            return result.ToUpper();
+            return result.ToUpperInvariant();
         }
 
         public static string ObfuscateSHA(this string data)
@@ -33,7 +33,7 @@ namespace Microsoft.Templates.Core
                 result = GetHash(sha2, b64data);
             }
 
-            return result.ToUpper();
+            return result.ToUpperInvariant();
         }
 
         private static string GetHash(HashAlgorithm md5Hash, byte[] inputData)

--- a/code/src/Core/Locations/LocalTemplatesSource.cs
+++ b/code/src/Core/Locations/LocalTemplatesSource.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Templates.Core.Locations
             _id = id + GetAgentName();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "Used to override the default value for this property in the local (test) source")]
         public LocalTemplatesSource(string wizardVersion, string templatesVersion, bool forcedAdquisition = true)
         {
             ForcedAcquisition = forcedAdquisition;
@@ -53,7 +54,7 @@ namespace Microsoft.Templates.Core.Locations
 
         public override void Extract(string source, string targetFolder)
         {
-            if (source.ToLower().EndsWith("mstx"))
+            if (source.ToLowerInvariant().EndsWith("mstx"))
             {
                 base.Extract(source, targetFolder);
             }

--- a/code/src/Core/Locations/LocalTemplatesSource.cs
+++ b/code/src/Core/Locations/LocalTemplatesSource.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Templates.Core.Locations
 
         public override void Extract(string source, string targetFolder)
         {
-            if (source.ToLowerInvariant().EndsWith("mstx"))
+            if (source.EndsWith("mstx", StringComparison.InvariantCultureIgnoreCase))
             {
                 base.Extract(source, targetFolder);
             }

--- a/code/src/Core/Locations/LocalTemplatesSource.cs
+++ b/code/src/Core/Locations/LocalTemplatesSource.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Templates.Core.Locations
 
         public override void Extract(string source, string targetFolder)
         {
-            if (source.EndsWith("mstx", StringComparison.InvariantCultureIgnoreCase))
+            if (source.EndsWith("mstx", StringComparison.OrdinalIgnoreCase))
             {
                 base.Extract(source, targetFolder);
             }

--- a/code/src/Core/Naming/Naming.cs
+++ b/code/src/Core/Naming/Naming.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Templates.Core
 
             foreach (var chunk in valueChunks)
             {
-                result.Append(string.Concat(char.ToUpper(chunk[0]), chunk.Substring(1), string.Empty));
+                result.Append(string.Concat(char.ToUpperInvariant(chunk[0]), chunk.Substring(1), string.Empty));
             }
 
             return result.ToString();

--- a/code/src/Core/Packaging/TemplatePackage.cs
+++ b/code/src/Core/Packaging/TemplatePackage.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Templates.Core.Packaging
         {
             string stringPart = packagePart.Uri.ToString().TrimStart('/');
             var partUri = new Uri(stringPart, UriKind.Relative);
-            string dir = targetDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()) ? targetDirectory : targetDirectory + Path.DirectorySeparatorChar;
+            string dir = targetDirectory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCultureIgnoreCase) ? targetDirectory : targetDirectory + Path.DirectorySeparatorChar;
             var uriFullPartPath = new Uri(new Uri(dir, UriKind.Absolute), partUri);
 
             // When packing, directories are automatically converted when turned into a URI

--- a/code/src/Core/Packaging/TemplatePackage.cs
+++ b/code/src/Core/Packaging/TemplatePackage.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Templates.Core.Packaging
 
         private static void EnsureDirectory(string dir)
         {
-            if (!string.IsNullOrEmpty(dir) && dir.ToLower() != Environment.CurrentDirectory.ToLower())
+            if (!string.IsNullOrEmpty(dir) && dir.ToLowerInvariant() != Environment.CurrentDirectory.ToLowerInvariant())
             {
                 if (!Directory.Exists(dir))
                 {

--- a/code/src/Core/Packaging/TemplatePackage.cs
+++ b/code/src/Core/Packaging/TemplatePackage.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Templates.Core.Packaging
         {
             string stringPart = packagePart.Uri.ToString().TrimStart('/');
             var partUri = new Uri(stringPart, UriKind.Relative);
-            string dir = targetDirectory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCultureIgnoreCase) ? targetDirectory : targetDirectory + Path.DirectorySeparatorChar;
+            string dir = targetDirectory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.OrdinalIgnoreCase) ? targetDirectory : targetDirectory + Path.DirectorySeparatorChar;
             var uriFullPartPath = new Uri(new Uri(dir, UriKind.Absolute), partUri);
 
             // When packing, directories are automatically converted when turned into a URI

--- a/code/src/Core/PostActions/Catalog/Merge/GenerateMergeInfoPostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/GenerateMergeInfoPostAction.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -57,7 +58,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
         private string GetFilePath()
         {
-            if (Path.GetFileName(Config).StartsWith(Extension))
+            if (Path.GetFileName(Config).StartsWith(Extension, StringComparison.InvariantCultureIgnoreCase))
             {
                 var extension = Path.GetExtension(Config);
                 var directory = Path.GetDirectoryName(Config);

--- a/code/src/Core/PostActions/Catalog/Merge/GenerateMergeInfoPostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/GenerateMergeInfoPostAction.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
         private string GetFilePath()
         {
-            if (Path.GetFileName(Config).StartsWith(Extension, StringComparison.InvariantCultureIgnoreCase))
+            if (Path.GetFileName(Config).StartsWith(Extension, StringComparison.OrdinalIgnoreCase))
             {
                 var extension = Path.GetExtension(Config);
                 var directory = Path.GetDirectoryName(Config);

--- a/code/src/Core/PostActions/Catalog/Merge/GetMergeFilesFromProjectPostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/GetMergeFilesFromProjectPostAction.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
         private string GetMergeFileFromDirectory(string directory)
         {
-            if (Path.GetFileName(Config).StartsWith(MergeConfiguration.Extension, StringComparison.InvariantCultureIgnoreCase))
+            if (Path.GetFileName(Config).StartsWith(MergeConfiguration.Extension, StringComparison.OrdinalIgnoreCase))
             {
                 var extension = Path.GetExtension(Config);
 

--- a/code/src/Core/PostActions/Catalog/Merge/GetMergeFilesFromProjectPostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/GetMergeFilesFromProjectPostAction.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.Templates.Core.Gen;
 
 namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
@@ -56,7 +58,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
         private string GetMergeFileFromDirectory(string directory)
         {
-            if (Path.GetFileName(Config).StartsWith(MergeConfiguration.Extension))
+            if (Path.GetFileName(Config).StartsWith(MergeConfiguration.Extension, StringComparison.InvariantCultureIgnoreCase))
             {
                 var extension = Path.GetExtension(Config);
 

--- a/code/src/Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
@@ -129,8 +129,8 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             var mergeString = string.Join(Environment.NewLine, merge);
             var sourceString = string.Join(Environment.NewLine, source);
 
-            var startIndex = mergeString.IndexOf(MacroStartDelete, StringComparison.InvariantCultureIgnoreCase);
-            var endIndex = mergeString.IndexOf(MacroEndDelete, StringComparison.InvariantCultureIgnoreCase);
+            var startIndex = mergeString.IndexOf(MacroStartDelete, StringComparison.OrdinalIgnoreCase);
+            var endIndex = mergeString.IndexOf(MacroEndDelete, StringComparison.OrdinalIgnoreCase);
 
             if (startIndex > 0 && endIndex > startIndex)
             {
@@ -152,8 +152,8 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         {
             var mergeString = string.Join(Environment.NewLine, merge);
 
-            var startIndex = mergeString.IndexOf(MacroStartDelete, StringComparison.InvariantCultureIgnoreCase);
-            var endIndex = mergeString.IndexOf(MacroEndDelete, StringComparison.InvariantCultureIgnoreCase);
+            var startIndex = mergeString.IndexOf(MacroStartDelete, StringComparison.OrdinalIgnoreCase);
+            var endIndex = mergeString.IndexOf(MacroEndDelete, StringComparison.OrdinalIgnoreCase);
 
             if (startIndex > 0 && endIndex > startIndex)
             {
@@ -162,7 +162,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
                 var lengthOfDeletion = endIndex - startIndex + MacroStartDelete.Length + commentIndicatorLength;
 
-                if (mergeString.Substring(startIndex + lengthOfDeletion - commentIndicatorLength).StartsWith(Environment.NewLine, StringComparison.InvariantCultureIgnoreCase))
+                if (mergeString.Substring(startIndex + lengthOfDeletion - commentIndicatorLength).StartsWith(Environment.NewLine, StringComparison.OrdinalIgnoreCase))
                 {
                     lengthOfDeletion += Environment.NewLine.Length;
                 }
@@ -227,7 +227,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
         private static bool NextLineIsComment(List<string> result, int insertIndex)
         {
-            return insertIndex < result.Count - 1 && (result[insertIndex].Trim().StartsWith(CSharpComment, StringComparison.InvariantCulture) || result[insertIndex].Trim().StartsWith(VBComment, StringComparison.InvariantCulture));
+            return insertIndex < result.Count - 1 && (result[insertIndex].Trim().StartsWith(CSharpComment, StringComparison.Ordinal) || result[insertIndex].Trim().StartsWith(VBComment, StringComparison.Ordinal));
         }
 
         private static bool BlockExists(IEnumerable<string> blockBuffer, IEnumerable<string> target, int skip)

--- a/code/src/Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
         private static bool NextLineIsComment(List<string> result, int insertIndex)
         {
-            return insertIndex < result.Count - 1 && (result[insertIndex].Trim().StartsWith(CSharpComment) || result[insertIndex].Trim().StartsWith(VBComment));
+            return insertIndex < result.Count - 1 && (result[insertIndex].Trim().StartsWith(CSharpComment, StringComparison.InvariantCulture) || result[insertIndex].Trim().StartsWith(VBComment, StringComparison.InvariantCulture));
         }
 
         private static bool BlockExists(IEnumerable<string> blockBuffer, IEnumerable<string> target, int skip)

--- a/code/src/Core/PostActions/Catalog/Merge/MergePostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/MergePostAction.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
 
         private string GetFilePath()
         {
-            if (Path.GetFileName(Config.FilePath).StartsWith(MergeConfiguration.Extension, StringComparison.InvariantCultureIgnoreCase))
+            if (Path.GetFileName(Config.FilePath).StartsWith(MergeConfiguration.Extension, StringComparison.OrdinalIgnoreCase))
             {
                 var extension = Path.GetExtension(Config.FilePath);
                 var directory = Path.GetDirectoryName(Config.FilePath);

--- a/code/src/Core/PostActions/Catalog/SortNamespaces/ListStringExtensions.cs
+++ b/code/src/Core/PostActions/Catalog/SortNamespaces/ListStringExtensions.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.SortNamespaces
                 return false;
             }
 
-            var startUsingIndex = classContent.IndexOf(l => l.TrimStart().StartsWith(comparer.Keyword, StringComparison.InvariantCultureIgnoreCase) || string.IsNullOrWhiteSpace(l));
-            var endUsingIndex = classContent.LastIndexOfWhile(startUsingIndex, l => l.TrimStart().StartsWith(comparer.Keyword, StringComparison.InvariantCultureIgnoreCase) || string.IsNullOrWhiteSpace(l));
+            var startUsingIndex = classContent.IndexOf(l => l.TrimStart().StartsWith(comparer.Keyword, StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(l));
+            var endUsingIndex = classContent.LastIndexOfWhile(startUsingIndex, l => l.TrimStart().StartsWith(comparer.Keyword, StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(l));
 
             if (startUsingIndex == -1 || endUsingIndex == -1)
             {

--- a/code/src/Core/PostActions/Catalog/SortNamespaces/NamespaceComparer.cs
+++ b/code/src/Core/PostActions/Catalog/SortNamespaces/NamespaceComparer.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.SortNamespaces
             var xNs = ExtractNs(x);
             var yNs = ExtractNs(y);
 
-            return string.Compare(xNs, yNs, StringComparison.InvariantCultureIgnoreCase);
+            return string.Compare(xNs, yNs, StringComparison.OrdinalIgnoreCase);
         }
 
         public string ExtractNs(string rawValue)
         {
-            if (rawValue.StartsWith(Keyword, StringComparison.InvariantCultureIgnoreCase))
+            if (rawValue.StartsWith(Keyword, StringComparison.OrdinalIgnoreCase))
             {
                 var ns = rawValue.Substring(Keyword.Length + 1);
 

--- a/code/src/Core/PostActions/PostActionFactory.cs
+++ b/code/src/Core/PostActions/PostActionFactory.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Templates.Core.PostActions
 
         private static bool IsResourceDictionaryPostaction(string f)
         {
-            return Path.GetExtension(f).ToLowerInvariant() == ".xaml" & File.ReadAllText(f).StartsWith(MergeConfiguration.ResourceDictionaryMatch, StringComparison.InvariantCulture);
+            return Path.GetExtension(f).ToLowerInvariant() == ".xaml" & File.ReadAllText(f).StartsWith(MergeConfiguration.ResourceDictionaryMatch, StringComparison.Ordinal);
         }
     }
 }

--- a/code/src/Core/PostActions/PostActionFactory.cs
+++ b/code/src/Core/PostActions/PostActionFactory.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Templates.Core.PostActions
 
         private static bool IsResourceDictionaryPostaction(string f)
         {
-            return Path.GetExtension(f).ToLowerInvariant() == ".xaml" & File.ReadAllText(f).StartsWith(MergeConfiguration.ResourceDictionaryMatch);
+            return Path.GetExtension(f).ToLowerInvariant() == ".xaml" & File.ReadAllText(f).StartsWith(MergeConfiguration.ResourceDictionaryMatch, StringComparison.InvariantCulture);
         }
     }
 }

--- a/code/src/Core/PostActions/PostActionFactory.cs
+++ b/code/src/Core/PostActions/PostActionFactory.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Templates.Core.PostActions
 
         private static bool IsResourceDictionaryPostaction(string f)
         {
-            return Path.GetExtension(f).ToLower() == ".xaml" & File.ReadAllText(f).StartsWith(MergeConfiguration.ResourceDictionaryMatch);
+            return Path.GetExtension(f).ToLowerInvariant() == ".xaml" & File.ReadAllText(f).StartsWith(MergeConfiguration.ResourceDictionaryMatch);
         }
     }
 }

--- a/code/src/Core/Templates/ITemplateInfoExtensions.cs
+++ b/code/src/Core/Templates/ITemplateInfoExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Templates.Core
         public static TemplateType GetTemplateType(this ITemplateInfo ti)
         {
             var type = GetValueFromTag(ti, TagPrefix + "type");
-            switch (type?.ToLower())
+            switch (type?.ToLowerInvariant())
             {
                 case "project":
                     return TemplateType.Project;
@@ -151,9 +151,9 @@ namespace Microsoft.Templates.Core
 
             if (ti != null)
             {
-                properties.Add(new QueryableProperty(nameof(ti.Name).ToLower(), ti.Name));
-                properties.Add(new QueryableProperty(nameof(ti.Identity).ToLower(), ti.Identity));
-                properties.Add(new QueryableProperty(nameof(ti.GroupIdentity).ToLower(), ti.GroupIdentity));
+                properties.Add(new QueryableProperty(nameof(ti.Name).ToLowerInvariant(), ti.Name));
+                properties.Add(new QueryableProperty(nameof(ti.Identity).ToLowerInvariant(), ti.Identity));
+                properties.Add(new QueryableProperty(nameof(ti.GroupIdentity).ToLowerInvariant(), ti.GroupIdentity));
 
                 foreach (var t in ti.Tags)
                 {

--- a/code/src/Installer.2017/Installer.2017.csproj
+++ b/code/src/Installer.2017/Installer.2017.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -55,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <CreateVsixContainer>True</CreateVsixContainer>
     <DeployExtension>True</DeployExtension>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -63,6 +64,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\GlobalSuppressions.cs">

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.csproj
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.csproj
@@ -45,7 +45,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -78,6 +78,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -86,6 +87,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.csproj
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.csproj
@@ -45,7 +45,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -78,6 +78,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -86,6 +87,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">

--- a/code/src/UI/Controls/CodeViewer.xaml.cs
+++ b/code/src/UI/Controls/CodeViewer.xaml.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Templates.UI.Controls
                 patternText = patternText.Replace("##language##", language);
                 patternText = patternText
                     .Replace("##ExecutingDirectory##", executingDirectory)
-                    .Replace("##renderSideBySide##", renderSideBySide.ToString().ToLower())
+                    .Replace("##renderSideBySide##", renderSideBySide.ToString().ToLowerInvariant())
                     .Replace("##theme##", SystemService.Instance.IsHighContrast ? "theme: 'hc-black'," : string.Empty)
                     .Replace("##fontSize##", $"fontSize: {CodeFontSize},");
                 if (_currentHtml != patternText)

--- a/code/src/UI/Controls/Markdown.cs
+++ b/code/src/UI/Controls/Markdown.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Templates.UI.Controls
             }
 
             string header = match.Groups[1].Value;
-            int level = match.Groups[2].Value.StartsWith("=", StringComparison.InvariantCulture) ? 1 : 2;
+            int level = match.Groups[2].Value.StartsWith("=", StringComparison.Ordinal) ? 1 : 2;
 
             // TODO: Style the paragraph based on the header level
             return CreateHeader(level, RunSpanGamut(header.Trim()));

--- a/code/src/UI/Controls/Markdown.cs
+++ b/code/src/UI/Controls/Markdown.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Templates.UI.Controls
             }
 
             string header = match.Groups[1].Value;
-            int level = match.Groups[2].Value.StartsWith("=") ? 1 : 2;
+            int level = match.Groups[2].Value.StartsWith("=", StringComparison.InvariantCulture) ? 1 : 2;
 
             // TODO: Style the paragraph based on the header level
             return CreateHeader(level, RunSpanGamut(header.Trim()));

--- a/code/src/UI/Converters/MicrosoftTemplatesAuthorConverter.cs
+++ b/code/src/UI/Converters/MicrosoftTemplatesAuthorConverter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Templates.UI.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value != null && value.ToString().ToLower() == "microsoft")
+            if (value != null && value.ToString().ToLowerInvariant() == "microsoft")
             {
                 return parameter == null ? Visibility.Collapsed : Visibility.Visible;
             }

--- a/code/src/UI/Generation/NewItemGenController.cs
+++ b/code/src/UI/Generation/NewItemGenController.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Templates.UI
             }
 
             // New files aren't listed as project file modifications so any modifications should be new package references, etc.
-            if (result.ModifiedFiles.Any(f => Path.GetExtension(f).EndsWith("proj", StringComparison.InvariantCultureIgnoreCase)))
+            if (result.ModifiedFiles.Any(f => Path.GetExtension(f).EndsWith("proj", StringComparison.OrdinalIgnoreCase)))
             {
                 // Forcing a package restore so don't get warnings in the designer once addition is complete
                 GenContext.ToolBox.Shell.RestorePackages();

--- a/code/src/UI/UI.csproj
+++ b/code/src/UI/UI.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -47,7 +49,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/code/src/UI/ViewModels/NewItem/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewItem/MainViewModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -119,11 +120,11 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
             var template = GetActiveTemplate();
             if (template.IsItemNameEditable)
             {
-                WizardStatus.WizardTitle = string.Format(StringRes.ChangesSummaryTitle_SF, NewItemSetup.ItemName, template.TemplateType.ToString().ToLower());
+                WizardStatus.WizardTitle = string.Format(StringRes.ChangesSummaryTitle_SF, NewItemSetup.ItemName, template.TemplateType.ToString().ToLower(CultureInfo.CurrentCulture));
             }
             else
             {
-                WizardStatus.WizardTitle = string.Format(StringRes.ChangesSummaryTitle_SF, template.Name, template.TemplateType.ToString().ToLower());
+                WizardStatus.WizardTitle = string.Format(StringRes.ChangesSummaryTitle_SF, template.Name, template.TemplateType.ToString().ToLower(CultureInfo.CurrentCulture));
             }
         }
 

--- a/code/src/UI/VisualStudio/VsGenShell.cs
+++ b/code/src/UI/VisualStudio/VsGenShell.cs
@@ -475,7 +475,7 @@ namespace Microsoft.Templates.UI.VisualStudio
                         break;
 
                     default:
-                        if (!item.EndsWith(".xaml.cs", StringComparison.InvariantCultureIgnoreCase))
+                        if (!item.EndsWith(".xaml.cs", StringComparison.OrdinalIgnoreCase))
                         {
                             Dte.ItemOperations.OpenFile(item, EnvDTE.Constants.vsViewKindPrimary);
                         }

--- a/code/src/UI/VisualStudio/VsShellExtensions.cs
+++ b/code/src/UI/VisualStudio/VsShellExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Templates.UI.VisualStudio
 
         public static string RemoveTailDirectorySparator(this string target)
         {
-            if (target.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCulture))
+            if (target.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
             {
                 return target.Substring(0, target.Length - 1);
             }
@@ -64,7 +64,7 @@ namespace Microsoft.Templates.UI.VisualStudio
 
         public static string RemoveStartDirectorySparator(this string target)
         {
-            if (target.StartsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCulture))
+            if (target.StartsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
             {
                 return target.Substring(1, target.Length - 1);
             }

--- a/code/src/UI/VisualStudio/VsShellExtensions.cs
+++ b/code/src/UI/VisualStudio/VsShellExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Templates.UI.VisualStudio
 
         public static string RemoveTailDirectorySparator(this string target)
         {
-            if (target.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            if (target.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCulture))
             {
                 return target.Substring(0, target.Length - 1);
             }
@@ -64,7 +64,7 @@ namespace Microsoft.Templates.UI.VisualStudio
 
         public static string RemoveStartDirectorySparator(this string target)
         {
-            if (target.StartsWith(Path.DirectorySeparatorChar.ToString()))
+            if (target.StartsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCulture))
             {
                 return target.Substring(1, target.Length - 1);
             }

--- a/code/test/Core.Test/Core.Test.csproj
+++ b/code/test/Core.Test/Core.Test.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +36,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Analyze|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -43,7 +45,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/code/test/Fakes/FakeGenShell.cs
+++ b/code/test/Fakes/FakeGenShell.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Templates.Fakes
             var msbuildProj = FakeMsBuildProject.Load(projectFullPath);
             var solutionFile = FakeSolution.Create(SolutionPath);
 
-            solutionFile.AddProjectToSolution(msbuildProj.Name, msbuildProj.Guid, projectFullPath.EndsWith(".csproj", StringComparison.InvariantCultureIgnoreCase));
+            solutionFile.AddProjectToSolution(msbuildProj.Name, msbuildProj.Guid, projectFullPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase));
         }
 
         public override string GetActiveProjectNamespace()

--- a/code/test/Fakes/Fakes.csproj
+++ b/code/test/Fakes/Fakes.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Analyze|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -37,7 +39,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/code/test/Fakes/MSBuild/FakeMsBuildProject.cs
+++ b/code/test/Fakes/MSBuild/FakeMsBuildProject.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Templates.Fakes
             switch (Path.GetExtension(fileName).ToLowerInvariant())
             {
                 case ".cs":
-                    if (fileName.EndsWith(".xaml.cs", true, CultureInfo.InvariantCulture))
+                    if (fileName.EndsWith(".xaml.cs", StringComparison.OrdinalIgnoreCase))
                     {
                         returnType = VsItemType.CompiledWithDependant;
                     }
@@ -132,7 +132,7 @@ namespace Microsoft.Templates.Fakes
 
                     break;
                 case ".vb":
-                    if (fileName.EndsWith(".xaml.vb", true, CultureInfo.InvariantCulture))
+                    if (fileName.EndsWith(".xaml.vb", StringComparison.OrdinalIgnoreCase))
                     {
                         returnType = VsItemType.CompiledWithDependant;
                     }

--- a/code/test/Fakes/MSBuild/FakeMsBuildProject.cs
+++ b/code/test/Fakes/MSBuild/FakeMsBuildProject.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Templates.Fakes
         {
             VsItemType returnType = VsItemType.Content;
 
-            switch (Path.GetExtension(fileName).ToLower())
+            switch (Path.GetExtension(fileName).ToLowerInvariant())
             {
                 case ".cs":
                     if (fileName.EndsWith(".xaml.cs", true, CultureInfo.InvariantCulture))

--- a/code/test/Fakes/Solution/FakeSolution.cs
+++ b/code/test/Fakes/Solution/FakeSolution.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -59,9 +60,9 @@ EndProject
         {
             var slnContent = File.ReadAllText(_path);
 
-            if (slnContent.IndexOf(projectName) == -1)
+            if (slnContent.IndexOf(projectName, StringComparison.InvariantCultureIgnoreCase) == -1)
             {
-                var globalIndex = slnContent.IndexOf("Global");
+                var globalIndex = slnContent.IndexOf("Global", StringComparison.InvariantCulture);
                 var projectTemplate = isCSharp ? ProjectTemplateCS : ProjectTemplateVB;
                 var projectContent = projectTemplate
                                             .Replace("{name}", projectName)
@@ -69,7 +70,7 @@ EndProject
 
                 slnContent = slnContent.Insert(globalIndex, projectContent);
 
-                var globalSectionIndex = slnContent.IndexOf(GlobalSectionText);
+                var globalSectionIndex = slnContent.IndexOf(GlobalSectionText, StringComparison.InvariantCulture);
                 var projectConfigContent = string.Format(ConfigurationTemplate, projectGuid);
 
                 slnContent = slnContent.Insert(globalSectionIndex + GlobalSectionText.Length + 1, projectConfigContent);

--- a/code/test/Fakes/Solution/FakeSolution.cs
+++ b/code/test/Fakes/Solution/FakeSolution.cs
@@ -60,9 +60,9 @@ EndProject
         {
             var slnContent = File.ReadAllText(_path);
 
-            if (slnContent.IndexOf(projectName, StringComparison.InvariantCultureIgnoreCase) == -1)
+            if (slnContent.IndexOf(projectName, StringComparison.Ordinal) == -1)
             {
-                var globalIndex = slnContent.IndexOf("Global", StringComparison.InvariantCulture);
+                var globalIndex = slnContent.IndexOf("Global", StringComparison.Ordinal);
                 var projectTemplate = isCSharp ? ProjectTemplateCS : ProjectTemplateVB;
                 var projectContent = projectTemplate
                                             .Replace("{name}", projectName)
@@ -70,7 +70,7 @@ EndProject
 
                 slnContent = slnContent.Insert(globalIndex, projectContent);
 
-                var globalSectionIndex = slnContent.IndexOf(GlobalSectionText, StringComparison.InvariantCulture);
+                var globalSectionIndex = slnContent.IndexOf(GlobalSectionText, StringComparison.Ordinal);
                 var projectConfigContent = string.Format(ConfigurationTemplate, projectGuid);
 
                 slnContent = slnContent.Insert(globalSectionIndex + GlobalSectionText.Length + 1, projectConfigContent);

--- a/code/test/Templates.Test/Templates.Test.csproj
+++ b/code/test/Templates.Test/Templates.Test.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,6 +39,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Analyze|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -46,7 +48,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/code/test/VsEmulator/Main/MainViewModel.cs
+++ b/code/test/VsEmulator/Main/MainViewModel.cs
@@ -481,7 +481,7 @@ namespace Microsoft.Templates.VsEmulator.Main
                     var dirs = Directory.EnumerateDirectories(templatesFolder);
                     foreach (var dir in dirs)
                     {
-                        if (!dir.EndsWith("0.0.0.0", StringComparison.InvariantCultureIgnoreCase))
+                        if (!dir.EndsWith("0.0.0.0", StringComparison.OrdinalIgnoreCase))
                         {
                             Fs.SafeDeleteDirectory(dir);
                         }

--- a/code/test/VsEmulator/VsEmulator.csproj
+++ b/code/test/VsEmulator/VsEmulator.csproj
@@ -27,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,6 +37,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -47,7 +49,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/code/tools/Localization/Localization.csproj
+++ b/code/tools/Localization/Localization.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -34,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Analyze|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -42,7 +44,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>

--- a/code/tools/Localization/Logic/LocalizableItemsExtractor.cs
+++ b/code/tools/Localization/Logic/LocalizableItemsExtractor.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -143,10 +145,10 @@ namespace Localization
                     string filePath = Path.Combine(desDirectory.FullName, culture + "." + Routes.TemplateJsonFile);
                     var con = new
                     {
-                        author = metadata.GetValue("author").Value<string>(),
-                        name = metadata.GetValue("name").Value<string>(),
-                        description = metadata.GetValue("description").Value<string>(),
-                        identity = metadata.GetValue("identity").Value<string>()
+                        author = metadata.GetValue("author", StringComparison.InvariantCulture).Value<string>(),
+                        name = metadata.GetValue("name", StringComparison.InvariantCulture).Value<string>(),
+                        description = metadata.GetValue("description", StringComparison.InvariantCulture).Value<string>(),
+                        identity = metadata.GetValue("identity", StringComparison.InvariantCulture).Value<string>()
                     };
                     string content = JsonConvert.SerializeObject(con, Newtonsoft.Json.Formatting.Indented);
                     File.WriteAllText(filePath, content, Encoding.UTF8);
@@ -201,9 +203,9 @@ namespace Localization
             var content = JsonConvert.DeserializeObject<List<JObject>>(fileContent);
             var projects = content.Select(json => new
             {
-                name = json.GetValue("name").Value<string>(),
-                displayName = json.GetValue("displayName").Value<string>(),
-                summary = json.GetValue("summary").Value<string>()
+                name = json.GetValue("name", StringComparison.InvariantCulture).Value<string>(),
+                displayName = json.GetValue("displayName", StringComparison.InvariantCulture).Value<string>(),
+                summary = json.GetValue("summary", StringComparison.InvariantCulture).Value<string>()
             });
 
             var data = JsonConvert.SerializeObject(projects, Newtonsoft.Json.Formatting.Indented);
@@ -222,7 +224,7 @@ namespace Localization
             var srcFile = GetFile(srcDirectory.FullName + ".json");
             var fileContent = File.ReadAllText(srcFile.FullName);
             var content = JsonConvert.DeserializeObject<List<JObject>>(fileContent);
-            var projectNames = content.Select(json => json.GetValue("name").Value<string>());
+            var projectNames = content.Select(json => json.GetValue("name", StringComparison.InvariantCulture).Value<string>());
 
             foreach (var name in projectNames)
             {

--- a/code/tools/Localization/Logic/LocalizableItemsExtractor.cs
+++ b/code/tools/Localization/Logic/LocalizableItemsExtractor.cs
@@ -145,10 +145,10 @@ namespace Localization
                     string filePath = Path.Combine(desDirectory.FullName, culture + "." + Routes.TemplateJsonFile);
                     var con = new
                     {
-                        author = metadata.GetValue("author", StringComparison.InvariantCulture).Value<string>(),
-                        name = metadata.GetValue("name", StringComparison.InvariantCulture).Value<string>(),
-                        description = metadata.GetValue("description", StringComparison.InvariantCulture).Value<string>(),
-                        identity = metadata.GetValue("identity", StringComparison.InvariantCulture).Value<string>()
+                        author = metadata.GetValue("author", StringComparison.Ordinal).Value<string>(),
+                        name = metadata.GetValue("name", StringComparison.Ordinal).Value<string>(),
+                        description = metadata.GetValue("description", StringComparison.Ordinal).Value<string>(),
+                        identity = metadata.GetValue("identity", StringComparison.Ordinal).Value<string>()
                     };
                     string content = JsonConvert.SerializeObject(con, Newtonsoft.Json.Formatting.Indented);
                     File.WriteAllText(filePath, content, Encoding.UTF8);
@@ -203,9 +203,9 @@ namespace Localization
             var content = JsonConvert.DeserializeObject<List<JObject>>(fileContent);
             var projects = content.Select(json => new
             {
-                name = json.GetValue("name", StringComparison.InvariantCulture).Value<string>(),
-                displayName = json.GetValue("displayName", StringComparison.InvariantCulture).Value<string>(),
-                summary = json.GetValue("summary", StringComparison.InvariantCulture).Value<string>()
+                name = json.GetValue("name", StringComparison.Ordinal).Value<string>(),
+                displayName = json.GetValue("displayName", StringComparison.Ordinal).Value<string>(),
+                summary = json.GetValue("summary", StringComparison.Ordinal).Value<string>()
             });
 
             var data = JsonConvert.SerializeObject(projects, Newtonsoft.Json.Formatting.Indented);
@@ -224,7 +224,7 @@ namespace Localization
             var srcFile = GetFile(srcDirectory.FullName + ".json");
             var fileContent = File.ReadAllText(srcFile.FullName);
             var content = JsonConvert.DeserializeObject<List<JObject>>(fileContent);
-            var projectNames = content.Select(json => json.GetValue("name", StringComparison.InvariantCulture).Value<string>());
+            var projectNames = content.Select(json => json.GetValue("name", StringComparison.Ordinal).Value<string>());
 
             foreach (var name in projectNames)
             {

--- a/code/tools/Localization/Logic/LocalizableItemsVerificator.cs
+++ b/code/tools/Localization/Logic/LocalizableItemsVerificator.cs
@@ -160,7 +160,7 @@ namespace Localization
             var filePath = Path.Combine(_sourceDir.FullName, Routes.WtsTemplatesRootDirPath, fileName);
             var fileContent = File.ReadAllText(filePath);
             var content = JsonConvert.DeserializeObject<List<JObject>>(fileContent);
-            var wtsItems = content.Select(json => json.GetValue("name", StringComparison.InvariantCulture).Value<string>());
+            var wtsItems = content.Select(json => json.GetValue("name", StringComparison.Ordinal).Value<string>());
 
             var wtsItemDirectory = Path.Combine(Routes.WtsTemplatesRootDirPath, wtsTemplateName);
 

--- a/code/tools/Localization/Logic/LocalizableItemsVerificator.cs
+++ b/code/tools/Localization/Logic/LocalizableItemsVerificator.cs
@@ -160,7 +160,7 @@ namespace Localization
             var filePath = Path.Combine(_sourceDir.FullName, Routes.WtsTemplatesRootDirPath, fileName);
             var fileContent = File.ReadAllText(filePath);
             var content = JsonConvert.DeserializeObject<List<JObject>>(fileContent);
-            var wtsItems = content.Select(json => json.GetValue("name").Value<string>());
+            var wtsItems = content.Select(json => json.GetValue("name", StringComparison.InvariantCulture).Value<string>());
 
             var wtsItemDirectory = Path.Combine(Routes.WtsTemplatesRootDirPath, wtsTemplateName);
 

--- a/code/tools/Localization/Logic/ProjectTemplateGeneratorBase.cs
+++ b/code/tools/Localization/Logic/ProjectTemplateGeneratorBase.cs
@@ -24,7 +24,7 @@ namespace Localization
                 throw new DirectoryNotFoundException($"Source directory \"{_config.SourceDir}\" not found.");
             }
 
-            if (_sourceDir.Name.ToLower() != _config.SourceDirNamePattern.ToLower())
+            if (_sourceDir.Name.ToLowerInvariant() != _config.SourceDirNamePattern.ToLowerInvariant())
             {
                 throw new Exception($"Source directory \"{_sourceDir.Name}\" is not valid. Directory name should be \"{_config.SourceDirNamePattern}\".");
             }

--- a/code/tools/Localization/Logic/RightClickCommandGenerator.cs
+++ b/code/tools/Localization/Logic/RightClickCommandGenerator.cs
@@ -31,7 +31,7 @@ namespace Localization
                 throw new DirectoryNotFoundException($"Source directory \"{sourceDirPath}\" not found.");
             }
 
-            if (_sourceDir.Name.ToLower() != SourceDirNamePattern.ToLower())
+            if (_sourceDir.Name.ToLowerInvariant() != SourceDirNamePattern.ToLowerInvariant())
             {
                 throw new Exception($"Source directory \"{_sourceDir.Name}\" is not valid. Directory name should be \"{SourceDirNamePattern}\".");
             }

--- a/code/tools/Localization/Program.cs
+++ b/code/tools/Localization/Program.cs
@@ -40,7 +40,7 @@ namespace Localization
 
         private static void ShowHelp(string verb, string[] args)
         {
-            if (!string.IsNullOrEmpty(verb) && verb.ToLower() == "help" && args?.Count() > 1 && args[1] != null)
+            if (!string.IsNullOrEmpty(verb) && verb.ToLowerInvariant() == "help" && args?.Count() > 1 && args[1] != null)
             {
                 PrintHelp(args[1]);
             }
@@ -95,7 +95,7 @@ namespace Localization
             }
             else
             {
-                switch (verb.ToUpper())
+                switch (verb.ToUpperInvariant())
                 {
                     case "EXT":
                         Console.WriteLine("Extract localizable items for different cultures.");

--- a/code/tools/TemplateValidator/TemplateValidator.csproj
+++ b/code/tools/TemplateValidator/TemplateValidator.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>TemplateValidator.Program</StartupObject>
@@ -41,7 +43,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>


### PR DESCRIPTION
Quick summary of changes
Ensure correct comparisons not affected by the Culture selected.
Fixed ToLower / ToUpper / ToString with out culture info or using the invariant or ordinal comparison versions

- Which issue does this PR relate to?
#1409 

- Anything that requires particular review or attention?
No

- Do all automated tests pass?
Yes
