### PR TITLE
Remove 65000 from dev wizard version

### DIFF
--- a/_build/Extension-SetIdentityAndVersion.ps1
+++ b/_build/Extension-SetIdentityAndVersion.ps1
@@ -43,9 +43,9 @@ if($buildNumber -match $VersionRegEx){
 
   $revision =  [int]::Parse($matches[4]).ToString()
 
-  if($buildNumber.ToLower().StartsWith("dev")){
-    $revision = (65000 + [int]::Parse($matches[4])).ToString();
-  }
+  #if($buildNumber.ToLower().StartsWith("dev")){
+  #  $revision = (65000 + [int]::Parse($matches[4])).ToString();
+  #}
   
   $versionNumber = [int]::Parse($matches[1]).ToString() + "." + [int]::Parse($matches[2]).ToString() + "." + [int]::Parse($matches[3]).ToString() + "." + $revision
   Write-Host "Version Number" $versionNumber


### PR DESCRIPTION
## PR checklist

Quick summary of changes
In dev wizard version is 65000 + revision number, but templates just have revision number.
Removing this to align with other environments. 
- Which issue does this PR relate to?
#1729 
