### PR TITLE
Prevent repeated navigation to the same page

### DIFF
--- a/templates/_composition/CodeBehind/ProjectVB/Services/NavigationService.vb
+++ b/templates/_composition/CodeBehind/ProjectVB/Services/NavigationService.vb
@@ -47,7 +47,7 @@ Namespace Services
 
         Public Function Navigate(pageType As Type, Optional parameter As Object = Nothing, Optional infoOverride As NavigationTransitionInfo = Nothing) As Boolean
             ' Don't open the same page multiple times
-            If Frame.Content?.GetType IsNot pageType.GetType Then
+            If Frame.Content?.GetType IsNot pageType Then
                 Return Frame.Navigate(pageType, parameter, infoOverride)
             Else
                 Return False

--- a/templates/_composition/MVVMBasic/ProjectVB/Services/NavigationService.vb
+++ b/templates/_composition/MVVMBasic/ProjectVB/Services/NavigationService.vb
@@ -47,7 +47,7 @@ Namespace Services
 
         Public Function Navigate(pageType As Type, Optional parameter As Object = Nothing, Optional infoOverride As NavigationTransitionInfo = Nothing) As Boolean
             ' Don't open the same page multiple times
-            If Frame.Content?.GetType IsNot pageType.GetType Then
+            If Frame.Content?.GetType IsNot pageType Then
                 Return Frame.Navigate(pageType, parameter, infoOverride)
             Else
                 Return False

--- a/templates/_composition/MVVMLight/Project/Services/NavigationServiceEx.cs
+++ b/templates/_composition/MVVMLight/Project/Services/NavigationServiceEx.cs
@@ -60,8 +60,15 @@ namespace Param_RootNamespace.Services
                 }
             }
 
-            var navigationResult = Frame.Navigate(page, parameter, infoOverride);
-            return navigationResult;
+            if (Frame.Content?.GetType() != page)
+            {
+                var navigationResult = Frame.Navigate(page, parameter, infoOverride);
+                return navigationResult;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public void Configure(string key, Type pageType)

--- a/templates/_composition/MVVMLight/ProjectVB/Services/NavigationServiceEx.vb
+++ b/templates/_composition/MVVMLight/ProjectVB/Services/NavigationServiceEx.vb
@@ -55,8 +55,13 @@ Namespace Services
                     Throw New ArgumentException(String.Format("ExceptionNavigationServiceExPageNotFound".GetLocalized(), pageKey), nameof(pageKey))
                 End If
             End SyncLock
-            Dim navigationResult = Frame.Navigate(page, parameter, infoOverride)
-            Return navigationResult
+
+            If Frame.Content?.GetType IsNot page Then
+                Dim navigationResult = Frame.Navigate(page, parameter, infoOverride)
+                Return navigationResult
+            Else
+                Return False
+            End If
         End Function
 
         Public Sub Configure(key As String, pageType As Type)


### PR DESCRIPTION
For #1774 

Affects all VB frameworks and MVVMLight with C#

For MVVMLight based projects we did not have the check we do for the other frameworks. (If already showing that page, don't navigate again.)
The VB code had a bug in it for comparing types.

