### PR TITLE
Suppress CS0618 warnings caused by UwpCommunityToolkit HamburgerMenu 

### DIFF
--- a/code/test/Templates.Test/Templates.Test.csproj
+++ b/code/test/Templates.Test/Templates.Test.csproj
@@ -334,6 +334,10 @@
     <Content Include="TestData\NonDefaultAssets\Wide310x150Logo.scale-200.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="TestData\StyleCop\_searchreplace.1.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </None>
     <None Include="TestData\SonarLintVB\_searchreplace.vbproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/code/test/Templates.Test/TestData/StyleCop/_searchreplace.1.csproj
+++ b/code/test/Templates.Test/TestData/StyleCop/_searchreplace.1.csproj
@@ -1,0 +1,3 @@
+    <NoWarn>NU1603;2008;</NoWarn>
+^^^-searchabove-replacebelow-vvv
+    <NoWarn>NU1603;2008;CS0618;</NoWarn>


### PR DESCRIPTION
Suppress CS0618 warnings caused by UwpCommunityToolkit HamburgerMenu to ensure tests pass.
I added this as stylecop tests are not passing as warnings are treated as errors here. 