### PR TITLE
Remove Grid background from pages

### DIFF
--- a/templates/Features/FeedbackHub.CaliburnMicro/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.CaliburnMicro/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/FeedbackHub.CodeBehind/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.CodeBehind/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/FeedbackHub.CodeBehindVB/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.CodeBehindVB/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/FeedbackHub.MVVMBasic/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.MVVMBasic/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/FeedbackHub.MVVMBasicVB/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.MVVMBasicVB/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/FeedbackHub.MVVMLight/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.MVVMLight/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/FeedbackHub.MVVMLightVB/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.MVVMLightVB/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/FeedbackHub.Prism/Views/Param_SettingsPageNamePage_postaction.xaml
+++ b/templates/Features/FeedbackHub.Prism/Views/Param_SettingsPageNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <StackPanel Grid.Row="1">
                 <StackPanel Margin="{StaticResource EightTopMargin}">

--- a/templates/Features/UriScheme.Prism/Views/UriSchemeExamplePage.xaml
+++ b/templates/Features/UriScheme.Prism/Views/UriSchemeExamplePage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     xmlns:prismMvvm="using:Prism.Windows.Mvvm"
     prismMvvm:ViewModelLocator.AutoWireViewModel="True"    
     mc:Ignorable="d">

--- a/templates/Pages/Map.CaliburnMicro/Views/MapPagePage.xaml
+++ b/templates/Pages/Map.CaliburnMicro/Views/MapPagePage.xaml
@@ -7,7 +7,7 @@
     xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <maps:MapControl
             x:Name="mapControl"
             ZoomLevel="{x:Bind ViewModel.ZoomLevel, Mode=OneWay}"

--- a/templates/Pages/Map.CodeBehind/Views/MapPagePage.xaml
+++ b/templates/Pages/Map.CodeBehind/Views/MapPagePage.xaml
@@ -7,7 +7,7 @@
     xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <maps:MapControl
             x:Name="mapControl"
             ZoomLevel="{x:Bind ZoomLevel, Mode=OneWay}"

--- a/templates/Pages/Map.CodeBehindVB/Views/MapPagePage.xaml
+++ b/templates/Pages/Map.CodeBehindVB/Views/MapPagePage.xaml
@@ -7,7 +7,7 @@
     xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <maps:MapControl
             x:Name="mapControl"
             ZoomLevel="{x:Bind ZoomLevel, Mode=OneWay}"

--- a/templates/Pages/Map.Prism/Views/MapPagePage.xaml
+++ b/templates/Pages/Map.Prism/Views/MapPagePage.xaml
@@ -11,7 +11,7 @@
     xmlns:b="using:Param_ItemNamespace.Behaviors"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <maps:MapControl
             x:Name="mapControl" MapServiceToken="{Binding MapServiceToken}"
             ZoomLevel="{x:Bind ViewModel.ZoomLevel, Mode=OneWay}" 

--- a/templates/Pages/Map/Views/MapPagePage.xaml
+++ b/templates/Pages/Map/Views/MapPagePage.xaml
@@ -7,7 +7,7 @@
     xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <maps:MapControl
             x:Name="mapControl"
             ZoomLevel="{x:Bind ViewModel.ZoomLevel, Mode=OneWay}"

--- a/templates/Pages/MapVB/Views/MapPagePage.xaml
+++ b/templates/Pages/MapVB/Views/MapPagePage.xaml
@@ -7,7 +7,7 @@
     xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <maps:MapControl
             x:Name="mapControl"
             ZoomLevel="{x:Bind ViewModel.ZoomLevel, Mode=OneWay}"

--- a/templates/Pages/Settings.CaliburnMicro/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings.CaliburnMicro/Views/SettingsPagePage.xaml
@@ -12,7 +12,7 @@
         <helper:EnumToBooleanConverter x:Key="EnumToBooleanConverter" EnumType="ElementTheme" />
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="48"/>

--- a/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings.CodeBehind/Views/SettingsPagePage.xaml
@@ -11,7 +11,7 @@
         <helper:EnumToBooleanConverter x:Key="EnumToBooleanConverter" EnumType="ElementTheme" />
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="48"/>

--- a/templates/Pages/Settings.CodeBehindVB/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings.CodeBehindVB/Views/SettingsPagePage.xaml
@@ -11,7 +11,7 @@
         <helper:EnumToBooleanConverter x:Key="EnumToBooleanConverter" EnumType="ElementTheme" />
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="48"/>

--- a/templates/Pages/Settings.Prism/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings.Prism/Views/SettingsPagePage.xaml
@@ -11,7 +11,7 @@
         <helper:EnumToBooleanConverter x:Key="EnumToBooleanConverter" EnumType="ElementTheme" />
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="48"/>

