### PR TITLE
Prism fixes

### DIFF
--- a/templates/Features/DragAndDrop/.template.config/cs-CZ.template.json
+++ b/templates/Features/DragAndDrop/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/de-DE.template.json
+++ b/templates/Features/DragAndDrop/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/es-ES.template.json
+++ b/templates/Features/DragAndDrop/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/fr-FR.template.json
+++ b/templates/Features/DragAndDrop/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/it-IT.template.json
+++ b/templates/Features/DragAndDrop/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/ja-JP.template.json
+++ b/templates/Features/DragAndDrop/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/ko-KR.template.json
+++ b/templates/Features/DragAndDrop/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/pl-PL.template.json
+++ b/templates/Features/DragAndDrop/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/pt-BR.template.json
+++ b/templates/Features/DragAndDrop/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/ru-RU.template.json
+++ b/templates/Features/DragAndDrop/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/template.json
+++ b/templates/Features/DragAndDrop/.template.config/template.json
@@ -4,7 +4,7 @@
   "name": "Drag & Drop",
   "groupIdentity": "wts.Feat.DragAndDrop",
   "identity": "wts.Feat.DragAndDrop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "tags": {
     "language": "C#",
     "type": "item",

--- a/templates/Features/DragAndDrop/.template.config/tr-TR.template.json
+++ b/templates/Features/DragAndDrop/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/zh-CN.template.json
+++ b/templates/Features/DragAndDrop/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/DragAndDrop/.template.config/zh-TW.template.json
+++ b/templates/Features/DragAndDrop/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Drag & Drop",
-  "description": "The Drag & Drop feature provides a wrapper service over the standard UWP Drag and Drop functionallity to simplify the required code to create drag and drop ready apps.",
+  "description": "The Drag & Drop feature provides a service to simplify the creation of drag and drop ready apps.",
   "identity": "wts.Feat.DragAndDrop"
 }

--- a/templates/Features/MultiView/Services/ViewLifetimeControl.cs
+++ b/templates/Features/MultiView/Services/ViewLifetimeControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
+using Param_ItemNamespace.Helpers;
 
 namespace Param_ItemNamespace.Services
 {
@@ -43,7 +44,7 @@ namespace Param_ItemNamespace.Services
 
                 if (releasedCopy)
                 {
-                    throw new InvalidOperationException("This view is being disposed");
+                    throw new InvalidOperationException("ExceptionViewLifeTimeControlViewDisposal".GetLocalized());
                 }
             }
 
@@ -87,7 +88,7 @@ namespace Param_ItemNamespace.Services
 
             if (releasedCopy)
             {
-                throw new InvalidOperationException("This view is being disposed");
+                throw new InvalidOperationException("ExceptionViewLifeTimeControlViewDisposal".GetLocalized());
             }
 
             return refCountCopy;
@@ -115,7 +116,7 @@ namespace Param_ItemNamespace.Services
 
             if (releasedCopy)
             {
-                throw new InvalidOperationException("This view is being disposed");
+                throw new InvalidOperationException("ExceptionViewLifeTimeControlViewDisposal".GetLocalized());
             }
 
             return refCountCopy;

--- a/templates/Features/MultiView/Strings/en-us/Resources_postaction.resw
+++ b/templates/Features/MultiView/Strings/en-us/Resources_postaction.resw
@@ -1,0 +1,13 @@
+﻿<!--{**-->
+<!--This xml blocks include string resources for the MultiViewFeature to your project.-->
+<!--**}-->
+
+<root>
+  <!--^^-->
+  <!--{[{-->
+  <data name="ExceptionViewLifeTimeControlViewDisposal" xml:space="preserve">
+    <value>This view is being disposed.</value>
+    <comment>View disposed</comment>
+  </data>
+  <!--}]}-->
+</root>

--- a/templates/Features/MultiViewVB/Services/ViewLifetimeControl.vb
+++ b/templates/Features/MultiViewVB/Services/ViewLifetimeControl.vb
@@ -1,4 +1,5 @@
 ﻿Imports Windows.UI.Core
+Imports Param_ItemNamespace.Helpers
 
 Namespace Services
 
@@ -39,7 +40,7 @@ Namespace Services
                 End SyncLock
 
                 If releasedCopy Then
