### PR TITLE
Handle use of filled Rectangles & Ellipses in template icon xaml

### DIFF
--- a/code/src/UI/Controls/ImageEx.cs
+++ b/code/src/UI/Controls/ImageEx.cs
@@ -109,9 +109,12 @@ namespace Microsoft.Templates.UI.Controls
                                 .ChildrenOfType<Shapes.Shape>(true)
                                 .ToList();
 
-                if (shapes.Any())
+                foreach (var shape in shapes)
                 {
-                    shapes.ForEach(s => BindingOperations.SetBinding(s, Shapes.Shape.StrokeProperty, CreateBinding(this, nameof(Foreground))));
+                    BindingOperations.SetBinding(
+                        shape,
+                        shape.StrokeThickness > 0 ? Shapes.Shape.StrokeProperty : Shapes.Shape.FillProperty,
+                        CreateBinding(this, nameof(Foreground)));
                 }
 
                 return element;


### PR DESCRIPTION
For #1764 

Enabled use of shape to specify either a stroke or a fill, but not both, when Binding the foreground to allow for different colors, such as when using high-contrast. Were previously overlooking Rectangle and Ellipse which set a Fill as the code only adjusted the StrokeProperty. Can now use either, but not both as some templates are using these shapes for outlines.

Also added a related check to the Template Validator code.