### PR TITLE
Fix #2240

### DIFF
--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyFixture.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyFixture.cs
@@ -71,16 +71,20 @@ namespace Microsoft.Templates.Test
             GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, language), new Version("2.0"), language);
             if (!syncExecuted)
             {
-                GenContext.ToolBox.Repo.SynchronizeAsync(true).Wait();
+                GenContext.ToolBox.Repo.SynchronizeAsync(true, true).Wait();
 
                 syncExecuted = true;
             }
         }
 
-        public async Task ChangeTemplatesSourceAsync(TemplatesSource source, string language, string platform)
+        [SuppressMessage(
+         "Usage",
+         "VSTHRD002:Synchronously waiting on tasks or awaiters may cause deadlocks",
+         Justification = "Required for unit testing.")]
+        public void ChangeTemplatesSource(TemplatesSource source, string language, string platform)
         {
             GenContext.Bootstrap(source, new FakeGenShell(platform, language), language);
-            await GenContext.ToolBox.Repo.SynchronizeAsync(true);
+            GenContext.ToolBox.Repo.SynchronizeAsync(true, true).Wait();
         }
 
         // Renamed second parameter as this fixture needs the language while others don't

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Templates.Test
         public BuildRightClickWithLegacyTests(BuildRightClickWithLegacyFixture fixture)
         {
             _fixture = fixture;
+            _fixture.InitializeFixture(this);
         }
 
         [Theory]
@@ -31,8 +32,6 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "BuildRightClickLegacy")]
         public async Task BuildEmptyLegacyProjectWithAllRightClickItemsAsync(string projectType, string framework, string platform, string language)
         {
-            _fixture.InitializeFixture(this, language);
-
             var projectName = $"{projectType}{framework}Legacy";
 
             Func<ITemplateInfo, bool> selector =
@@ -47,7 +46,7 @@ namespace Microsoft.Templates.Test
             var projectPath = await AssertGenerateProjectWithOutPlatformAsync(selector, projectName, projectType, framework, language, null, false);
 
             var fixture = _fixture as BuildRightClickWithLegacyFixture;
-            await fixture.ChangeTemplatesSourceAsync(fixture.LocalSource, language, Platforms.Uwp);
+            fixture.ChangeTemplatesSource(fixture.LocalSource, language, Platforms.Uwp);
 
             var rightClickTemplates = _fixture.Templates().Where(
                                           t => (t.GetTemplateType() == TemplateType.Feature || t.GetTemplateType() == TemplateType.Page)
@@ -68,8 +67,6 @@ namespace Microsoft.Templates.Test
         ////This test sets up projects for further manual tests. It generates legacy projects with all pages and features.
         public async Task GenerateLegacyProjectWithAllPagesAndFeaturesAsync(string projectType, string framework, string platform, string language)
         {
-            _fixture.InitializeFixture(this, language);
-
             var projectName = $"{ShortProjectType(projectType)}{framework}AllLegacy";
 
             Func<ITemplateInfo, bool> selector =

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSourceV2.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSourceV2.cs
@@ -23,12 +23,9 @@ namespace Microsoft.Templates.Test
 
         public override async Task<TemplatesContentInfo> GetContentAsync(TemplatesPackageInfo packageInfo, string workingFolder, CancellationToken ct)
         {
-            await LoadConfigAsync(ct);
-            var package = Config.Latest;
+            await AcquireAsync(packageInfo, ct);
 
-            await AcquireAsync(package, ct);
-
-            return await base.GetContentAsync(package, workingFolder, ct);
+            return await base.GetContentAsync(packageInfo, workingFolder, ct);
         }
 
         private static string GetAgentName()


### PR DESCRIPTION
Fixes right click tests. 
This was downloading 2.1 templates instead of 2.0 templates.