### PR TITLE
Force re-loading initial content from template tests

### DIFF
--- a/code/src/Core/Locations/TemplatesSynchronization.cs
+++ b/code/src/Core/Locations/TemplatesSynchronization.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Templates.Core.Locations
             CurrentWizardVersion = wizardVersion;
         }
 
-        public async Task EnsureContentAsync()
+        public async Task EnsureContentAsync(bool force = false)
         {
             await EnsureVsInstancesSyncingAsync();
 
@@ -52,7 +52,7 @@ namespace Microsoft.Templates.Core.Locations
             {
                 try
                 {
-                    if (!_content.Exists())
+                    if (!_content.Exists() || force)
                     {
                         await ExtractInstalledContentAsync();
                     }

--- a/code/src/Core/Templates/TemplatesRepository.cs
+++ b/code/src/Core/Templates/TemplatesRepository.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Templates.Core
 
         public async Task SynchronizeAsync(bool force = false)
         {
-            await Sync.EnsureContentAsync();
+            await Sync.EnsureContentAsync(force);
             await Sync.RefreshTemplateCacheAsync(force);
             await Sync.CheckForNewContentAsync();
         }


### PR DESCRIPTION
## PR checklist

Quick summary of changes
Force re-loading initial content from template tests to avoid build failures on build servers where template directory changes depending on the working folder
- Which issue does this PR relate to?
#1710 
- Anything that requires particular review or attention?
No
- Do all automated tests pass?
Yes

