### PR TITLE
Fixing scripts & tests affected by template folder structure change

### DIFF
--- a/_utils/Identify-CSharp-Template-Commits-Without-VisualBasic-Equivalents.ps1
+++ b/_utils/Identify-CSharp-Template-Commits-Without-VisualBasic-Equivalents.ps1
@@ -7,7 +7,7 @@
 ## This script cannot be perfect in identifying everything. It should be used in combination with the script that looks at file last-modified times.
 
 # last param is the SHA of the commit to check from (this should normally be the last release)
-$files = git diff --name-only df0f996d22e0847337ee54aec72c50aa5bf21614
+$files = git diff --name-only 7a4c807bf03ad0b3f8fff045752e1b3375603b67
 
 function Get-CsEquivalentFile($vbfile)
 {

--- a/_utils/Identify-CSharp-Templates-Changed-More-Recently-Than-VisualBasic-Equivalents.ps1
+++ b/_utils/Identify-CSharp-Templates-Changed-More-Recently-Than-VisualBasic-Equivalents.ps1
@@ -12,7 +12,7 @@ function Get-CsEquivalentFile($vbfile)
 }
 
 # Get list of all templates
-$allTemplates = Get-ChildItem ..\templates\* -Recurse -include template.json | where { $_.FullName -notmatch "\\templates\\test\\" } | % { Write-Output $_.FullName }
+$allTemplates = Get-ChildItem ..\templates\* -Recurse -include template.json | where { $_.FullName -notmatch "\\templates\\Uwp\\test\\" } | % { Write-Output $_.FullName }
 Foreach ($t in $allTemplates)
 {
     # find VB ones

--- a/_utils/List-CSharp-Templates-Without-VisualBasic-Equivalents.ps1
+++ b/_utils/List-CSharp-Templates-Without-VisualBasic-Equivalents.ps1
@@ -1,5 +1,5 @@
 ﻿# Get list of all templates
-$allTemplates = Get-ChildItem ..\templates\* -Recurse -include template.json | where { $_.FullName -notmatch "\\templates\\test\\" } | % { Write-Output $_.FullName }
+$allTemplates = Get-ChildItem ..\templates\* -Recurse -include template.json | where { $_.FullName -notmatch "\\templates\\Uwp\\test\\" } | % { Write-Output $_.FullName }
 Foreach ($t in $allTemplates)
 {
     # Ignore VB ones

--- a/_utils/Synchronize-Files-Used-By-VisualBasic-Templates.ps1
+++ b/_utils/Synchronize-Files-Used-By-VisualBasic-Templates.ps1
@@ -3,10 +3,10 @@
 # This is necessary because the way template folders are copied and filtered means that, for example, the VB templates can't point to files in the C# folders.
 
 # This script finds all interested files in VB folders and then copies the equivalent file from the CS version
-Get-ChildItem ..\templates\* -Recurse -include *.xaml, *.resw, *.md, *.png, Package.appxmanifest | where { $_.FullName -Match "VB\\" -and ($_.FullName -notmatch "\\templates\\test\\") } | % { $cs = $_.FullName -replace "VB\\", "\\"; Copy-Item $cs $_.FullName }
+Get-ChildItem ..\templates\* -Recurse -include *.xaml, *.resw, *.md, *.png, Package.appxmanifest | where { $_.FullName -Match "VB\\" -and ($_.FullName -notmatch "\\templates\\Uwp\\test\\") } | % { $cs = $_.FullName -replace "VB\\", "\\"; Copy-Item $cs $_.FullName }
 
 # This script handles project file postactions that add 3rd party references
-Get-ChildItem ..\templates\* -Recurse -include _postaction.vbproj | where { $_.FullName -notmatch "\\templates\\test\\" } | % { $cs = $_.FullName -replace "VB\\", "\\"; $cs = $cs -replace ".vbproj", ".csproj"; Copy-Item $cs $_.FullName }
+Get-ChildItem ..\templates\* -Recurse -include _postaction.vbproj | where { $_.FullName -notmatch "\\templates\\Uwp\\test\\" } | % { $cs = $_.FullName -replace "VB\\", "\\"; $cs = $cs -replace ".vbproj", ".csproj"; Copy-Item $cs $_.FullName }
 
 # Formats JSON in a nicer format than the built-in ConvertTo-Json does.
 # This is based on code from https://github.com/PowerShell/PowerShell/issues/2736 and will be built into PS6.0
@@ -31,7 +31,7 @@ function Format-Json([Parameter(Mandatory, ValueFromPipeline)][String] $json) {
 
 # This script updates all the localized string values in VB template files from their C# equivalents.
 # This is needed as the files can't just be copied as they have VB specific content.
-Get-ChildItem ..\templates\* -Recurse -include *template.json | where { $_.FullName -Match "VB\\" -and ($_.FullName -notmatch "\\templates\\test\\") } |  % { 
+Get-ChildItem ..\templates\* -Recurse -include *template.json | where { $_.FullName -Match "VB\\" -and ($_.FullName -notmatch "\\templates\\Uwp\\test\\") } |  % { 
 
     $vbFile = $_.FullName;
     $csFile = $_.FullName -replace "VB\\", "\\"; 

--- a/code/test/Templates.Test/GenTests/LanguageComparisonTests.cs
+++ b/code/test/Templates.Test/GenTests/LanguageComparisonTests.cs
@@ -76,6 +76,9 @@ namespace Microsoft.Templates.Test
             var csResourcesString = File.ReadAllText(csReswFilePath);
             var vbResourcesString = File.ReadAllText(vbReswFilePath);
 
+            // Account for different project names in resources files
+            vbResourcesString = vbResourcesString.Replace(vbProjectName, csProjectName);
+
             var reswFilesMatch = csResourcesString == vbResourcesString;
             Assert.True(reswFilesMatch, $"Resource files do not match ({csResultPath.Replace("CS", "*")}).");
 
@@ -95,21 +98,24 @@ namespace Microsoft.Templates.Test
                 }
             }
 
-            foreach (var vbFile in new DirectoryInfo(Path.Combine(vbResultPath, vbProjectName)).GetFiles("*.vb", SearchOption.AllDirectories))
+            foreach (var filter in new[] { "*.vb", "Package.appxmanifest" })
             {
-                var vbFileContents = File.ReadAllText(vbFile.FullName);
-
-                for (var i = resourceKeys.Count - 1; i >= 0; i--)
+                foreach (var vbFile in new DirectoryInfo(Path.Combine(vbResultPath, vbProjectName)).GetFiles(filter, SearchOption.AllDirectories))
                 {
-                    if (vbFileContents.Contains(resourceKeys[i]))
+                    var vbFileContents = File.ReadAllText(vbFile.FullName);
+
+                    for (var i = resourceKeys.Count - 1; i >= 0; i--)
                     {
-                        resourceKeys.RemoveAt(i);
+                        if (vbFileContents.Contains(resourceKeys[i]))
+                        {
+                            resourceKeys.RemoveAt(i);
+                        }
                     }
-                }
 
-                if (!resourceKeys.Any())
-                {
-                    break;
+                    if (!resourceKeys.Any())
+                    {
+                        break;
+                    }
                 }
             }
 

--- a/templates/Uwp/Features/MultiViewVB/.template.config/description.md
+++ b/templates/Uwp/Features/MultiViewVB/.template.config/description.md
@@ -1,3 +1,5 @@
 ﻿Help your users be more productive by letting them view independent parts of your app in separate windows. When you create multiple windows for an app, each window behaves independently. The taskbar shows each window separately. Users can move, resize, show, and hide app windows independently and can switch between app windows as if they were separate apps. Each window operates in its own thread.
 
 To find out more about multiple views, head to [docs.microsoft.com](https://docs.microsoft.com/en-us/windows/uwp/design/layout/show-multiple-views).
+
+See more info in [multiple views documentation](https://github.com/Microsoft/WindowsTemplateStudio/blob/dev/docs/features/multiple-views.md).

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/Views/ShellPage.xaml
@@ -30,7 +30,7 @@
                     Style="{StaticResource TitleTextBlockStyle}"
                     Margin="12,0,0,0"
                     VerticalAlignment="Center"
-                    Text="{Binding Selected.Content}" />
+                    Text="{Binding}" />
             </DataTemplate>
         </NavigationView.HeaderTemplate>
         <i:Interaction.Behaviors>


### PR DESCRIPTION
Update PowerShell scripts to use paths that account for the differences in the template folder structure.
Also, fix a manual test that was reporting false negatives due to the changes for #1859