-                    Throw New InvalidOperationException("This view is being disposed")
+                    Throw New InvalidOperationException("ExceptionViewLifeTimeControlViewDisposal".GetLocalized())
                 End If
             End AddHandler
 
@@ -79,7 +80,7 @@ Namespace Services
             End SyncLock
 
             If releasedCopy Then
-                Throw New InvalidOperationException("This view is being disposed")
+                Throw New InvalidOperationException("ExceptionViewLifeTimeControlViewDisposal".GetLocalized())
             End If
 
             Return refCountCopy
@@ -102,7 +103,7 @@ Namespace Services
             End SyncLock
 
             If releasedCopy Then
-                Throw New InvalidOperationException("This view is being disposed")
+                Throw New InvalidOperationException("ExceptionViewLifeTimeControlViewDisposal".GetLocalized())
             End If
 
             Return refCountCopy

--- a/templates/Features/MultiViewVB/Strings/en-us/Resources_postaction.resw
+++ b/templates/Features/MultiViewVB/Strings/en-us/Resources_postaction.resw
@@ -1,0 +1,14 @@
+﻿<!--{**-->
+<!--This xml blocks include string resources for the MultiViewFeature to your project.-->
+<!--**}-->
+
+<root>
+  <!--^^-->
+  <!--{[{-->
+  <data name="ExceptionViewLifeTimeControlViewDisposal" xml:space="preserve">
+    <value>This view is being disposed.</value>
+    <comment>View disposed</comment>
+  </data>
+  <!--}]}-->
+</root>
+

--- a/templates/Features/ShareSource/Models/ShareSourceFeatureData.cs
+++ b/templates/Features/ShareSource/Models/ShareSourceFeatureData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Param_ItemNamespace.Helpers;
 using Windows.Storage;
 
 namespace Param_ItemNamespace.Models
