### PR TITLE
Fix error in comments of FireAndForget method

### DIFF
--- a/templates/Uwp/Features/BackgroundTask.Prism/Helpers/TaskExtensions.cs
+++ b/templates/Uwp/Features/BackgroundTask.Prism/Helpers/TaskExtensions.cs
@@ -7,7 +7,7 @@ namespace Param_ItemNamespace.Helpers
     {
         public static void FireAndForget(this Task task)
         {
-            // This method allows you to call an async method with awaiting it.
+            // This method allows you to call an async method without awaiting it.
             // Use it when you don't want or need to wait for the task to complete.
         }
     }

--- a/templates/Uwp/Features/BackgroundTask/Helpers/TaskExtensions.cs
+++ b/templates/Uwp/Features/BackgroundTask/Helpers/TaskExtensions.cs
@@ -7,7 +7,7 @@ namespace Param_ItemNamespace.Helpers
     {
         public static void FireAndForget(this Task task)
         {
-            // This method allows you to call an async method with awaiting it.
+            // This method allows you to call an async method without awaiting it.
             // Use it when you don't want or need to wait for the task to complete.
         }
     }

--- a/templates/Uwp/Features/BackgroundTaskVB/Helpers/TaskExtensions.vb
+++ b/templates/Uwp/Features/BackgroundTaskVB/Helpers/TaskExtensions.vb
@@ -3,7 +3,7 @@
  
         <Extension>
         Public Sub FireAndForget(task As Task)
-            ' This method allows you to call an async method with awaiting it.
+            ' This method allows you to call an async method without awaiting it.
             ' Use it when you don't want or need to wait for the task to complete.
         End Sub
     End Module


### PR DESCRIPTION
For #2202

`FireAndForget` method allows code to be called with**out** awaiting it.