--- a/templates/Pages/Settings/Views/SettingsPagePage.xaml
+++ b/templates/Pages/Settings/Views/SettingsPagePage.xaml
@@ -11,7 +11,7 @@
         <helper:EnumToBooleanConverter x:Key="EnumToBooleanConverter" EnumType="ElementTheme" />
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="48"/>

--- a/templates/Pages/SettingsVB/Views/SettingsPagePage.xaml
+++ b/templates/Pages/SettingsVB/Views/SettingsPagePage.xaml
@@ -11,7 +11,7 @@
         <helper:EnumToBooleanConverter x:Key="EnumToBooleanConverter" EnumType="ElementTheme" />
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid Margin="{StaticResource MediumLeftRightMargin}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="48"/>

--- a/templates/Pages/TabbedPivot.CaliburnMicro/Views/ExampleTabPage.xaml
+++ b/templates/Pages/TabbedPivot.CaliburnMicro/Views/ExampleTabPage.xaml
@@ -3,11 +3,12 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:App1.Views"
+    Style="{StaticResource PageStyle}"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
 
     </Grid>
 </Page>

--- a/templates/Pages/TabbedPivot.CaliburnMicro/Views/TabbedPivotPagePage.xaml
+++ b/templates/Pages/TabbedPivot.CaliburnMicro/Views/TabbedPivotPagePage.xaml
@@ -7,7 +7,7 @@
     xmlns:cm="using:Caliburn.Micro"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition x:Name="TitleRow" Height="48"/>
             <RowDefinition Height="*"/>

--- a/templates/Pages/TabbedPivot.CodeBehind/Views/TabbedPivotPagePage.xaml
+++ b/templates/Pages/TabbedPivot.CodeBehind/Views/TabbedPivotPagePage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition x:Name="TitleRow" Height="48"/>
             <RowDefinition Height="*"/>

--- a/templates/Pages/TabbedPivot.CodeBehindVB/Views/TabbedPivotPagePage.xaml
+++ b/templates/Pages/TabbedPivot.CodeBehindVB/Views/TabbedPivotPagePage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition x:Name="TitleRow" Height="48"/>
             <RowDefinition Height="*"/>

--- a/templates/Pages/TabbedPivot/Views/TabbedPivotPagePage.xaml
+++ b/templates/Pages/TabbedPivot/Views/TabbedPivotPagePage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition x:Name="TitleRow" Height="48"/>
             <RowDefinition Height="*"/>

--- a/templates/Pages/TabbedPivotVB/Views/TabbedPivotPagePage.xaml
+++ b/templates/Pages/TabbedPivotVB/Views/TabbedPivotPagePage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition x:Name="TitleRow" Height="48"/>
             <RowDefinition Height="*"/>

--- a/templates/Pages/WebView.CaliburnMicro/Views/WebViewPagePage.xaml
+++ b/templates/Pages/WebView.CaliburnMicro/Views/WebViewPagePage.xaml
@@ -77,7 +77,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />

--- a/templates/Pages/WebView.CodeBehind/Views/WebViewPagePage.xaml
+++ b/templates/Pages/WebView.CodeBehind/Views/WebViewPagePage.xaml
@@ -74,7 +74,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />

--- a/templates/Pages/WebView.CodeBehindVB/Views/WebViewPagePage.xaml
+++ b/templates/Pages/WebView.CodeBehindVB/Views/WebViewPagePage.xaml
@@ -74,7 +74,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />

--- a/templates/Pages/WebView.Prism/Views/WebViewPagePage.xaml
+++ b/templates/Pages/WebView.Prism/Views/WebViewPagePage.xaml
@@ -75,7 +75,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />

--- a/templates/Pages/WebView/Views/WebViewPagePage.xaml
+++ b/templates/Pages/WebView/Views/WebViewPagePage.xaml
@@ -76,7 +76,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />

--- a/templates/Pages/WebViewVB/Views/WebViewPagePage.xaml
+++ b/templates/Pages/WebViewVB/Views/WebViewPagePage.xaml
@@ -76,7 +76,7 @@
         </Style>
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />

--- a/templates/_composition/CaliburnMicro/Feature.UriSchemeExamplePage/Views/wts.ItemNameExamplePage.xaml
+++ b/templates/_composition/CaliburnMicro/Feature.UriSchemeExamplePage/Views/wts.ItemNameExamplePage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"

--- a/templates/_composition/CaliburnMicro/Project.TabbedPivot/Views/PivotPage.xaml
+++ b/templates/_composition/CaliburnMicro/Project.TabbedPivot/Views/PivotPage.xaml
@@ -4,11 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     xmlns:views="using:wts.ItemName.Views"
     xmlns:cm="using:Caliburn.Micro"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage" x:Name="Items">
              <Pivot.HeaderTemplate>
                 <DataTemplate>

