### PR TITLE
Adds logic to init the Unity container.

### DIFF
--- a/templates/Features/BackgroundTask.Prism/App_postaction.xaml.cs
+++ b/templates/Features/BackgroundTask.Prism/App_postaction.xaml.cs
@@ -30,12 +30,7 @@ namespace Param_RootNamespace
         protected override void OnBackgroundActivated(BackgroundActivatedEventArgs args)
         {
             base.OnBackgroundActivated(args);
-            if (Container == null)
-            {
-                CreateAndConfigureContainer();
-                ConfigureContainer();
-            }
-
+            CreateAndConfigureContainer();
             Container.Resolve<IBackgroundTaskService>().Start(args.TaskInstance);
         }
 //}]}

--- a/templates/Features/BackgroundTask.Prism/App_postaction.xaml.cs
+++ b/templates/Features/BackgroundTask.Prism/App_postaction.xaml.cs
@@ -32,9 +32,10 @@ namespace Param_RootNamespace
             base.OnBackgroundActivated(args);
             if (Container == null)
             {
-                base.CreateAndConfigureContainer();
+                CreateAndConfigureContainer();
                 ConfigureContainer();
             }
+
             Container.Resolve<IBackgroundTaskService>().Start(args.TaskInstance);
         }
 //}]}

--- a/templates/Features/BackgroundTask.Prism/App_postaction.xaml.cs
+++ b/templates/Features/BackgroundTask.Prism/App_postaction.xaml.cs
@@ -30,6 +30,11 @@ namespace Param_RootNamespace
         protected override void OnBackgroundActivated(BackgroundActivatedEventArgs args)
         {
             base.OnBackgroundActivated(args);
+            if (Container == null)
+            {
+                base.CreateAndConfigureContainer();
+                ConfigureContainer();
+            }
             Container.Resolve<IBackgroundTaskService>().Start(args.TaskInstance);
         }
 //}]}


### PR DESCRIPTION
This PR resolves a crash condition for issue #1586.  The original crash condition reported in the issue was not encountered.  This change adds logic to invoke the appropriate methods in the base class to initialize the Container variable if it is null when a background task is launched.

