### PR TITLE
Exlude xamarin templates from BuildMinimum ExecutionSet

### DIFF
--- a/code/src/UI/VisualStudio/VsGenShell.cs
+++ b/code/src/UI/VisualStudio/VsGenShell.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Templates.UI.VisualStudio
             {
                 var projectGuid = GetProjectTypeGuid(p);
 
-                if (projectGuid.ToUpper().Split(';').Contains($"{{{projectTypeGuid}}}"))
+                if (projectGuid.ToUpperInvariant().Split(';').Contains($"{{{projectTypeGuid}}}"))
                 {
                     return p;
                 }

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -350,11 +350,11 @@ namespace Microsoft.Templates.Test
         // Need overload with different number of params to work with XUnit.MemeberData
         public static IEnumerable<object[]> GetProjectTemplatesForBuildAsync(string framework)
         {
-            return GetProjectTemplatesForBuildAsync(framework, string.Empty);
+            return GetProjectTemplatesForBuildAsync(framework, string.Empty, string.Empty);
         }
 
         // Set a single programming language to stop the fixture using all languages available to it
-        public static IEnumerable<object[]> GetProjectTemplatesForBuildAsync(string framework, string programmingLanguage)
+        public static IEnumerable<object[]> GetProjectTemplatesForBuildAsync(string framework, string programmingLanguage, string platform)
         {
             JoinableTaskContext context = new JoinableTaskContext();
             JoinableTaskCollection tasks = context.CreateCollection();
@@ -364,15 +364,15 @@ namespace Microsoft.Templates.Test
             switch (framework)
             {
                 case "CodeBehind":
-                    result = context.Factory.Run(() => BuildCodeBehindFixture.GetProjectTemplatesAsync(framework, programmingLanguage));
+                    result = context.Factory.Run(() => BuildCodeBehindFixture.GetProjectTemplatesAsync(framework, programmingLanguage, platform));
                     break;
 
                 case "MVVMBasic":
-                    result = context.Factory.Run(() => BuildMVVMBasicFixture.GetProjectTemplatesAsync(framework, programmingLanguage));
+                    result = context.Factory.Run(() => BuildMVVMBasicFixture.GetProjectTemplatesAsync(framework, programmingLanguage, platform));
                     break;
 
                 case "MVVMLight":
-                    result = context.Factory.Run(() => BuildMVVMLightFixture.GetProjectTemplatesAsync(framework, programmingLanguage));
+                    result = context.Factory.Run(() => BuildMVVMLightFixture.GetProjectTemplatesAsync(framework, programmingLanguage, platform));
                     break;
 
                 case "CaliburnMicro":

--- a/code/test/Templates.Test/BuildCaliburnMicroTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildCaliburnMicroTests/BuildCaliburnMicroProjectTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "BuildRightClick")]
         public async Task BuildEmptyProjectWithAllRightClickItemsAsync(string projectType, string framework, string platform, string language)
         {
-            var projectName = $"{projectType}AllRC ";
+            var projectName = $"{projectType}AllRC";
 
             var projectPath = await AssertGenerateRightClickAsync(projectName, projectType, framework, platform, language, true, false);
 

--- a/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindFixture.cs
+++ b/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Templates.Test
 
         private static bool syncExecuted;
 
-        public static async Task<IEnumerable<object[]>> GetProjectTemplatesAsync(string frameworkFilter, string programmingLanguage)
+        public static async Task<IEnumerable<object[]>> GetProjectTemplatesAsync(string frameworkFilter, string programmingLanguage, string selectedPlatform)
         {
             List<object[]> result = new List<object[]>();
 
@@ -37,9 +37,17 @@ namespace Microsoft.Templates.Test
                 languagesOfInterest.Add(programmingLanguage);
             }
 
+            var platformsOfInterest = Platforms.GetAllPlatforms().ToList();
+
+            if (!string.IsNullOrWhiteSpace(selectedPlatform))
+            {
+                platformsOfInterest.Clear();
+                platformsOfInterest.Add(selectedPlatform);
+            }
+
             foreach (var language in languagesOfInterest)
             {
-                foreach (var platform in Platforms.GetAllPlatforms())
+                foreach (var platform in platformsOfInterest)
                 {
                     await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldCodeBehind"), platform, language);
 

--- a/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildCodeBehindTests/BuildCodeBehindProjectTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForBuildAsync", "CodeBehind", ProgrammingLanguages.CSharp)]
+        [MemberData("GetProjectTemplatesForBuildAsync", "CodeBehind", ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimum")]
@@ -72,7 +72,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForBuildAsync", "CodeBehind", ProgrammingLanguages.VisualBasic)]
+        [MemberData("GetProjectTemplatesForBuildAsync", "CodeBehind", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimumVB")]

--- a/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicFixture.cs
+++ b/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Templates.Test
 
         private static bool syncExecuted;
 
-        public static async Task<IEnumerable<object[]>> GetProjectTemplatesAsync(string frameworkFilter, string programmingLanguage)
+        public static async Task<IEnumerable<object[]>> GetProjectTemplatesAsync(string frameworkFilter, string programmingLanguage, string selectedPlatform)
         {
             List<object[]> result = new List<object[]>();
 
@@ -37,9 +37,17 @@ namespace Microsoft.Templates.Test
                 languagesOfInterest.Add(programmingLanguage);
             }
 
+            var platformsOfInterest = Platforms.GetAllPlatforms().ToList();
+
+            if (!string.IsNullOrWhiteSpace(selectedPlatform))
+            {
+                platformsOfInterest.Clear();
+                platformsOfInterest.Add(selectedPlatform);
+            }
+
             foreach (var language in languagesOfInterest)
             {
-                foreach (var platform in Platforms.GetAllPlatforms())
+                foreach (var platform in platformsOfInterest)
                 {
                     await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldMVVMB"), platform, language);
                     var templateProjectTypes = GenComposer.GetSupportedProjectTypes(platform);

--- a/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildMVVMBasic/BuildMVVMBasicProjectTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMBasic", ProgrammingLanguages.CSharp)]
+        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimum")]
@@ -72,7 +72,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMBasic", ProgrammingLanguages.VisualBasic)]
+        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMBasic", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimumVB")]

--- a/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightFixture.cs
+++ b/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Templates.Test
 
         private static bool syncExecuted;
 
-        public static async Task<IEnumerable<object[]>> GetProjectTemplatesAsync(string frameworkFilter, string programmingLanguage)
+        public static async Task<IEnumerable<object[]>> GetProjectTemplatesAsync(string frameworkFilter, string programmingLanguage, string selectedPlatform)
         {
             List<object[]> result = new List<object[]>();
 
@@ -37,9 +37,17 @@ namespace Microsoft.Templates.Test
                 languagesOfInterest.Add(programmingLanguage);
             }
 
+            var platformsOfInterest = Platforms.GetAllPlatforms().ToList();
+
+            if (!string.IsNullOrWhiteSpace(selectedPlatform))
+            {
+                platformsOfInterest.Clear();
+                platformsOfInterest.Add(selectedPlatform);
+            }
+
             foreach (var language in languagesOfInterest)
             {
-                foreach (var platform in Platforms.GetAllPlatforms())
+                foreach (var platform in platformsOfInterest)
                 {
                     await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("TstBldMVVML"), platform, language);
 

--- a/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildMVVMLightTests/BuildMVVMLightProjectTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMLight", ProgrammingLanguages.CSharp)]
+        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimum")]
@@ -72,7 +72,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMLight", ProgrammingLanguages.VisualBasic)]
+        [MemberData("GetProjectTemplatesForBuildAsync", "MVVMLight", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimumVB")]


### PR DESCRIPTION
 Exlude xamarin templates from BuildMinimum ExecutionSet to avoid appveyor generation errors

- Which issue does this PR relate to?
#1471 