--- a/templates/_composition/CodeBehind/Project.TabbedPivot/Views/PivotPage.xaml
+++ b/templates/_composition/CodeBehind/Project.TabbedPivot/Views/PivotPage.xaml
@@ -4,11 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     xmlns:model="using:wts.ItemName.Models"
     xmlns:views="using:wts.ItemName.Views"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage">
         </Pivot>
     </Grid>

--- a/templates/_composition/CodeBehind/Project.TabbedPivotVB/Views/PivotPage.xaml
+++ b/templates/_composition/CodeBehind/Project.TabbedPivotVB/Views/PivotPage.xaml
@@ -4,11 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     xmlns:model="using:wts.ItemName.Models"
     xmlns:views="using:wts.ItemName.Views"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage">
         </Pivot>
     </Grid>

--- a/templates/_composition/MVVMBasic/Feature.UriSchemeExamplePage/Views/wts.ItemNameExamplePage.xaml
+++ b/templates/_composition/MVVMBasic/Feature.UriSchemeExamplePage/Views/wts.ItemNameExamplePage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"

--- a/templates/_composition/MVVMBasic/Feature.UriSchemeExamplePageVB/Views/wts.ItemNameExamplePage.xaml
+++ b/templates/_composition/MVVMBasic/Feature.UriSchemeExamplePageVB/Views/wts.ItemNameExamplePage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"

--- a/templates/_composition/MVVMBasic/Project.TabbedPivot/Views/PivotPage.xaml
+++ b/templates/_composition/MVVMBasic/Project.TabbedPivot/Views/PivotPage.xaml
@@ -4,11 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     xmlns:model="using:wts.ItemName.Models"
     xmlns:views="using:wts.ItemName.Views"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage">
         </Pivot>
     </Grid>

--- a/templates/_composition/MVVMBasic/Project.TabbedPivotVB/Views/PivotPage.xaml
+++ b/templates/_composition/MVVMBasic/Project.TabbedPivotVB/Views/PivotPage.xaml
@@ -4,11 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     xmlns:model="using:wts.ItemName.Models"
     xmlns:views="using:wts.ItemName.Views"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage">
         </Pivot>
     </Grid>

--- a/templates/_composition/MVVMLight/Feature.UriSchemeExamplePage/Views/wts.ItemNameExamplePage.xaml
+++ b/templates/_composition/MVVMLight/Feature.UriSchemeExamplePage/Views/wts.ItemNameExamplePage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     DataContext="{Binding wts.ItemNameExampleViewModel, Source={StaticResource Locator}}"
     mc:Ignorable="d">
     <Grid

--- a/templates/_composition/MVVMLight/Feature.UriSchemeExamplePageVB/Views/wts.ItemNameExamplePage.xaml
+++ b/templates/_composition/MVVMLight/Feature.UriSchemeExamplePageVB/Views/wts.ItemNameExamplePage.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     DataContext="{Binding wts.ItemNameExampleViewModel, Source={StaticResource Locator}}"
+    Style="{StaticResource PageStyle}"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"

--- a/templates/_composition/MVVMLight/Project.TabbedPivot/Views/PivotPage.xaml
+++ b/templates/_composition/MVVMLight/Project.TabbedPivot/Views/PivotPage.xaml
@@ -5,11 +5,12 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     DataContext="{Binding PivotViewModel, Source={StaticResource Locator}}"
+    Style="{StaticResource PageStyle}"
     xmlns:model="using:wts.ItemName.Models"
     xmlns:views="using:wts.ItemName.Views"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage">
         </Pivot>
     </Grid>

--- a/templates/_composition/MVVMLight/Project.TabbedPivotVB/Views/PivotPage.xaml
+++ b/templates/_composition/MVVMLight/Project.TabbedPivotVB/Views/PivotPage.xaml
@@ -4,12 +4,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     DataContext="{Binding PivotViewModel, Source={StaticResource Locator}}"
     xmlns:model="using:wts.ItemName.Models"
     xmlns:views="using:wts.ItemName.Views"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage">
         </Pivot>
     </Grid>

--- a/templates/_composition/Prism/Project.TabbedPivot/Views/PivotPage.xaml
+++ b/templates/_composition/Prism/Project.TabbedPivot/Views/PivotPage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Style="{StaticResource PageStyle}"
     xmlns:prismMvvm="using:Prism.Windows.Mvvm"
     prismMvvm:ViewModelLocator.AutoWireViewModel="True"
     xmlns:views="using:wts.ItemName.Views"
@@ -11,7 +12,7 @@
     xmlns:b="using:wts.ItemName.Behaviors"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Pivot x:Uid="PivotPage">
             <i:Interaction.Behaviors>
                 <b:PivotNavigationBehavior />


### PR DESCRIPTION
Fix #1525

Remove Page main grid background because it is set by **Page.AddPageStyle** composition template.