### PR TITLE
Fix code viewer background

### DIFF
--- a/code/src/UI/Controls/CodeViewer.xaml
+++ b/code/src/UI/Controls/CodeViewer.xaml
@@ -4,11 +4,15 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:strings="clr-namespace:Microsoft.Templates.UI.Resources"
+             xmlns:services="clr-namespace:Microsoft.Templates.UI.Services"
              mc:Ignorable="d"
              Focusable="False"
              AutomationProperties.Name="{x:Static strings:StringRes.AccessibilityCodeViewerControl}"
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid>
-        <WebBrowser x:Name="webBrowser" ScrollViewer.VerticalScrollBarVisibility="Hidden" />
+    <Grid Background="{Binding WindowPanel, Source={x:Static services:UIStylesService.Instance}}">
+        <WebBrowser x:Name="webBrowser"
+                    ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                    Visibility="Collapsed"
+                    LoadCompleted="WebBrowser_LoadCompleted" />
     </Grid>
 </UserControl>

--- a/code/src/UI/Controls/CodeViewer.xaml.cs
+++ b/code/src/UI/Controls/CodeViewer.xaml.cs
@@ -180,5 +180,10 @@ namespace Microsoft.Templates.UI.Controls
                     break;
             }
         }
+
+        private void WebBrowser_LoadCompleted(object sender, System.Windows.Navigation.NavigationEventArgs e)
+        {
+            webBrowser.Visibility = Visibility.Visible;
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

Quick summary of changes

- Which issue does this PR relate to?
#1945 - Monaco Editor shows a white screen before render the dark theme colors