### PR TITLE
Added columndefinitions to datagrids to correctly show symbol icon

### DIFF
--- a/templates/Uwp/Pages/DataGrid.CodeBehind/Views/DataGridViewPage.xaml
+++ b/templates/Uwp/Pages/DataGrid.CodeBehind/Views/DataGridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <controls:DataGrid ItemsSource="{x:Bind Source}" AutoGenerateColumns="True" />
+            <controls:DataGrid ItemsSource="{x:Bind Source}" AutoGenerateColumns="False" >
+                <controls:DataGrid.Columns>
+                    <!--TODO WTS:
+                    Remove this column definitions and define columns for your data.
+                    Consider adding header properties to Resources.resw-->
+                    <controls:DataGridTextColumn Header="OrderId" Binding="{Binding OrderId}" />
+                    <controls:DataGridTextColumn Header="OrderDate" Binding="{Binding OrderDate}"  />
+                    <controls:DataGridTextColumn Header="Company" Binding="{Binding Company}" />
+                    <controls:DataGridTextColumn Header="ShipTo" Binding="{Binding ShipTo}" />
+                    <controls:DataGridTextColumn Header="OrderTotal" Binding="{Binding OrderTotal}" />
+                    <controls:DataGridTextColumn Header="Status" Binding="{Binding Status}"  />
+                    <controls:DataGridTemplateColumn Header="Symbol">
+                        <controls:DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                HorizontalAlignment="Left"
+                                Margin="{StaticResource MediumLeftRightMargin}"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                Glyph="{x:Bind Symbol}" />
+                            </DataTemplate>
+                        </controls:DataGridTemplateColumn.CellTemplate>
+                    </controls:DataGridTemplateColumn>
+                </controls:DataGrid.Columns>
+            </controls:DataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/DataGrid.CodeBehind/Views/DataGridViewPage.xaml.cs
+++ b/templates/Uwp/Pages/DataGrid.CodeBehind/Views/DataGridViewPage.xaml.cs
@@ -8,7 +8,7 @@ namespace Param_ItemNamespace.Views
 {
     public sealed partial class DataGridViewPage : Page, System.ComponentModel.INotifyPropertyChanged
     {
-        // TODO WTS: Change the grid as appropriate to your app.
+        // TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on DataGridViewPage.xaml.
         // For more details see the documentation at https://github.com/Microsoft/WindowsCommunityToolkit/blob/harinikmsft/datagrid/docs/controls/DataGrid.md
         public DataGridViewPage()
         {

--- a/templates/Uwp/Pages/DataGrid.CodeBehindVB/Views/DataGridViewPage.xaml
+++ b/templates/Uwp/Pages/DataGrid.CodeBehindVB/Views/DataGridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <controls:DataGrid ItemsSource="{x:Bind Source}" AutoGenerateColumns="True" />
+            <controls:DataGrid ItemsSource="{x:Bind Source}" AutoGenerateColumns="False" >
+                <controls:DataGrid.Columns>
+                    <!--TODO WTS:
+                    Remove this column definitions and define columns for your data.
+                    Consider adding header properties to Resources.resw-->
+                    <controls:DataGridTextColumn Header="OrderId" Binding="{Binding OrderId}" />
+                    <controls:DataGridTextColumn Header="OrderDate" Binding="{Binding OrderDate}"  />
+                    <controls:DataGridTextColumn Header="Company" Binding="{Binding Company}" />
+                    <controls:DataGridTextColumn Header="ShipTo" Binding="{Binding ShipTo}" />
+                    <controls:DataGridTextColumn Header="OrderTotal" Binding="{Binding OrderTotal}" />
+                    <controls:DataGridTextColumn Header="Status" Binding="{Binding Status}"  />
+                    <controls:DataGridTemplateColumn Header="Symbol">
+                        <controls:DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                HorizontalAlignment="Left"
+                                Margin="{StaticResource MediumLeftRightMargin}"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                Glyph="{x:Bind Symbol}" />
+                            </DataTemplate>
+                        </controls:DataGridTemplateColumn.CellTemplate>
+                    </controls:DataGridTemplateColumn>
+                </controls:DataGrid.Columns>
+            </controls:DataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/DataGrid.CodeBehindVB/Views/DataGridViewPage.xaml.vb
+++ b/templates/Uwp/Pages/DataGrid.CodeBehindVB/Views/DataGridViewPage.xaml.vb
@@ -6,7 +6,7 @@ Namespace Views
         Inherits Page
         Implements System.ComponentModel.INotifyPropertyChanged
 
-        ' TODO WTS: Change the grid as appropriate to your app.
+        ' TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on DataGridViewPage.xaml.
         ' For more details see the documentation at https://github.com/Microsoft/WindowsCommunityToolkit/blob/harinikmsft/datagrid/docs/controls/DataGrid.md
         Public Sub New()
             InitializeComponent()

--- a/templates/Uwp/Pages/DataGrid.Prism/Views/DataGridViewPage.xaml
+++ b/templates/Uwp/Pages/DataGrid.Prism/Views/DataGridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <controls:DataGrid ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="True" />
+            <controls:DataGrid ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="False" >
+                <controls:DataGrid.Columns>
+                    <!--TODO WTS:
+                    Remove this column definitions and define columns for your data.
+                    Consider adding header properties to Resources.resw-->
+                    <controls:DataGridTextColumn Header="OrderId" Binding="{Binding OrderId}" />
+                    <controls:DataGridTextColumn Header="OrderDate" Binding="{Binding OrderDate}"  />
+                    <controls:DataGridTextColumn Header="Company" Binding="{Binding Company}" />
+                    <controls:DataGridTextColumn Header="ShipTo" Binding="{Binding ShipTo}" />
+                    <controls:DataGridTextColumn Header="OrderTotal" Binding="{Binding OrderTotal}" />
+                    <controls:DataGridTextColumn Header="Status" Binding="{Binding Status}"  />
+                    <controls:DataGridTemplateColumn Header="Symbol">
+                        <controls:DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                HorizontalAlignment="Left"
+                                Margin="{StaticResource MediumLeftRightMargin}"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                Glyph="{x:Bind Symbol}" />
+                            </DataTemplate>
+                        </controls:DataGridTemplateColumn.CellTemplate>
+                    </controls:DataGridTemplateColumn>
+                </controls:DataGrid.Columns>
+            </controls:DataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/DataGrid.Prism/Views/DataGridViewPage.xaml.cs
+++ b/templates/Uwp/Pages/DataGrid.Prism/Views/DataGridViewPage.xaml.cs
@@ -5,7 +5,7 @@ namespace Param_ItemNamespace.Views
 {
     public sealed partial class DataGridViewPage : Page
     {
-        // TODO WTS: Change the grid as appropriate to your app.
+        // TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on DataGridViewPage.xaml.
         // For more details see the documentation at https://github.com/Microsoft/WindowsCommunityToolkit/blob/harinikmsft/datagrid/docs/controls/DataGrid.md
         public DataGridViewPage()
         {

--- a/templates/Uwp/Pages/DataGrid/Views/DataGridViewPage.xaml
+++ b/templates/Uwp/Pages/DataGrid/Views/DataGridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <controls:DataGrid ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="True" />
+            <controls:DataGrid ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="False" >
+                <controls:DataGrid.Columns>
+                    <!--TODO WTS:
+                    Remove this column definitions and define columns for your data.
+                    Consider adding header properties to Resources.resw-->
+                    <controls:DataGridTextColumn Header="OrderId" Binding="{Binding OrderId}" />
+                    <controls:DataGridTextColumn Header="OrderDate" Binding="{Binding OrderDate}"  />
+                    <controls:DataGridTextColumn Header="Company" Binding="{Binding Company}" />
+                    <controls:DataGridTextColumn Header="ShipTo" Binding="{Binding ShipTo}" />
+                    <controls:DataGridTextColumn Header="OrderTotal" Binding="{Binding OrderTotal}" />
+                    <controls:DataGridTextColumn Header="Status" Binding="{Binding Status}"  />
+                    <controls:DataGridTemplateColumn Header="Symbol">
+                        <controls:DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                HorizontalAlignment="Left"
+                                Margin="{StaticResource MediumLeftRightMargin}"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                Glyph="{x:Bind Symbol}" />
+                            </DataTemplate>
+                        </controls:DataGridTemplateColumn.CellTemplate>
+                    </controls:DataGridTemplateColumn>
+                </controls:DataGrid.Columns>
+            </controls:DataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/DataGrid/Views/DataGridViewPage.xaml.cs
+++ b/templates/Uwp/Pages/DataGrid/Views/DataGridViewPage.xaml.cs
@@ -5,7 +5,7 @@ namespace Param_ItemNamespace.Views
 {
     public sealed partial class DataGridViewPage : Page
     {
-        // TODO WTS: Change the grid as appropriate to your app.
+        // TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on DataGridViewPage.xaml.
         // For more details see the documentation at https://github.com/Microsoft/WindowsCommunityToolkit/blob/harinikmsft/datagrid/docs/controls/DataGrid.md
         public DataGridViewPage()
         {

--- a/templates/Uwp/Pages/DataGridVB/Views/DataGridViewPage.xaml
+++ b/templates/Uwp/Pages/DataGridVB/Views/DataGridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <controls:DataGrid ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="True" />
+            <controls:DataGrid ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="False" >
+                <controls:DataGrid.Columns>
+                    <!--TODO WTS:
+                    Remove this column definitions and define columns for your data.
+                    Consider adding header properties to Resources.resw-->
+                    <controls:DataGridTextColumn Header="OrderId" Binding="{Binding OrderId}" />
+                    <controls:DataGridTextColumn Header="OrderDate" Binding="{Binding OrderDate}"  />
+                    <controls:DataGridTextColumn Header="Company" Binding="{Binding Company}" />
+                    <controls:DataGridTextColumn Header="ShipTo" Binding="{Binding ShipTo}" />
+                    <controls:DataGridTextColumn Header="OrderTotal" Binding="{Binding OrderTotal}" />
+                    <controls:DataGridTextColumn Header="Status" Binding="{Binding Status}"  />
+                    <controls:DataGridTemplateColumn Header="Symbol">
+                        <controls:DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                HorizontalAlignment="Left"
+                                Margin="{StaticResource MediumLeftRightMargin}"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                Glyph="{x:Bind Symbol}" />
+                            </DataTemplate>
+                        </controls:DataGridTemplateColumn.CellTemplate>
+                    </controls:DataGridTemplateColumn>
+                </controls:DataGrid.Columns>
+            </controls:DataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/DataGridVB/Views/DataGridViewPage.xaml.vb
+++ b/templates/Uwp/Pages/DataGridVB/Views/DataGridViewPage.xaml.vb
@@ -2,7 +2,7 @@
     Public NotInheritable Partial Class DataGridViewPage
         Inherits Page
 
-        ' TODO WTS: Change the grid as appropriate to your app.
+        ' TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on DataGridViewPage.xaml.
         ' For more details see the documentation at https://github.com/Microsoft/WindowsCommunityToolkit/blob/harinikmsft/datagrid/docs/controls/DataGrid.md
         Public Sub New()
             InitializeComponent()

--- a/templates/Uwp/Pages/Grid.CodeBehind/Views/GridViewPage.xaml
+++ b/templates/Uwp/Pages/Grid.CodeBehind/Views/GridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:tg="using:Telerik.UI.Xaml.Controls.Grid"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind Source}" />
+            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind Source}" AutoGenerateColumns="False" >
+                <tg:RadDataGrid.Columns>
+                    <!--TODO WTS:
+                      Remove this column definitions and define columns for your data.
+                      Consider adding header properties to Resources.resw-->
+                    <tg:DataGridTextColumn PropertyName="OrderId" />
+                    <tg:DataGridDateColumn PropertyName="OrderDate" />
+                    <tg:DataGridTextColumn PropertyName="Company" />
+                    <tg:DataGridTextColumn PropertyName="ShipTo" />
+                    <tg:DataGridNumericalColumn PropertyName="OrderTotal" />
+                    <tg:DataGridTextColumn PropertyName="Status" />
+                    <tg:DataGridTemplateColumn Header="Symbol">
+                        <tg:DataGridTemplateColumn.CellContentTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                      HorizontalAlignment="Left"
+                                      Margin="{StaticResource MediumLeftRightMargin}"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      Glyph="{x:Bind Symbol}" />        
+                            </DataTemplate>
+                        </tg:DataGridTemplateColumn.CellContentTemplate>
+                    </tg:DataGridTemplateColumn>
+                </tg:RadDataGrid.Columns>
+            </tg:RadDataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/Grid.CodeBehind/Views/GridViewPage.xaml.cs
+++ b/templates/Uwp/Pages/Grid.CodeBehind/Views/GridViewPage.xaml.cs
@@ -8,7 +8,7 @@ namespace Param_ItemNamespace.Views
 {
     public sealed partial class GridViewPage : Page, System.ComponentModel.INotifyPropertyChanged
     {
-        // TODO WTS: Change the grid as appropriate to your app.
+        // TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on GridViewPage.xaml.
         // For help see http://docs.telerik.com/windows-universal/controls/raddatagrid/gettingstarted
         // You may also want to extend the grid to work with the RadDataForm http://docs.telerik.com/windows-universal/controls/raddataform/dataform-gettingstarted
         public GridViewPage()

--- a/templates/Uwp/Pages/Grid.CodeBehindVB/Views/GridViewPage.xaml
+++ b/templates/Uwp/Pages/Grid.CodeBehindVB/Views/GridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:tg="using:Telerik.UI.Xaml.Controls.Grid"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind Source}" />
+            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind Source}" AutoGenerateColumns="False" >
+                <tg:RadDataGrid.Columns>
+                    <!--TODO WTS:
+                      Remove this column definitions and define columns for your data.
+                      Consider adding header properties to Resources.resw-->
+                    <tg:DataGridTextColumn PropertyName="OrderId" />
+                    <tg:DataGridDateColumn PropertyName="OrderDate" />
+                    <tg:DataGridTextColumn PropertyName="Company" />
+                    <tg:DataGridTextColumn PropertyName="ShipTo" />
+                    <tg:DataGridNumericalColumn PropertyName="OrderTotal" />
+                    <tg:DataGridTextColumn PropertyName="Status" />
+                    <tg:DataGridTemplateColumn Header="Symbol">
+                        <tg:DataGridTemplateColumn.CellContentTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                      HorizontalAlignment="Left"
+                                      Margin="{StaticResource MediumLeftRightMargin}"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      Glyph="{x:Bind Symbol}" />        
+                            </DataTemplate>
+                        </tg:DataGridTemplateColumn.CellContentTemplate>
+                    </tg:DataGridTemplateColumn>
+                </tg:RadDataGrid.Columns>
+            </tg:RadDataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/Grid.CodeBehindVB/Views/GridViewPage.xaml.vb
+++ b/templates/Uwp/Pages/Grid.CodeBehindVB/Views/GridViewPage.xaml.vb
@@ -6,7 +6,7 @@ Namespace Views
         Inherits Page
         Implements System.ComponentModel.INotifyPropertyChanged
 
-        ' TODO WTS: Change the grid as appropriate to your app.
+        ' TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on GridViewPage.xaml.
         ' For help see http://docs.telerik.com/windows-universal/controls/raddatagrid/gettingstarted
         ' You may also want to extend the grid to work with the RadDataForm http://docs.telerik.com/windows-universal/controls/raddataform/dataform-gettingstarted
         Public Sub New()

--- a/templates/Uwp/Pages/Grid.Prism/Views/GridViewPage.xaml
+++ b/templates/Uwp/Pages/Grid.Prism/Views/GridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:tg="using:Telerik.UI.Xaml.Controls.Grid"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind ViewModel.Source}" />
+            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="False" >
+                <tg:RadDataGrid.Columns>
+                    <!--TODO WTS:
+                      Remove this column definitions and define columns for your data.
+                      Consider adding header properties to Resources.resw-->
+                    <tg:DataGridTextColumn PropertyName="OrderId" />
+                    <tg:DataGridDateColumn PropertyName="OrderDate" />
+                    <tg:DataGridTextColumn PropertyName="Company" />
+                    <tg:DataGridTextColumn PropertyName="ShipTo" />
+                    <tg:DataGridNumericalColumn PropertyName="OrderTotal" />
+                    <tg:DataGridTextColumn PropertyName="Status" />
+                    <tg:DataGridTemplateColumn Header="Symbol">
+                        <tg:DataGridTemplateColumn.CellContentTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                      HorizontalAlignment="Left"
+                                      Margin="{StaticResource MediumLeftRightMargin}"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      Glyph="{x:Bind Symbol}" />        
+                            </DataTemplate>
+                        </tg:DataGridTemplateColumn.CellContentTemplate>
+                    </tg:DataGridTemplateColumn>
+                </tg:RadDataGrid.Columns>
+            </tg:RadDataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/Grid.Prism/Views/GridViewPage.xaml.cs
+++ b/templates/Uwp/Pages/Grid.Prism/Views/GridViewPage.xaml.cs
@@ -5,7 +5,7 @@ namespace Param_ItemNamespace.Views
 {
     public sealed partial class GridViewPage : Page
     {
-        // TODO WTS: Change the grid as appropriate to your app.
+        // TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on GridViewPage.xaml.
         // For help see http://docs.telerik.com/windows-universal/controls/raddatagrid/gettingstarted
         // You may also want to extend the grid to work with the RadDataForm http://docs.telerik.com/windows-universal/controls/raddataform/dataform-gettingstarted
         public GridViewPage()

--- a/templates/Uwp/Pages/Grid/Views/GridViewPage.xaml
+++ b/templates/Uwp/Pages/Grid/Views/GridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:tg="using:Telerik.UI.Xaml.Controls.Grid"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind ViewModel.Source}" />
+            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="False" >
+                <tg:RadDataGrid.Columns>
+                    <!--TODO WTS:
+                      Remove this column definitions and define columns for your data.
+                      Consider adding header properties to Resources.resw-->
+                    <tg:DataGridTextColumn PropertyName="OrderId" />
+                    <tg:DataGridDateColumn PropertyName="OrderDate" />
+                    <tg:DataGridTextColumn PropertyName="Company" />
+                    <tg:DataGridTextColumn PropertyName="ShipTo" />
+                    <tg:DataGridNumericalColumn PropertyName="OrderTotal" />
+                    <tg:DataGridTextColumn PropertyName="Status" />
+                    <tg:DataGridTemplateColumn Header="Symbol">
+                        <tg:DataGridTemplateColumn.CellContentTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                      HorizontalAlignment="Left"
+                                      Margin="{StaticResource MediumLeftRightMargin}"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      Glyph="{x:Bind Symbol}" />        
+                            </DataTemplate>
+                        </tg:DataGridTemplateColumn.CellContentTemplate>
+                    </tg:DataGridTemplateColumn>
+                </tg:RadDataGrid.Columns>
+            </tg:RadDataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/Grid/Views/GridViewPage.xaml.cs
+++ b/templates/Uwp/Pages/Grid/Views/GridViewPage.xaml.cs
@@ -5,7 +5,7 @@ namespace Param_ItemNamespace.Views
 {
     public sealed partial class GridViewPage : Page
     {
-        // TODO WTS: Change the grid as appropriate to your app.
+        // TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on GridViewPage.xaml.
         // For help see http://docs.telerik.com/windows-universal/controls/raddatagrid/gettingstarted
         // You may also want to extend the grid to work with the RadDataForm http://docs.telerik.com/windows-universal/controls/raddataform/dataform-gettingstarted
         public GridViewPage()

--- a/templates/Uwp/Pages/GridVB/Views/GridViewPage.xaml
+++ b/templates/Uwp/Pages/GridVB/Views/GridViewPage.xaml
@@ -5,13 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:tg="using:Telerik.UI.Xaml.Controls.Grid"
+    xmlns:model="using:Param_ItemNamespace.Models"
     mc:Ignorable="d">
     <Grid
         x:Name="ContentArea"
         Margin="{StaticResource MediumLeftRightMargin}">
         <Grid
             Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind ViewModel.Source}" />
+           <tg:RadDataGrid ColumnDataOperationsMode="Flyout" x:Name="grid" ItemsSource="{x:Bind ViewModel.Source}" AutoGenerateColumns="False" >
+                <tg:RadDataGrid.Columns>
+                    <!--TODO WTS:
+                      Remove this column definitions and define columns for your data.
+                      Consider adding header properties to Resources.resw-->
+                    <tg:DataGridTextColumn PropertyName="OrderId" />
+                    <tg:DataGridDateColumn PropertyName="OrderDate" />
+                    <tg:DataGridTextColumn PropertyName="Company" />
+                    <tg:DataGridTextColumn PropertyName="ShipTo" />
+                    <tg:DataGridNumericalColumn PropertyName="OrderTotal" />
+                    <tg:DataGridTextColumn PropertyName="Status" />
+                    <tg:DataGridTemplateColumn Header="Symbol">
+                        <tg:DataGridTemplateColumn.CellContentTemplate>
+                            <DataTemplate x:DataType="model:SampleOrder">
+                                <FontIcon
+                                      HorizontalAlignment="Left"
+                                      Margin="{StaticResource MediumLeftRightMargin}"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      Glyph="{x:Bind Symbol}" />        
+                            </DataTemplate>
+                        </tg:DataGridTemplateColumn.CellContentTemplate>
+                    </tg:DataGridTemplateColumn>
+                </tg:RadDataGrid.Columns>
+            </tg:RadDataGrid>
         </Grid>
     </Grid>
 </Page>

--- a/templates/Uwp/Pages/GridVB/Views/GridViewPage.xaml.vb
+++ b/templates/Uwp/Pages/GridVB/Views/GridViewPage.xaml.vb
@@ -2,7 +2,7 @@
     Public NotInheritable Partial Class GridViewPage
         Inherits Page
 
-        ' TODO WTS: Change the grid as appropriate to your app.
+        ' TODO WTS: Change the grid as appropriate to your app, adjust the column definitions on GridViewPage.xaml.
         ' For help see http://docs.telerik.com/windows-universal/controls/raddatagrid/gettingstarted
         ' You may also want to extend the grid to work with the RadDataForm http://docs.telerik.com/windows-universal/controls/raddataform/dataform-gettingstarted
         Public Sub New()


### PR DESCRIPTION
## PR checklist

Quick summary of changes
Added column definitions to datagrid to correctly show symbol column
- Which issue does this PR relate to?
#2351 DataGrid template does not display symbol icon
- Anything that requires particular review or attention?
The DataGrid from the community toolkit does not allow x:bind yet, thats why I used binding for now. 
(https://github.com/Microsoft/WindowsCommunityToolkit/issues/2112)