### PR TITLE
Fixed certificate generation postaction for multiproject solutions

### DIFF
--- a/code/src/Core/PostActions/PostActionFactory.cs
+++ b/code/src/Core/PostActions/PostActionFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Templates.Core.PostActions
             var genCertificatePostAction = genResult.ResultInfo.PostActions.Where(x => x.ActionId == GenerateTestCertificatePostAction.Id).FirstOrDefault();
             if (genCertificatePostAction != null)
             {
-                postActions.Add(new GenerateTestCertificatePostAction(genInfo.Template.Identity, genInfo.GetUserName(), genCertificatePostAction, genResult.ResultInfo.PrimaryOutputs));
+                postActions.Add(new GenerateTestCertificatePostAction(genInfo.Template.Identity, genInfo.GetUserName(), genCertificatePostAction, genResult.ResultInfo.PrimaryOutputs, genInfo.Parameters));
             }
         }
 

--- a/code/test/Core.Test/PostActions/Catalog/GenerateTestCertificatePostActionTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/GenerateTestCertificatePostActionTest.cs
@@ -65,11 +65,12 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
 
             Dictionary<string, string> testArgs = new Dictionary<string, string>();
             testArgs.Add("files", "0");
+
             List<FakeCreationPath> testPrimaryOutputs = new List<FakeCreationPath>();
             testPrimaryOutputs.Add(new FakeCreationPath() { Path = projectFile });
             IPostAction templateDefinedPostAction = new FakeTemplateDefinedPostAction(GenerateTestCertificatePostAction.Id, testArgs, true);
 
-            var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", templateDefinedPostAction, testPrimaryOutputs as IReadOnlyList<ICreationPath>);
+            var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", templateDefinedPostAction, testPrimaryOutputs as IReadOnlyList<ICreationPath>, new Dictionary<string, string>());
 
             postAction.Execute();
 
@@ -101,11 +102,11 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             testPrimaryOutputs.Add(new FakeCreationPath() { Path = projectFile });
             IPostAction templateDefinedPostAction = new FakeTemplateDefinedPostAction(GenerateTestCertificatePostAction.Id, testArgs, true);
 
-            var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", templateDefinedPostAction, testPrimaryOutputs as IReadOnlyList<ICreationPath>);
+            var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", templateDefinedPostAction, testPrimaryOutputs as IReadOnlyList<ICreationPath>, new Dictionary<string, string>());
 
             postAction.Execute();
 
-            var expectedCertFilePath = Path.Combine(GenContext.Current.OutputPath, $"{projectName}_TemporaryKey.pfx");
+            var expectedCertFilePath = Path.Combine(GenContext.Current.ProjectPath, $"{projectName}_TemporaryKey.pfx");
 
             Assert.True(File.Exists(expectedCertFilePath));
 
@@ -119,7 +120,7 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             testArgs.Add("myArg", "myValue");
             IPostAction inventedIdPostAction = new FakeTemplateDefinedPostAction(Guid.NewGuid(), testArgs, true);
 
-            var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", inventedIdPostAction, null);
+            var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", inventedIdPostAction, null, new Dictionary<string, string>());
 
             Assert.True(postAction.ContinueOnError);
             Assert.NotEqual(inventedIdPostAction.ActionId, GenerateTestCertificatePostAction.Id);
@@ -134,7 +135,7 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
                    Dictionary<string, string> testArgs = new Dictionary<string, string>();
                    testArgs.Add("myArg", "myValue");
                    IPostAction inventedIdPostAction = new FakeTemplateDefinedPostAction(Guid.NewGuid(), testArgs, false);
-                   var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", inventedIdPostAction, null);
+                   var postAction = new GenerateTestCertificatePostAction("TestTemplate", "TestUser", inventedIdPostAction, null, new Dictionary<string, string>());
                });
         }
     }


### PR DESCRIPTION
Quick summary of changes
-Added replacement of parameters in primary output path to certificate generation postaction.

- Which issue does this PR relate to?
#1330, #1329 
- Anything that requires particular review or attention?
Where the primaryoutput path is used, the fix for parameter replacemement has to be applied until template engine is updated
- Do all automated tests pass?
Yes
