### PR TITLE
Corrects error message.  I found this in our STS fork.

### DIFF
--- a/code/tools/TemplateValidator/TemplateJsonVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateJsonVerifier.cs
@@ -287,7 +287,7 @@ namespace TemplateValidator
         {
             if (!new[] { "Analytics", "BackgroundWork", "UserInteraction", "ApplicationLifecycle", "ApplicationLaunching", "ConnectedExperiences" }.Contains(tag.Value))
             {
-                results.Add($"Invalid value '{tag.Value}' specified in the wts.rightClickEnabled tag.");
+                results.Add($"Invalid value '{tag.Value}' specified in the wts.group tag.");
             }
         }
 


### PR DESCRIPTION
This PR corrects the error message when an invalid wts.group value is encountered.  We added a new Telemetry group in our STS fork, and were seeing this error incorrectly reported when running the unit tests.  

This PR does not change or add any functionality.