### PR TITLE
Fix Issue on Prism NavigationView activation

### DIFF
--- a/templates/Uwp/_composition/Prism/Project.SplitView/ViewModels/ShellViewModel.cs
+++ b/templates/Uwp/_composition/Prism/Project.SplitView/ViewModels/ShellViewModel.cs
@@ -56,7 +56,8 @@ namespace wts.ItemName.ViewModels
 
         private bool IsMenuItemForPageType(NavigationViewItem menuItem, Type sourcePageType)
         {
-            var sourcePageKey = sourcePageType.ToString().Split('.').Last().Replace("Page", string.Empty);
+            var sourcePageKey = sourcePageType.Name;
+            sourcePageKey = sourcePageKey.Substring(0, sourcePageKey.Length - 4);
             var pageKey = menuItem.GetValue(NavHelper.NavigateToProperty) as string;
             return pageKey == sourcePageKey;
         }


### PR DESCRIPTION
Page with "Page" suffix causes Header in NavigationView not to work #2362