@@ -19,7 +20,7 @@ namespace Param_ItemNamespace.Models
         {
             if (string.IsNullOrEmpty(title))
             {
-                throw new ArgumentException($"The parameter '{nameof(title)}' can not be null or empty.");
+                throw new ArgumentException("ExceptionShareSourceFeatureDataTitleIsNullOrEmpty".GetLocalized(), nameof(title));
             }
 
             Items = new List<ShareSourceFeatureItem>();
@@ -31,7 +32,7 @@ namespace Param_ItemNamespace.Models
         {
             if (string.IsNullOrEmpty(text))
             {
-                throw new ArgumentException($"The parameter '{nameof(text)}' is null or empty");
+                throw new ArgumentException("ExceptionShareSourceFeatureDataTitleIsNullOrEmpty".GetLocalized(), nameof(text));
             }
 
             Items.Add(ShareSourceFeatureItem.FromText(text));
@@ -71,7 +72,7 @@ namespace Param_ItemNamespace.Models
         {
             if (string.IsNullOrEmpty(html))
             {
-                throw new ArgumentException($"Parameter '{nameof(html)}' to share is null or empty.");
+                throw new ArgumentException("ExceptionShareSourceFeatureDataHtmlIsNullOrEmpty".GetLocalized(), nameof(html));
             }
 
             Items.Add(ShareSourceFeatureItem.FromHtml(html));
@@ -81,7 +82,7 @@ namespace Param_ItemNamespace.Models
         {
             if (image == null)
             {
-                throw new ArgumentNullException($"{nameof(image)}");
+                throw new ArgumentNullException(nameof(image));
             }
 
             Items.Add(ShareSourceFeatureItem.FromImage(image));
@@ -91,7 +92,7 @@ namespace Param_ItemNamespace.Models
         {
             if (storageItems == null || !storageItems.Any())
             {
-                throw new ArgumentException($"Paramter '{nameof(storageItems)}' is null or does not contains any element.");
+                throw new ArgumentException("ExceptionShareSourceFeatureDataStorageItemsIsNullOrEmpty".GetLocalized(), nameof(storageItems));
             }
 
             Items.Add(ShareSourceFeatureItem.FromStorageItems(storageItems));
@@ -104,7 +105,7 @@ namespace Param_ItemNamespace.Models
         {
             if (string.IsNullOrEmpty(deferredDataFormatId))
             {
-                throw new ArgumentException($"Parameter '{nameof(deferredDataFormatId)}' to share is null or empty");
+                throw new ArgumentException("ExceptionShareSourceFeatureDataDeferredDataFormatIdIsNullOrEmpty".GetLocalized(), nameof(deferredDataFormatId));
             }
 
             Items.Add(ShareSourceFeatureItem.FromDeferredContent(deferredDataFormatId, getDeferredDataAsyncFunc));

--- a/templates/Features/ShareSource/Strings/en-us/Resources_postaction.resw
+++ b/templates/Features/ShareSource/Strings/en-us/Resources_postaction.resw
@@ -1,0 +1,29 @@
+﻿<!--{**-->
+<!--This xml blocks include string resources for adding the ShareSourceFeature to your project.-->
+<!--**}-->
+
+<root>
+  <!--^^-->
+  <!--{[{-->
+  <data name="ExceptionShareSourceFeatureDataTitleIsNullOrEmpty" xml:space="preserve">
+    <value>The parameter title can not be null or empty.</value>
+    <comment>The parameter title can not be null or empty</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataTextIsNullOrEmpty" xml:space="preserve">
+    <value>The parameter text is null or empty.</value>
+    <comment>The parameter text can not be null or empty</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataHtmlIsNullOrEmpty" xml:space="preserve">
+    <value>The Parameter html is null or empty.</value>
+    <comment>The Parameter html is null or empty.</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataStorageItemsIsNullOrEmpty" xml:space="preserve">
+    <value>The Parameter StorageItems is null or does not contains any element.</value>
+    <comment>The Parameter StorageItems is null or does not contains any element.</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataDeferredDataFormatIdIsNullOrEmpty" xml:space="preserve">
+    <value>The Parameter DeferredDataFormatId is null or does not contains any element.</value>
+    <comment>The Parameter DeferredDataFormatId is null or does not contains any element.</comment>
+  </data>
+  <!--}]}-->
+</root>

--- a/templates/Features/ShareSourceVB/Models/ShareSourceFeatureData.vb
+++ b/templates/Features/ShareSourceVB/Models/ShareSourceFeatureData.vb
@@ -1,4 +1,5 @@
 ﻿Imports Windows.Storage
+Imports Param_ItemNamespace.Helpers
 
 Namespace Models
     Public Class ShareSourceFeatureData
@@ -11,7 +12,7 @@ Namespace Models
 
         Public Sub New(ByVal title As String, ByVal Optional desciption As String = Nothing)
             If String.IsNullOrEmpty(title) Then
-                Throw New ArgumentException($"The parameter '{NameOf(title)}' can not be null or empty.")
+                Throw New ArgumentException("ExceptionShareSourceFeatureDataTitleIsNullOrEmpty".GetLocalized(), NameOf(title))
             End If
 
             Items = New List(Of ShareSourceFeatureItem)()
@@ -21,7 +22,7 @@ Namespace Models
 
         Public Sub SetText(ByVal text As String)
             If String.IsNullOrEmpty(text) Then
-                Throw New ArgumentException($"The parameter '{NameOf(text)}' is null or empty")
+                Throw New ArgumentException("ExceptionShareSourceFeatureDataTitleIsNullOrEmpty".GetLocalized(), nameof(text))
             End If
 
             Items.Add(ShareSourceFeatureItem.FromText(text))
@@ -45,7 +46,7 @@ Namespace Models
 
         Public Sub SetHtml(ByVal html As String)
             If String.IsNullOrEmpty(html) Then
-                Throw New ArgumentException($"Parameter '{NameOf(html)}' to share is null or empty.")
+                Throw New ArgumentException("ExceptionShareSourceFeatureDataHtmlIsNullOrEmpty".GetLocalized(), nameof(html))
             End If
 
             Items.Add(ShareSourceFeatureItem.FromHtml(html))
@@ -53,7 +54,7 @@ Namespace Models
 
         Public Sub SetImage(ByVal image As StorageFile)
             If image Is Nothing Then
-                Throw New ArgumentNullException($"{NameOf(image)}")
+                Throw New ArgumentNullException(NameOf(image))
             End If
 
             Items.Add(ShareSourceFeatureItem.FromImage(image))
@@ -61,7 +62,7 @@ Namespace Models
 
         Public Sub SetStorageItems(ByVal storageItems As IEnumerable(Of IStorageItem))
             If storageItems Is Nothing OrElse Not storageItems.Any() Then
-                Throw New ArgumentException($"Paramter '{NameOf(storageItems)}' is null or does not contains any element.")
+                Throw New ArgumentException("ExceptionShareSourceFeatureDataStorageItemsIsNullOrEmpty".GetLocalized(), nameof(storageItems))
             End If
 
             Items.Add(ShareSourceFeatureItem.FromStorageItems(storageItems))
@@ -69,7 +70,7 @@ Namespace Models
 
         Public Sub SetDeferredContent(ByVal deferredDataFormatId As String, ByVal getDeferredDataAsyncFunc As Func(Of Task(Of Object)))
             If String.IsNullOrEmpty(deferredDataFormatId) Then
-                Throw New ArgumentException($"Parameter '{NameOf(deferredDataFormatId)}' to share is null or empty")
+                Throw New ArgumentException("ExceptionShareSourceFeatureDataDeferredDataFormatIdIsNullOrEmpty".GetLocalized(), nameof(deferredDataFormatId))
             End If
 
             Items.Add(ShareSourceFeatureItem.FromDeferredContent(deferredDataFormatId, getDeferredDataAsyncFunc))

--- a/templates/Features/ShareSourceVB/Strings/en-us/Resources_postaction.resw
+++ b/templates/Features/ShareSourceVB/Strings/en-us/Resources_postaction.resw
@@ -1,0 +1,29 @@
+﻿<!--{**-->
+<!--This xml blocks include string resources for adding the ShareSourceFeature to your project.-->
+<!--**}-->
+
+<root>
+  <!--^^-->
+  <!--{[{-->
+  <data name="ExceptionShareSourceFeatureDataTitleIsNullOrEmpty" xml:space="preserve">
+    <value>The parameter title can not be null or empty.</value>
+    <comment>The parameter title can not be null or empty</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataTextIsNullOrEmpty" xml:space="preserve">
+    <value>The parameter text is null or empty.</value>
+    <comment>The parameter text can not be null or empty</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataHtmlIsNullOrEmpty" xml:space="preserve">
+    <value>The Parameter html is null or empty.</value>
+    <comment>The Parameter html is null or empty.</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataStorageItemsIsNullOrEmpty" xml:space="preserve">
+    <value>The Parameter StorageItems is null or does not contains any element.</value>
+    <comment>The Parameter StorageItems is null or does not contains any element.</comment>
+  </data>
+  <data name="ExceptionShareSourceFeatureDataDeferredDataFormatIdIsNullOrEmpty" xml:space="preserve">
+    <value>The Parameter DeferredDataFormatId is null or does not contains any element.</value>
+    <comment>The Parameter DeferredDataFormatId is null or does not contains any element.</comment>
+  </data>
+  <!--}]}-->
+</root>

--- a/templates/Features/WebToAppLink.Prism/.template.config/cs-CZ.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/cs-CZ.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/cs-CZ.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/de-DE.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/de-DE.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/de-DE.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/es-ES.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/es-ES.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/es-ES.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/fr-FR.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/fr-FR.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/fr-FR.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/it-IT.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/it-IT.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/it-IT.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/ja-JP.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/ja-JP.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/ja-JP.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/ko-KR.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/ko-KR.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/ko-KR.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/pl-PL.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/pl-PL.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/pl-PL.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/pt-BR.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/pt-BR.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/pt-BR.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/ru-RU.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/ru-RU.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/ru-RU.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/template.json
@@ -6,7 +6,7 @@
   "name": "Web to App link",
   "groupIdentity": "wts.Feat.WebToAppLink",
   "identity": "wts.Feat.WebToAppLink.Prism",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "tags": {
     "language": "C#",
     "type": "item",

--- a/templates/Features/WebToAppLink.Prism/.template.config/tr-TR.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/tr-TR.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/tr-TR.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/zh-CN.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/zh-CN.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/zh-CN.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Features/WebToAppLink.Prism/.template.config/zh-TW.description.md
+++ b/templates/Features/WebToAppLink.Prism/.template.config/zh-TW.description.md
@@ -1,4 +1,5 @@
-﻿Configures your app to handle links from a website and adds an ActivationHandler that parses received arguments.
+﻿Web to App link associates your app with a website so that when someone opens a link to your website, your app is launched instead of opening the browser. If your app is not installed, your website opens in the browser as usual. Users can trust this experience because only verified content owners can register for a link. Users will be able to check all of their registered web-to-app links by going to Settings > Apps > Apps for websites.
 
 For more info about web to app linking, consult 
-[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking)
+[docs.microsoft.com](https://docs.microsoft.com/windows/uwp/launch-resume/web-to-app-linking) and
+[blogs.windows.com](https://blogs.windows.com/buildingapps/2016/10/14/web-to-app-linking-with-appurihandlers/)

--- a/templates/Features/WebToAppLink.Prism/.template.config/zh-TW.template.json
+++ b/templates/Features/WebToAppLink.Prism/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft",
   "name": "Web to app link",
-  "description": "Adds the ability to open your app from a link in a website.",
+  "description": "Web to App link associates your app with a website so that when someone opens a link to your website.",
   "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Pages/ImageGallery.Prism/Views/ImageGalleryViewDetailPage.xaml
+++ b/templates/Pages/ImageGallery.Prism/Views/ImageGalleryViewDetailPage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:prismMvvm="using:Prism.Windows.Mvvm"
-    prismMvvm:ViewModelLocator.AutoWireViewModel="True" 
+    prismMvvm:ViewModelLocator.AutoWireViewModel="True"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
@@ -27,7 +27,7 @@
         <FlipView
             x:Name="flipView"
             Visibility="Collapsed"
-            ItemsSource="{x:Bind ViewModel.Source, Mode=OneWay}"
+            ItemsSource="{x:Bind ViewModel.Source}"
             SelectedItem="{x:Bind ViewModel.SelectedImage, Mode=TwoWay}">
             <FlipView.ItemTemplate>
                 <DataTemplate x:DataType="models:SampleImage">

--- a/templates/Pages/ImageGallery.Prism/Views/ImageGalleryViewDetailPage.xaml.cs
+++ b/templates/Pages/ImageGallery.Prism/Views/ImageGalleryViewDetailPage.xaml.cs
@@ -24,8 +24,11 @@ namespace Param_ItemNamespace.Views
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             base.OnNavigatingFrom(e);
-            previewImage.Visibility = Visibility.Visible;
-            ViewModel.SetAnimation();
+            if (e.NavigationMode == NavigationMode.Back)
+            {
+                previewImage.Visibility = Visibility.Visible;
+                ViewModel.SetAnimation();
+            }
         }
     }
 }

--- a/templates/Pages/Map.Prism/Services/LocationService.cs
+++ b/templates/Pages/Map.Prism/Services/LocationService.cs
@@ -85,8 +85,7 @@ namespace Param_ItemNamespace.Services
         {
             if (_geolocator == null)
             {
-                throw new InvalidOperationException(
-                    "The StartListening method cannot be called before the InitializeAsync method is called and returns true.");
+                throw new InvalidOperationException("ExceptionLocationServiceStartListeningCanNotBeCalled".GetLocalized());
             }
 
             _geolocator.PositionChanged += GeolocatorOnPositionChanged;

--- a/templates/Projects/DefaultPrism/.template.config/template.json
+++ b/templates/Projects/DefaultPrism/.template.config/template.json
@@ -12,8 +12,9 @@
     "wts.framework": "Prism",
     "wts.projecttype":"Blank|SplitView|TabbedPivot",
     "wts.version": "1.0.0",
-    "wts.displayOrder": "1"
-  },
+    "wts.displayOrder": "1",
+    "wts.licenses": "[Prism](https://github.com/PrismLibrary/Prism/blob/master/LICENSE)"
+    },
   "sourceName": "wts.DefaultProject",
   "preferNameDirectory": true,
   "guids": [ "7cf740f7-735f-48ea-8b7b-3ffa4902371c", "be236938-efed-4037-b3f2-70788b43ca20" ],

--- a/templates/_catalog/cs-CZ.frameworks.json
+++ b/templates/_catalog/cs-CZ.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro je oblíbený rámec (framework) MVVM, který klade důraz na konvence a uspořadatelnost."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/de-DE.frameworks.json
+++ b/templates/_catalog/de-DE.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro ist ein verbreitetes MVVM-framework, das Konventionen und Zusammensetzbarkeit betont."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/en-US.frameworks.json
+++ b/templates/_catalog/en-US.frameworks.json
@@ -13,5 +13,15 @@
         "name": "CodeBehind",
         "displayName": "Code Behind",
         "summary": "This is the traditional model for an application where logic is handled in the code-behind.  For a quick application, this is a great option."
+    }, 
+    {
+        "name": "CaliburnMicro",
+        "displayName": "Caliburn.Micro",
+        "summary": "Caliburn.Micro is a popular MVVM framework emphasising conventions and composability."
+    },
+    {
+      "name": "Prism",
+      "displayName": "Prism",
+      "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
     }
 ]

--- a/templates/_catalog/es-ES.frameworks.json
+++ b/templates/_catalog/es-ES.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro es un framework MVVM popular que enfatiza las convenciones y la redacción."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/fr-FR.frameworks.json
+++ b/templates/_catalog/fr-FR.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro est une framework MVVM populaire, qui met en avant les conventions et la composabilité."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/frameworks.json
+++ b/templates/_catalog/frameworks.json
@@ -41,7 +41,7 @@
         "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications.",
         "author": "Brian Lagunas, Bart Lannoeye, Dan Siegel",
         "order": "5",
-        "licenses": "",
+        "licenses": "[Prism](https://github.com/PrismLibrary/Prism/blob/master/LICENSE)",
         "languages": [ "C#" ]
     }
 ]

--- a/templates/_catalog/frameworks.json
+++ b/templates/_catalog/frameworks.json
@@ -38,7 +38,7 @@
     {
         "name": "Prism",
         "displayName": "Prism",
-        "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications in WPF, Windows 10 UWP, and Xamarin Forms.",
+        "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications.",
         "author": "Brian Lagunas, Bart Lannoeye, Dan Siegel",
         "order": "5",
         "licenses": "",

--- a/templates/_catalog/it-IT.frameworks.json
+++ b/templates/_catalog/it-IT.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro è un noto framework MVVM che enfatizza convenzioni e componibilità."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/ja-JP.frameworks.json
+++ b/templates/_catalog/ja-JP.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro は、規則と組み立て可能性に重点を置いた人気の高い MVVM framework です。"
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/ko-KR.frameworks.json
+++ b/templates/_catalog/ko-KR.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro는 규칙과 결합성에 중점을 둔 인기 있는 MVVM framework프레임워크입니다."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/pl-PL.frameworks.json
+++ b/templates/_catalog/pl-PL.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro to popularny framework MVVM, w którym główny nacisk jest kładziony na konwersje i tworzenie struktury."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/pt-BR.frameworks.json
+++ b/templates/_catalog/pt-BR.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro é uma framework MVVM popular que enfatiza convenções e capacidade de composição."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/ru-RU.frameworks.json
+++ b/templates/_catalog/ru-RU.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro — это популярная платформа (framework) MVVM, которая акцентируется на соблюдении соглашений и возможностях модульной компоновки."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/tr-TR.frameworks.json
+++ b/templates/_catalog/tr-TR.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro, kuralları ve oluşturulabilirliği vurgulayan popüler bir MVVM framework'tür."
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/zh-CN.frameworks.json
+++ b/templates/_catalog/zh-CN.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro 是一种强调约定和可组合性的常用 MVVM framework。"
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]

--- a/templates/_catalog/zh-TW.frameworks.json
+++ b/templates/_catalog/zh-TW.frameworks.json
@@ -18,5 +18,10 @@
     "name": "CaliburnMicro",
     "displayName": "Caliburn.Micro",
     "summary": "Caliburn.Micro 是強調慣例和組合性的常用 MVVM framework。"
+  },
+  {
+    "name": "Prism",
+    "displayName": "Prism",
+    "summary": "Prism is a framework for building loosely coupled, maintainable, and testable XAML applications."
   }
 ]


### PR DESCRIPTION
Some smaller prism fixes: 

- Add prism to localized framework.json files
- Move exception messages to resource files
- Missing license on Prism
- Shortened Prism framework and Drag and Drop feature description, as they are too long and do not fit in the box
- Fixes for bugs:
  - https://github.com/Microsoft/WindowsTemplateStudio/issues/1317
  - https://github.com/Microsoft/WindowsTemplateStudio/issues/1264 
  - https://github.com/Microsoft/WindowsTemplateStudio/pull/1534

Related issue:
#304 
