### PR TITLE
Get latest (compatible) version from working folder in case of VS Update

### DIFF
--- a/code/src/Core/Locations/TemplatesContent.cs
+++ b/code/src/Core/Locations/TemplatesContent.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Templates.Core.Locations
             LoadAvailableContents();
 
             Source = source;
-            SetCurrentContent(tengineCurrentContent);
+            SetCurrentContent(tengineCurrentContent, wizardVersion);
 
             WizardVersion = wizardVersion;
         }
@@ -293,9 +293,17 @@ namespace Microsoft.Templates.Core.Locations
             return All.OrderByDescending(c => c.Version).ThenByDescending(c => c.Date).FirstOrDefault();
         }
 
-        private void SetCurrentContent(string tengineCurrentContent)
+        private void SetCurrentContent(string tengineCurrentContent, Version wizardVersion)
         {
-            Current = All.Where(c => c.Path.Equals(tengineCurrentContent, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            if (!string.IsNullOrEmpty(tengineCurrentContent))
+            {
+                Current = All.Where(c => c.Path.Equals(tengineCurrentContent, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            }
+            else
+            {
+                var mainWizardVersion = $"{wizardVersion.Major.ToString()}.{wizardVersion.Minor.ToString()}";
+                Current = All.Where(c => c.MainVersion.Equals(mainWizardVersion, StringComparison.OrdinalIgnoreCase)).OrderByDescending(c => c.Version).ThenByDescending(c => c.Date).FirstOrDefault();
+            }
         }
 
         internal void RefreshContentFolder(string tengineCurrentContent)


### PR DESCRIPTION
Quick summary of changes
- if there is no cached templatefolder, set current templates to latest valid version from working folder

Which issue does this PR relate to?
- #2291 WTS is extracting templates after VSUpdate
