### PR TITLE
Issue933 eliminatecodeclones

### DIFF
--- a/code/test/Core.Test/.codeclonesettings
+++ b/code/test/Core.Test/.codeclonesettings
@@ -1,0 +1,8 @@
+﻿<CodeCloneSettings>  
+  <Exclusions>  
+    <!-- Collection assert in two tests, that are proofing the same condition set up in two ways. -->  
+    <Type>Microsoft.Templates.Core.Test.Composition.CompositionQueryTest</Type>  
+    <FunctionName>Microsoft.Templates.Core.Test.Composition.CompositionQueryTest.Parse</FunctionName>  
+    <FunctionName>Microsoft.Templates.Core.Test.Composition.CompositionQueryTest.Parse_MultipleItems</FunctionName>  
+  </Exclusions>  
+</CodeCloneSettings>  

--- a/code/test/Core.Test/Core.Test.csproj
+++ b/code/test/Core.Test/Core.Test.csproj
@@ -216,6 +216,7 @@
     <AdditionalFiles Include="..\..\StyleCop.json">
       <Link>StyleCop.json</Link>
     </AdditionalFiles>
+    <None Include=".codeclonesettings" />
     <None Include="Packaging\MsSigned\Templates.mstx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/code/test/Templates.Test/BaseGenAndBuildFixture.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildFixture.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Templates.Test
 
             foreach (var item in layouts)
             {
-                if (getName != null)
+                if (getName == BaseGenAndBuildFixture.GetDefaultName || getName == null)
                 {
-                    AddItem(userSelection, item.Template, getName);
+                    AddItem(userSelection, item.Layout.Name, item.Template);
                 }
                 else
                 {
-                    AddItem(userSelection, item.Layout.Name, item.Template);
+                    AddItem(userSelection, item.Template, getName);
                 }
             }
 

--- a/code/test/Templates.Test/BaseGenAndBuildFixture.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildFixture.cs
@@ -284,5 +284,49 @@ namespace Microsoft.Templates.Test
             var fakeShell = GenContext.ToolBox.Shell as FakeGenShell;
             fakeShell.SetCurrentPlatform(platform);
         }
+
+        protected static IEnumerable<object[]> GetPageAndFeatureTemplates(string frameworkFilter)
+        {
+            List<object[]> result = new List<object[]>();
+            foreach (var language in ProgrammingLanguages.GetAllLanguages())
+            {
+                SetCurrentLanguage(language);
+                foreach (var platform in Platforms.GetAllPlatforms())
+                {
+                    SetCurrentPlatform(platform);
+                    var templateProjectTypes = GenComposer.GetSupportedProjectTypes(platform);
+
+                    var projectTypes = GenContext.ToolBox.Repo.GetProjectTypes(platform)
+                                .Where(m => templateProjectTypes.Contains(m.Name) && !string.IsNullOrEmpty(m.Description))
+                                .Select(m => m.Name);
+
+                    foreach (var projectType in projectTypes)
+                    {
+                        var projectFrameworks = GenComposer.GetSupportedFx(projectType, platform);
+
+                        var targetFrameworks = GenContext.ToolBox.Repo.GetFrameworks(platform)
+                                                    .Where(m => projectFrameworks.Contains(m.Name) && m.Name == frameworkFilter)
+                                                    .Select(m => m.Name).ToList();
+
+                        foreach (var framework in targetFrameworks)
+                        {
+                            var itemTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetFrameworkList().Contains(framework)
+                                                                 && (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                                                                 && t.GetPlatform() == platform
+                                                                 && t.GetLanguage() == language
+                                                                 && !t.GetIsHidden());
+
+                            foreach (var itemTemplate in itemTemplates)
+                            {
+                                result.Add(new object[]
+                                    { itemTemplate.Name, projectType, framework, platform, itemTemplate.Identity, language });
+                            }
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Templates.Test
 
         public static IEnumerable<object[]> GetPageAndFeatureTemplatesForGeneration(string framework)
         {
-            var result = GenerationFixture.GetPageAndFeatureTemplates(framework);
+            var result = GenerationFixture.GetPageAndFeatureTemplatesForGeneration(framework);
             return result;
         }
 
@@ -413,23 +413,23 @@ namespace Microsoft.Templates.Test
             switch (framework)
             {
                 case "CodeBehind":
-                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplates(framework);
+                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework);
                     break;
 
                 case "MVVMBasic":
-                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplates(framework);
+                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework);
                     break;
 
                 case "MVVMLight":
-                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplates(framework);
+                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework);
                     break;
 
                 case "CaliburnMicro":
-                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplates(framework);
+                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework);
                     break;
 
                 case "Prism":
-                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplates(framework);
+                    result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework);
                     break;
             }
 

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -43,31 +43,12 @@ namespace Microsoft.Templates.Test
             }
         }
 
-        protected static string ShortFramework(string framework)
-        {
-            switch (framework)
-            {
-                case "CodeBehind":
-                    return "CB";
-                case "MVVMBasic":
-                    return "MB";
-                case "MVVMLight":
-                    return "ML";
-                case "CaliburnMicro":
-                    return "CM";
-                case "Prism":
-                    return "P";
-                default:
-                    return framework;
-            }
-        }
-
         protected static string GetProjectExtension(string language)
         {
             return language == ProgrammingLanguages.CSharp ? "csproj" : "vbproj";
         }
 
-        protected async Task<string> AssertGenerateProjectAsync(Func<ITemplateInfo, bool> projectTemplateSelector, string projectName, string projectType, string framework, string platform, string language, Func<ITemplateInfo, string> getName = null, bool cleanGeneration = true)
+        protected async Task<string> AssertGenerateProjectAsync(Func<ITemplateInfo, bool> projectTemplateSelector, string projectName, string projectType, string framework, string platform, string language, Func<ITemplateInfo, bool> itemTemplatesSelector = null, Func<ITemplateInfo, string> getName = null, bool cleanGeneration = true)
         {
             BaseGenAndBuildFixture.SetCurrentLanguage(language);
             BaseGenAndBuildFixture.SetCurrentPlatform(platform);
@@ -79,11 +60,12 @@ namespace Microsoft.Templates.Test
             DestinationPath = Path.Combine(_fixture.TestProjectsPath, projectName, projectName);
             DestinationParentPath = Path.Combine(_fixture.TestProjectsPath, projectName);
 
-            var userSelection = _fixture.SetupProject(projectType, framework, platform, language, getName);
+            var userSelection = _fixture.SetupProject(projectType, framework, platform, language);
 
-            if (getName != null)
+            if (getName != null || itemTemplatesSelector == null)
             {
-                _fixture.AddItems(userSelection, _fixture.GetTemplates(framework, platform), getName);
+                var itemTemplates = _fixture.Templates().Where(itemTemplatesSelector);
+                _fixture.AddItems(userSelection, itemTemplates, getName);
             }
 
             await NewProjectGenController.Instance.UnsafeGenerateProjectAsync(userSelection);
@@ -126,7 +108,7 @@ namespace Microsoft.Templates.Test
             Assert.True(result.exitCode.Equals(0), $"Solution {projectName} was not built successfully. {Environment.NewLine}Errors found: {_fixture.GetErrorLines(result.outputFile)}.{Environment.NewLine}Please see {Path.GetFullPath(result.outputFile)} for more details.");
 
             // Clean
-            Fs.SafeDeleteDirectory(projectPath);
+           // Fs.SafeDeleteDirectory(projectPath);
         }
 
         protected async Task<string> AssertGenerateRightClickAsync(string projectName, string projectType, string framework, string platform, string language, bool emptyProject, bool cleanGeneration = true)

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Templates.Test
             Assert.True(result.exitCode.Equals(0), $"Solution {projectName} was not built successfully. {Environment.NewLine}Errors found: {_fixture.GetErrorLines(result.outputFile)}.{Environment.NewLine}Please see {Path.GetFullPath(result.outputFile)} for more details.");
 
             // Clean
-           // Fs.SafeDeleteDirectory(projectPath);
+            Fs.SafeDeleteDirectory(projectPath);
         }
 
         protected async Task<string> AssertGenerateRightClickAsync(string projectName, string projectType, string framework, string platform, string language, bool emptyProject, bool cleanGeneration = true)

--- a/code/test/Templates.Test/BuildFixture.cs
+++ b/code/test/Templates.Test/BuildFixture.cs
@@ -68,52 +68,6 @@ namespace Microsoft.Templates.Test
             return result;
         }
 
-        public static IEnumerable<object[]> GetPageAndFeatureTemplates()
-        {
-            InitializeTemplates(new LocalTemplatesSource("TstBld"));
-
-            List<object[]> result = new List<object[]>();
-            foreach (var language in ProgrammingLanguages.GetAllLanguages())
-            {
-                BaseGenAndBuildFixture.SetCurrentLanguage(language);
-                foreach (var platform in Platforms.GetAllPlatforms())
-                {
-                    SetCurrentPlatform(platform);
-                    var templateProjectTypes = GenComposer.GetSupportedProjectTypes(platform);
-
-                    var projectTypes = GenContext.ToolBox.Repo.GetProjectTypes(platform)
-                                .Where(m => templateProjectTypes.Contains(m.Name) && !string.IsNullOrEmpty(m.Description))
-                                .Select(m => m.Name);
-
-                    foreach (var projectType in projectTypes)
-                    {
-                        var projectFrameworks = GenComposer.GetSupportedFx(projectType, platform);
-
-                        var targetFrameworks = GenContext.ToolBox.Repo.GetFrameworks(platform)
-                                                    .Where(m => projectFrameworks.Contains(m.Name))
-                                                    .Select(m => m.Name).ToList();
-
-                        foreach (var framework in targetFrameworks)
-                        {
-                            var itemTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetFrameworkList().Contains(framework)
-                                                                 && (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
-                                                                 && t.GetPlatform() == platform
-                                                                 && t.GetLanguage() == language
-                                                                 && !t.GetIsHidden());
-
-                            foreach (var itemTemplate in itemTemplates)
-                            {
-                                result.Add(new object[]
-                                    { itemTemplate.Name, projectType, framework, itemTemplate.Identity, language });
-                            }
-                        }
-                    }
-                }
-            }
-
-            return result;
-        }
-
         [SuppressMessage(
          "Usage",
          "VSTHRD002:Synchronously waiting on tasks or awaiters may cause deadlocks",

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Templates.Test
                    && !t.GetIsHidden()
                    && t.GetLanguage() == language;
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, Platforms.Uwp, language, null, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, Platforms.Uwp, language, null, null, false);
 
             var fixture = _fixture as BuildRightClickWithLegacyFixture;
             fixture.ChangeTemplatesSource(fixture.LocalSource, language, Platforms.Uwp);
@@ -90,7 +90,7 @@ namespace Microsoft.Templates.Test
             DestinationPath = Path.Combine(_fixture.TestProjectsPath, projectName, projectName);
             DestinationParentPath = Path.Combine(_fixture.TestProjectsPath, projectName);
 
-            var userSelection = _fixture.SetupProject(projectType, framework, string.Empty, language, getName);
+            var userSelection = _fixture.SetupProject(projectType, framework, string.Empty, language);
 
             if (getName != null)
             {

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, null, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -55,9 +55,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}All";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -77,9 +83,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}AllRandom";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetRandomName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, null, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -55,9 +55,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}All{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -92,9 +98,15 @@ namespace Microsoft.Templates.Test
                      && !t.GetIsHidden()
                      && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetRandomName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, null, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -55,9 +55,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}All{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -92,9 +98,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetRandomName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, null, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -55,9 +55,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}All{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -92,9 +98,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetRandomName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, null, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -62,9 +62,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}All";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, GenerationFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, GenerationFixture.GetDefaultName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -83,9 +89,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{ShortProjectType(projectType)}AllRandom";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, GenerationFixture.GetRandomName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, GenerationFixture.GetRandomName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildTemplatesTestFixture.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildTemplatesTestFixture.cs
@@ -88,50 +88,11 @@ namespace Microsoft.Templates.Test
             return result;
         }
 
-        public static IEnumerable<object[]> GetPageAndFeatureTemplates(string frameworkFilter)
+        public static IEnumerable<object[]> GetPageAndFeatureTemplatesForBuild(string frameworkFilter)
         {
             InitializeTemplates(new LocalTemplatesSource(ShortFrameworkName(frameworkFilter)));
 
-            List<object[]> result = new List<object[]>();
-            foreach (var language in ProgrammingLanguages.GetAllLanguages())
-            {
-                SetCurrentLanguage(language);
-                foreach (var platform in Platforms.GetAllPlatforms())
-                {
-                    SetCurrentPlatform(platform);
-                    var templateProjectTypes = GenComposer.GetSupportedProjectTypes(platform);
-
-                    var projectTypes = GenContext.ToolBox.Repo.GetProjectTypes(platform)
-                                .Where(m => templateProjectTypes.Contains(m.Name) && !string.IsNullOrEmpty(m.Description))
-                                .Select(m => m.Name);
-
-                    foreach (var projectType in projectTypes)
-                    {
-                        var projectFrameworks = GenComposer.GetSupportedFx(projectType, platform);
-
-                        var targetFrameworks = GenContext.ToolBox.Repo.GetFrameworks(platform)
-                                                    .Where(m => projectFrameworks.Contains(m.Name) && m.Name == frameworkFilter)
-                                                    .Select(m => m.Name).ToList();
-
-                        foreach (var framework in targetFrameworks)
-                        {
-                            var itemTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetFrameworkList().Contains(framework)
-                                                                 && (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
-                                                                 && t.GetPlatform() == platform
-                                                                 && t.GetLanguage() == language
-                                                                 && !t.GetIsHidden());
-
-                            foreach (var itemTemplate in itemTemplates)
-                            {
-                                result.Add(new object[]
-                                    { itemTemplate.Name, projectType, framework, platform, itemTemplate.Identity, language });
-                            }
-                        }
-                    }
-                }
-            }
-
-            return result;
+            return BaseGenAndBuildFixture.GetPageAndFeatureTemplates(frameworkFilter);
         }
 
         [SuppressMessage(

--- a/code/test/Templates.Test/CodeAnalysis/SonarLintGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/SonarLintGenerationTestsFixture.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Templates.Test
          Justification = "Required for unit testing.")]
         private static void InitializeTemplates(TemplatesSource source)
         {
-            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.CSharp), ProgrammingLanguages.CSharp);
+            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.VisualBasic), ProgrammingLanguages.VisualBasic);
 
             if (!syncExecuted == true)
             {
@@ -54,23 +54,22 @@ namespace Microsoft.Templates.Test
 
             List<object[]> result = new List<object[]>();
 
-            foreach (var platform in Platforms.GetAllPlatforms())
+            var platform = Platforms.Uwp;
+
+            var projectTemplates =
+               GenContext.ToolBox.Repo.GetAll().Where(
+                   t => t.GetTemplateType() == TemplateType.Project
+                    && t.GetLanguage() == ProgrammingLanguages.VisualBasic);
+
+            foreach (var projectTemplate in projectTemplates)
             {
-                var templateProjectTypes = GenComposer.GetSupportedProjectTypes(platform);
+                var projectTypeList = projectTemplate.GetProjectTypeList();
 
-                var projectTypes = GenContext.ToolBox.Repo.GetProjectTypes(platform)
-                            .Where(m => templateProjectTypes.Contains(m.Name) && !string.IsNullOrEmpty(m.Description))
-                            .Select(m => m.Name);
-
-                foreach (var projectType in projectTypes)
+                foreach (var projectType in projectTypeList)
                 {
-                    var projectFrameworks = GenComposer.GetSupportedFx(projectType, platform);
+                    var frameworks = GenComposer.GetSupportedFx(projectType, platform);
 
-                    var targetFrameworks = GenContext.ToolBox.Repo.GetFrameworks(platform)
-                                                .Where(m => projectFrameworks.Contains(m.Name))
-                                                .Select(m => m.Name).ToList();
-
-                    foreach (var framework in targetFrameworks)
+                    foreach (var framework in frameworks)
                     {
                         result.Add(new object[] { projectType, framework, platform });
                     }

--- a/code/test/Templates.Test/CodeAnalysis/SonarLintGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/SonarLintGenerationTestsFixture.cs
@@ -4,15 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
-using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.Templates.Core;
 using Microsoft.Templates.Core.Gen;
 using Microsoft.Templates.Core.Locations;
@@ -21,52 +16,43 @@ using Microsoft.Templates.UI;
 
 namespace Microsoft.Templates.Test
 {
-    public sealed class SonarLintGenerationTestsFixture : IDisposable
+    public sealed class SonarLintGenerationTestsFixture : BaseGenAndBuildFixture, IDisposable
     {
-        private const string Platform = "x86";
-        private const string Configuration = "Debug";
-        private List<string> _usedNames = new List<string>();
+        private string _testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
 
-        internal string TestRunPath = $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SC{DateTime.Now.FormatAsDateHoursMinutes()}\\";
+        private static bool syncExecuted = false;
 
-        internal string TestProjectsPath => Path.GetFullPath(Path.Combine(TestRunPath, "Proj"));
+        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SL{_testExecutionTimeStamp}\\";
 
-        public static IEnumerable<ITemplateInfo> Templates;
+        public TemplatesSource Source => new LocalTemplatesSource("SonarLint");
 
-        private static async Task InitializeTemplatesAsync(TemplatesSource source)
+        [SuppressMessage(
+         "Usage",
+         "VSTHRD002:Synchronously waiting on tasks or awaiters may cause deadlocks",
+         Justification = "Required for unit testing.")]
+        private static void InitializeTemplates(TemplatesSource source)
         {
-            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.VisualBasic), ProgrammingLanguages.VisualBasic);
-            if (Templates == null)
+            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.CSharp), ProgrammingLanguages.CSharp);
+
+            if (!syncExecuted == true)
             {
-                await GenContext.ToolBox.Repo.SynchronizeAsync(true);
-                Templates = GenContext.ToolBox.Repo.GetAll();
+                GenContext.ToolBox.Repo.SynchronizeAsync(true).Wait();
+                syncExecuted = true;
             }
         }
 
-        public async Task InitializeFixtureAsync(IContextProvider contextProvider)
+        public override void InitializeFixture(IContextProvider contextProvider, string framework = "")
         {
-            var source = new LocalTemplatesSource("SonarLint");
             GenContext.Current = contextProvider;
 
-            await InitializeTemplatesAsync(source);
+            InitializeTemplates(Source);
         }
 
-        public void Dispose()
+        public static IEnumerable<object[]> GetProjectTemplatesForSonarLint()
         {
-            if (Directory.Exists(TestRunPath))
-            {
-                if (!Directory.Exists(TestProjectsPath)
-                 || !Directory.EnumerateDirectories(TestProjectsPath).Any())
-                {
-                    Directory.Delete(TestRunPath, true);
-                }
-            }
-        }
+            InitializeTemplates(new LocalTemplatesSource("SonarLint"));
 
-        public static async Task<IEnumerable<object[]>> GetProjectTemplatesForSonarLintAsync()
-        {
             List<object[]> result = new List<object[]>();
-            await InitializeTemplatesAsync(new LocalTemplatesSource("SonarLint"));
 
             foreach (var platform in Platforms.GetAllPlatforms())
             {
@@ -92,117 +78,6 @@ namespace Microsoft.Templates.Test
             }
 
             return result;
-        }
-
-        public void AddItems(UserSelection userSelection, IEnumerable<ITemplateInfo> templates, Func<ITemplateInfo, string> getName)
-        {
-            foreach (var template in templates)
-            {
-                if (template.GetMultipleInstance() || !AlreadyAdded(userSelection, template))
-                {
-                    var itemName = getName(template);
-
-                    var validators = new List<Validator>()
-                    {
-                        new ExistingNamesValidator(_usedNames),
-                        new ReservedNamesValidator(),
-                    };
-                    if (template.GetItemNameEditable())
-                    {
-                        validators.Add(new DefaultNamesValidator());
-                    }
-
-                    itemName = Naming.Infer(itemName, validators);
-                    AddItem(userSelection, itemName, template);
-                }
-            }
-        }
-
-        public void AddItem(UserSelection userSelection, string itemName, ITemplateInfo template)
-        {
-            switch (template.GetTemplateType())
-            {
-                case TemplateType.Page:
-                    userSelection.Pages.Add((itemName, template));
-                    break;
-                case TemplateType.Feature:
-                    userSelection.Features.Add((itemName, template));
-                    break;
-            }
-
-            _usedNames.Add(itemName);
-
-            var dependencies = GenComposer.GetAllDependencies(template, userSelection.Framework, userSelection.Platform);
-
-            foreach (var item in dependencies)
-            {
-                if (!AlreadyAdded(userSelection, item))
-                {
-                    AddItem(userSelection, item.GetDefaultName(), item);
-                }
-            }
-        }
-
-        [SuppressMessage("StyleCop", "SA1008", Justification = "StyleCop doesn't understand C#7 tuple return types yet.")]
-        public (int exitCode, string outputFile) BuildSolution(string solutionName, string outputPath)
-        {
-            var outputFile = Path.Combine(outputPath, $"_buildOutput_{solutionName}.txt");
-
-            // Build
-            var solutionFile = Path.GetFullPath(outputPath + @"\" + solutionName + ".sln");
-            var startInfo = new ProcessStartInfo(GetPath("RestoreAndBuild.bat"))
-            {
-                Arguments = $"\"{solutionFile}\" {Platform} {Configuration}",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                CreateNoWindow = false,
-                WorkingDirectory = outputPath
-            };
-
-            var process = Process.Start(startInfo);
-
-            File.WriteAllText(outputFile, process.StandardOutput.ReadToEnd());
-
-            process.WaitForExit();
-
-            return (process.ExitCode, outputFile);
-        }
-
-        public string GetErrorLines(string filePath)
-        {
-            var re = new Regex(@"^.*error .*$", RegexOptions.Multiline & RegexOptions.IgnoreCase);
-            var outputLines = File.ReadAllLines(filePath);
-            var errorLines = outputLines.Where(l => re.IsMatch(l));
-
-            return errorLines.Any() ? errorLines.Aggregate((i, j) => i + Environment.NewLine + j) : string.Empty;
-        }
-
-        public string GetDefaultName(ITemplateInfo template)
-        {
-            return template.GetDefaultName();
-        }
-
-        private static string GetPath(string fileName)
-        {
-            var path = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, fileName);
-
-            if (!File.Exists(path))
-            {
-                path = Path.GetFullPath($@".\{fileName}");
-
-                if (!File.Exists(path))
-                {
-                    throw new ApplicationException($"Can not find {fileName}");
-                }
-            }
-
-            return path;
-        }
-
-        private static bool AlreadyAdded(UserSelection userSelection, ITemplateInfo item)
-        {
-            return userSelection.Pages.Any(p => p.template.Identity == item.Identity)
-                || userSelection.Features.Any(f => f.template.Identity == item.Identity);
         }
     }
 }

--- a/code/test/Templates.Test/CodeAnalysis/SonarLintGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/SonarLintGenerationTestsFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Templates.Test
 
         private static bool syncExecuted = false;
 
-        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SL{_testExecutionTimeStamp}\\";
+        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SL\\{_testExecutionTimeStamp}\\";
 
         public TemplatesSource Source => new LocalTemplatesSource("SonarLint");
 

--- a/code/test/Templates.Test/CodeAnalysis/SonarLintProjectGenerationTests.cs
+++ b/code/test/Templates.Test/CodeAnalysis/SonarLintProjectGenerationTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{projectType}{framework}AllSonarLint";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, ProgrammingLanguages.CSharp, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/CodeAnalysis/SonarLintProjectGenerationTests.cs
+++ b/code/test/Templates.Test/CodeAnalysis/SonarLintProjectGenerationTests.cs
@@ -17,89 +17,43 @@ namespace Microsoft.Templates.Test
 {
     [Collection("SonarLintCollection")]
     [Trait("ExecutionSet", "BuildVBStyle")]
-    public class SonarLintProjectGenerationTests : BaseTestContextProvider
+    public class SonarLintProjectGenerationTests : BaseGenAndBuildTests
     {
-        private readonly SonarLintGenerationTestsFixture _fixture;
-
         public SonarLintProjectGenerationTests(SonarLintGenerationTestsFixture fixture)
         {
             _fixture = fixture;
-        }
-
-        private async Task SetUpFixtureForTestingAsync()
-        {
-            await _fixture.InitializeFixtureAsync(this);
+            _fixture.InitializeFixture(this);
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForSonarLintAsync")]
+        [MemberData("GetProjectTemplatesForSonarLint")]
         [Trait("Type", "CodeStyle")]
         public async Task GenerateAllPagesAndFeaturesAndCheckWithSonarLintAsync(string projectType, string framework, string platform)
         {
-             await SetUpFixtureForTestingAsync();
+            Func<ITemplateInfo, bool> selector =
+                    t => t.GetTemplateType() == TemplateType.Project
+                    && t.GetLanguage() == ProgrammingLanguages.VisualBasic
+                    && t.GetPlatform() == platform
+                    && t.GetProjectTypeList().Contains(projectType)
+                    && t.GetFrameworkList().Contains(framework);
 
-            var targetProjectTemplate = SonarLintGenerationTestsFixture.Templates
-                .FirstOrDefault(t => t.GetTemplateType() == TemplateType.Project
-                                  && t.GetLanguage() == ProgrammingLanguages.VisualBasic
-                                  && t.GetProjectTypeList().Contains(projectType)
-                                  && t.GetFrameworkList().Contains(framework));
+            Func<ITemplateInfo, bool> templateSelector =
+                t => ((t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                        && t.GetFrameworkList().Contains(framework)
+                        && t.GetPlatform() == platform
+                        && !t.GetIsHidden())
+                     || (t.Name == "Feature.Testing.SonarLint.VB");
 
             var projectName = $"{projectType}{framework}AllSonarLint";
 
-            ProjectName = projectName;
-            DestinationPath = Path.Combine(_fixture.TestProjectsPath, projectName, projectName);
-            OutputPath = DestinationPath;
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, ProgrammingLanguages.CSharp, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
-            var userSelection = new UserSelection(projectType, framework, platform, ProgrammingLanguages.VisualBasic)
-            {
-                HomeName = "Main"
-            };
-
-            AddLayoutItems(userSelection);
-            _fixture.AddItems(userSelection, GetTemplates(framework, TemplateType.Page), _fixture.GetDefaultName);
-            _fixture.AddItems(userSelection, GetTemplates(framework, TemplateType.Feature), _fixture.GetDefaultName);
-
-            var x = SonarLintGenerationTestsFixture.Templates.First(t => t.Name == "Feature.Testing.SonarLint.VB");
-
-            _fixture.AddItem(userSelection, "SonarLintTesting", x);
-
-            await NewProjectGenController.Instance.UnsafeGenerateProjectAsync(userSelection);
-
-            // Build solution
-            var outputPath = Path.Combine(_fixture.TestProjectsPath, projectName);
-            var result = _fixture.BuildSolution(projectName, outputPath);
-
-            // Assert
-            Assert.True(result.exitCode.Equals(0), $"Solution {targetProjectTemplate.Name} was not built successfully. {Environment.NewLine}Errors found: {_fixture.GetErrorLines(result.outputFile)}.{Environment.NewLine}Please see {Path.GetFullPath(result.outputFile)} for more details.");
-
-            // Clean
-            Fs.SafeDeleteDirectory(outputPath);
+            AssertBuildProjectAsync(projectPath, projectName, platform);
         }
 
-        public static IEnumerable<object[]> GetProjectTemplatesForSonarLintAsync()
+        public static IEnumerable<object[]> GetProjectTemplatesForSonarLint()
         {
-            JoinableTaskContext context = new JoinableTaskContext();
-            JoinableTaskCollection tasks = context.CreateCollection();
-            context.CreateFactory(tasks);
-            var result = context.Factory.Run(() => SonarLintGenerationTestsFixture.GetProjectTemplatesForSonarLintAsync());
-            return result;
-        }
-
-        private IEnumerable<ITemplateInfo> GetTemplates(string framework, TemplateType templateType)
-        {
-            return SonarLintGenerationTestsFixture.Templates
-                                         .Where(t => t.GetFrameworkList().Contains(framework)
-                                                  && t.GetTemplateType() == templateType);
-        }
-
-        private void AddLayoutItems(UserSelection userSelection)
-        {
-            var layouts = GenComposer.GetLayoutTemplates(userSelection.ProjectType, userSelection.Framework, userSelection.Platform);
-
-            foreach (var item in layouts)
-            {
-                _fixture.AddItem(userSelection, item.Layout.Name, item.Template);
-            }
+            return SonarLintGenerationTestsFixture.GetProjectTemplatesForSonarLint();
         }
     }
 }

--- a/code/test/Templates.Test/CodeAnalysis/StyleCopGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/StyleCopGenerationTestsFixture.cs
@@ -21,52 +21,41 @@ using Microsoft.Templates.UI;
 
 namespace Microsoft.Templates.Test
 {
-    public sealed class StyleCopGenerationTestsFixture : IDisposable
+    public sealed class StyleCopGenerationTestsFixture : BaseGenAndBuildFixture, IDisposable
     {
-        private const string Platform = "x86";
-        private const string Configuration = "Debug";
-        private List<string> _usedNames = new List<string>();
+        private string _testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
 
-        internal string TestRunPath = $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SC{DateTime.Now.FormatAsDateHoursMinutes()}\\";
+        private static bool syncExecuted = false;
 
-        internal string TestProjectsPath => Path.GetFullPath(Path.Combine(TestRunPath, "Proj"));
+        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SC{_testExecutionTimeStamp}\\";
 
-        public static IEnumerable<ITemplateInfo> Templates;
+        public TemplatesSource Source => new LocalTemplatesSource("StyleCop");
 
-        private static async Task InitializeTemplatesAsync(TemplatesSource source)
+        [SuppressMessage(
+         "Usage",
+         "VSTHRD002:Synchronously waiting on tasks or awaiters may cause deadlocks",
+         Justification = "Required for unit testing.")]
+        private static void InitializeTemplates(TemplatesSource source)
         {
             GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.CSharp), ProgrammingLanguages.CSharp);
-            if (Templates == null)
-            {
-                await GenContext.ToolBox.Repo.SynchronizeAsync(true);
 
-                Templates = GenContext.ToolBox.Repo.GetAll();
+            if (!syncExecuted == true)
+            {
+                GenContext.ToolBox.Repo.SynchronizeAsync(true).Wait();
+                syncExecuted = true;
             }
         }
 
-        public async Task InitializeFixtureAsync(IContextProvider contextProvider)
+        public override void InitializeFixture(IContextProvider contextProvider, string framework = "")
         {
-            var source = new LocalTemplatesSource("StyleCop");
             GenContext.Current = contextProvider;
 
-            await InitializeTemplatesAsync(source);
+            InitializeTemplates(Source);
         }
 
-        public void Dispose()
+        public static IEnumerable<object[]> GetProjectTemplatesForStyleCop()
         {
-            if (Directory.Exists(TestRunPath))
-            {
-                if (!Directory.Exists(TestProjectsPath)
-                 || !Directory.EnumerateDirectories(TestProjectsPath).Any())
-                {
-                    Directory.Delete(TestRunPath, true);
-                }
-            }
-        }
-
-        public static async Task<IEnumerable<object[]>> GetProjectTemplatesForStyleCopAsync()
-        {
-            await InitializeTemplatesAsync(new LocalTemplatesSource("StyleCop"));
+            InitializeTemplates(new LocalTemplatesSource("StyleCop"));
 
             List<object[]> result = new List<object[]>();
 
@@ -93,117 +82,6 @@ namespace Microsoft.Templates.Test
             }
 
             return result;
-        }
-
-        public void AddItems(UserSelection userSelection, IEnumerable<ITemplateInfo> templates, Func<ITemplateInfo, string> getName)
-        {
-            foreach (var template in templates)
-            {
-                if (template.GetMultipleInstance() || !AlreadyAdded(userSelection, template))
-                {
-                    var itemName = getName(template);
-
-                    var validators = new List<Validator>()
-                    {
-                        new ExistingNamesValidator(_usedNames),
-                        new ReservedNamesValidator(),
-                    };
-                    if (template.GetItemNameEditable())
-                    {
-                        validators.Add(new DefaultNamesValidator());
-                    }
-
-                    itemName = Naming.Infer(itemName, validators);
-                    AddItem(userSelection, itemName, template);
-                }
-            }
-        }
-
-        public void AddItem(UserSelection userSelection, string itemName, ITemplateInfo template)
-        {
-            switch (template.GetTemplateType())
-            {
-                case TemplateType.Page:
-                    userSelection.Pages.Add((itemName, template));
-                    break;
-                case TemplateType.Feature:
-                    userSelection.Features.Add((itemName, template));
-                    break;
-            }
-
-            _usedNames.Add(itemName);
-
-            var dependencies = GenComposer.GetAllDependencies(template, userSelection.Framework, userSelection.Platform);
-
-            foreach (var item in dependencies)
-            {
-                if (!AlreadyAdded(userSelection, item))
-                {
-                    AddItem(userSelection, item.GetDefaultName(), item);
-                }
-            }
-        }
-
-        [SuppressMessage("StyleCop", "SA1008", Justification = "StyleCop doesn't understand C#7 tuple return types yet.")]
-        public (int exitCode, string outputFile) BuildSolution(string solutionName, string outputPath)
-        {
-            var outputFile = Path.Combine(outputPath, $"_buildOutput_{solutionName}.txt");
-
-            // Build
-            var solutionFile = Path.GetFullPath(outputPath + @"\" + solutionName + ".sln");
-            var startInfo = new ProcessStartInfo(GetPath("RestoreAndBuild.bat"))
-            {
-                Arguments = $"\"{solutionFile}\" {Platform} {Configuration}",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                CreateNoWindow = false,
-                WorkingDirectory = outputPath
-            };
-
-            var process = Process.Start(startInfo);
-
-            File.WriteAllText(outputFile, process.StandardOutput.ReadToEnd());
-
-            process.WaitForExit();
-
-            return (process.ExitCode, outputFile);
-        }
-
-        public string GetErrorLines(string filePath)
-        {
-            var re = new Regex(@"^.*error .*$", RegexOptions.Multiline & RegexOptions.IgnoreCase);
-            var outputLines = File.ReadAllLines(filePath);
-            var errorLines = outputLines.Where(l => re.IsMatch(l));
-
-            return errorLines.Any() ? errorLines.Aggregate((i, j) => i + Environment.NewLine + j) : string.Empty;
-        }
-
-        public string GetDefaultName(ITemplateInfo template)
-        {
-            return template.GetDefaultName();
-        }
-
-        private static string GetPath(string fileName)
-        {
-            var path = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, fileName);
-
-            if (!File.Exists(path))
-            {
-                path = Path.GetFullPath($@".\{fileName}");
-
-                if (!File.Exists(path))
-                {
-                    throw new ApplicationException($"Can not find {fileName}");
-                }
-            }
-
-            return path;
-        }
-
-        private static bool AlreadyAdded(UserSelection userSelection, ITemplateInfo item)
-        {
-            return userSelection.Pages.Any(p => p.template.Identity == item.Identity)
-                || userSelection.Features.Any(f => f.template.Identity == item.Identity);
         }
     }
 }

--- a/code/test/Templates.Test/CodeAnalysis/StyleCopGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/StyleCopGenerationTestsFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Templates.Test
 
         private static bool syncExecuted = false;
 
-        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SC{_testExecutionTimeStamp}\\";
+        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\SC\\{_testExecutionTimeStamp}\\";
 
         public TemplatesSource Source => new LocalTemplatesSource("StyleCop");
 

--- a/code/test/Templates.Test/CodeAnalysis/VBStyleGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/VBStyleGenerationTestsFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Templates.Test
 
         private static bool syncExecuted = false;
 
-        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\VBSA{_testExecutionTimeStamp}\\";
+        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\VBSA\\{_testExecutionTimeStamp}\\";
 
         public TemplatesSource Source => new LocalTemplatesSource("VBStyle");
 

--- a/code/test/Templates.Test/CodeAnalysis/VBStyleGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/VBStyleGenerationTestsFixture.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test
    Justification = "Required for unit testing.")]
         private static void InitializeTemplates(TemplatesSource source)
         {
-            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.CSharp), ProgrammingLanguages.CSharp);
+            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.VisualBasic), ProgrammingLanguages.VisualBasic);
 
             if (!syncExecuted == true)
             {
@@ -53,17 +53,18 @@ namespace Microsoft.Templates.Test
             InitializeTemplates(Source);
         }
 
-        public static IEnumerable<object[]> GetProjectTemplatesForVBStyleAsync()
+        public static IEnumerable<object[]> GetProjectTemplatesForVBStyle()
         {
             InitializeTemplates(new LocalTemplatesSource("VBStyle"));
 
             List<object[]> result = new List<object[]>();
 
             var platform = Platforms.Uwp;
+
             var projectTemplates =
-                GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
-                                                             && t.GetLanguage() == ProgrammingLanguages.VisualBasic
-                                                             && t.Name != "Feature.Testing.VBStyleAnalysis");
+               GenContext.ToolBox.Repo.GetAll().Where(
+                   t => t.GetTemplateType() == TemplateType.Project
+                    && t.GetLanguage() == ProgrammingLanguages.VisualBasic);
 
             foreach (var projectTemplate in projectTemplates)
             {

--- a/code/test/Templates.Test/CodeAnalysis/VBStyleGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/VBStyleGenerationTestsFixture.cs
@@ -21,57 +21,47 @@ using Microsoft.Templates.UI;
 
 namespace Microsoft.Templates.Test
 {
-    public sealed class VBStyleGenerationTestsFixture : IDisposable
+    public sealed class VBStyleGenerationTestsFixture : BaseGenAndBuildFixture, IDisposable
     {
-        private const string Platform = "x86";
-        private const string Configuration = "Debug";
-        private List<string> _usedNames = new List<string>();
+        private string _testExecutionTimeStamp = DateTime.Now.FormatAsDateHoursMinutes();
 
-        internal string TestRunPath = $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\VBSA{DateTime.Now.FormatAsDateHoursMinutes()}\\";
+        private static bool syncExecuted = false;
 
-        internal string TestProjectsPath => Path.GetFullPath(Path.Combine(TestRunPath, "Proj"));
+        public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\VBSA{_testExecutionTimeStamp}\\";
 
-        public static IEnumerable<ITemplateInfo> Templates;
+        public TemplatesSource Source => new LocalTemplatesSource("VBStyle");
 
-        private static async Task InitializeTemplatesForLanguageAsync(TemplatesSource source)
+        [SuppressMessage(
+   "Usage",
+   "VSTHRD002:Synchronously waiting on tasks or awaiters may cause deadlocks",
+   Justification = "Required for unit testing.")]
+        private static void InitializeTemplates(TemplatesSource source)
         {
-            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.VisualBasic), ProgrammingLanguages.VisualBasic);
-            if (Templates == null)
-            {
-                await GenContext.ToolBox.Repo.SynchronizeAsync(true);
+            GenContext.Bootstrap(source, new FakeGenShell(Platforms.Uwp, ProgrammingLanguages.CSharp), ProgrammingLanguages.CSharp);
 
-                Templates = GenContext.ToolBox.Repo.GetAll();
+            if (!syncExecuted == true)
+            {
+                GenContext.ToolBox.Repo.SynchronizeAsync(true).Wait();
+                syncExecuted = true;
             }
         }
 
-        public async Task InitializeFixtureAsync(IContextProvider contextProvider)
+        public override void InitializeFixture(IContextProvider contextProvider, string framework = "")
         {
-            var source = new LocalTemplatesSource("VBStyle");
             GenContext.Current = contextProvider;
 
-            await InitializeTemplatesForLanguageAsync(source);
+            InitializeTemplates(Source);
         }
 
-        public void Dispose()
+        public static IEnumerable<object[]> GetProjectTemplatesForVBStyleAsync()
         {
-            if (Directory.Exists(TestRunPath))
-            {
-                if (!Directory.Exists(TestProjectsPath)
-                 || !Directory.EnumerateDirectories(TestProjectsPath).Any())
-                {
-                    Directory.Delete(TestRunPath, true);
-                }
-            }
-        }
+            InitializeTemplates(new LocalTemplatesSource("VBStyle"));
 
-        public static async Task<IEnumerable<object[]>> GetProjectTemplatesForVBStyleAsync()
-        {
             List<object[]> result = new List<object[]>();
-            await InitializeTemplatesForLanguageAsync(new LocalTemplatesSource("VBStyle"));
 
             var platform = Platforms.Uwp;
             var projectTemplates =
-                VBStyleGenerationTestsFixture.Templates.Where(t => t.GetTemplateType() == TemplateType.Project
+                GenContext.ToolBox.Repo.GetAll().Where(t => t.GetTemplateType() == TemplateType.Project
                                                              && t.GetLanguage() == ProgrammingLanguages.VisualBasic
                                                              && t.Name != "Feature.Testing.VBStyleAnalysis");
 
@@ -91,117 +81,6 @@ namespace Microsoft.Templates.Test
             }
 
             return result;
-        }
-
-        public void AddItems(UserSelection userSelection, IEnumerable<ITemplateInfo> templates, Func<ITemplateInfo, string> getName)
-        {
-            foreach (var template in templates)
-            {
-                if (template.GetMultipleInstance() || !AlreadyAdded(userSelection, template))
-                {
-                    var itemName = getName(template);
-
-                    var validators = new List<Validator>
-                    {
-                        new ExistingNamesValidator(_usedNames),
-                        new ReservedNamesValidator(),
-                    };
-                    if (template.GetItemNameEditable())
-                    {
-                        validators.Add(new DefaultNamesValidator());
-                    }
-
-                    itemName = Naming.Infer(itemName, validators);
-                    AddItem(userSelection, itemName, template);
-                }
-            }
-        }
-
-        public void AddItem(UserSelection userSelection, string itemName, ITemplateInfo template)
-        {
-            switch (template.GetTemplateType())
-            {
-                case TemplateType.Page:
-                    userSelection.Pages.Add((itemName, template));
-                    break;
-                case TemplateType.Feature:
-                    userSelection.Features.Add((itemName, template));
-                    break;
-            }
-
-            _usedNames.Add(itemName);
-
-            var dependencies = GenComposer.GetAllDependencies(template, userSelection.Framework, userSelection.Platform);
-
-            foreach (var item in dependencies)
-            {
-                if (!AlreadyAdded(userSelection, item))
-                {
-                    AddItem(userSelection, item.GetDefaultName(), item);
-                }
-            }
-        }
-
-        [SuppressMessage("StyleCop", "SA1008", Justification = "StyleCop doesn't understand C#7 tuple return types yet.")]
-        public (int exitCode, string outputFile) BuildSolution(string solutionName, string outputPath)
-        {
-            var outputFile = Path.Combine(outputPath, $"_buildOutput_{solutionName}.txt");
-
-            // Build
-            var solutionFile = Path.GetFullPath(outputPath + @"\" + solutionName + ".sln");
-            var startInfo = new ProcessStartInfo(GetPath("RestoreAndBuild.bat"))
-            {
-                Arguments = $"\"{solutionFile}\" {Platform} {Configuration}",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                CreateNoWindow = false,
-                WorkingDirectory = outputPath
-            };
-
-            var process = Process.Start(startInfo);
-
-            File.WriteAllText(outputFile, process.StandardOutput.ReadToEnd());
-
-            process.WaitForExit();
-
-            return (process.ExitCode, outputFile);
-        }
-
-        public string GetErrorLines(string filePath)
-        {
-            var re = new Regex(@"^.*error .*$", RegexOptions.Multiline & RegexOptions.IgnoreCase);
-            var outputLines = File.ReadAllLines(filePath);
-            var errorLines = outputLines.Where(l => re.IsMatch(l));
-
-            return errorLines.Any() ? errorLines.Aggregate((i, j) => i + Environment.NewLine + j) : string.Empty;
-        }
-
-        public string GetDefaultName(ITemplateInfo template)
-        {
-            return template.GetDefaultName();
-        }
-
-        private static string GetPath(string fileName)
-        {
-            var path = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, fileName);
-
-            if (!File.Exists(path))
-            {
-                path = Path.GetFullPath($@".\{fileName}");
-
-                if (!File.Exists(path))
-                {
-                    throw new ApplicationException($"Can not find {fileName}");
-                }
-            }
-
-            return path;
-        }
-
-        private static bool AlreadyAdded(UserSelection userSelection, ITemplateInfo item)
-        {
-            return userSelection.Pages.Any(p => p.template.Identity == item.Identity)
-                || userSelection.Features.Any(f => f.template.Identity == item.Identity);
         }
     }
 }

--- a/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
+++ b/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
@@ -17,18 +17,12 @@ namespace Microsoft.Templates.Test
 {
     [Collection("VBStyleCollection")]
     [Trait("ExecutionSet", "BuildVBStyle")]
-    public class VBStyleProjectGenerationTests : BaseTestContextProvider
+    public class VBStyleProjectGenerationTests : BaseGenAndBuildTests
     {
-        private readonly VBStyleGenerationTestsFixture _fixture;
-
         public VBStyleProjectGenerationTests(VBStyleGenerationTestsFixture fixture)
         {
             _fixture = fixture;
-        }
-
-        private async Task SetUpFixtureForTestingAsync()
-        {
-            await _fixture.InitializeFixtureAsync(this);
+            _fixture.InitializeFixture(this);
         }
 
         [Theory]
@@ -36,70 +30,30 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "CodeStyle")]
         public async Task GenerateAllPagesAndFeaturesAndCheckWithVBStyleAsync(string projectType, string framework, string platform)
         {
-            await SetUpFixtureForTestingAsync();
+            Func<ITemplateInfo, bool> selector =
+                               t => t.GetTemplateType() == TemplateType.Project
+                               && t.GetLanguage() == ProgrammingLanguages.VisualBasic
+                               && t.GetPlatform() == platform
+                               && t.GetProjectTypeList().Contains(projectType)
+                               && t.GetFrameworkList().Contains(framework);
 
-            var targetProjectTemplate = VBStyleGenerationTestsFixture.Templates
-                .FirstOrDefault(t => t.GetTemplateType() == TemplateType.Project
-                                  && t.GetLanguage() == ProgrammingLanguages.VisualBasic
-                                  && t.GetPlatform() == platform
-                                  && t.GetProjectTypeList().Contains(projectType)
-                                  && t.GetFrameworkList().Contains(framework));
+            Func<ITemplateInfo, bool> templateSelector =
+                t => ((t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                        && t.GetFrameworkList().Contains(framework)
+                        && t.GetPlatform() == platform
+                        && !t.GetIsHidden())
+                     || (t.Name == "Feature.Testing.VBStyleAnalysis");
 
             var projectName = $"{projectType}{framework}AllVBStyle";
 
-            ProjectName = projectName;
-            DestinationPath = Path.Combine(_fixture.TestProjectsPath, projectName, projectName);
-            OutputPath = DestinationPath;
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, ProgrammingLanguages.CSharp, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
-            var userSelection = new UserSelection(projectType, framework, platform, ProgrammingLanguages.VisualBasic)
-            {
-                HomeName = "Main"
-            };
-
-            AddLayoutItems(userSelection);
-            _fixture.AddItems(userSelection, GetTemplates(framework, platform, TemplateType.Page), _fixture.GetDefaultName);
-            _fixture.AddItems(userSelection, GetTemplates(framework, platform, TemplateType.Feature), _fixture.GetDefaultName);
-
-            var x = VBStyleGenerationTestsFixture.Templates.First(t => t.Name == "Feature.Testing.VBStyleAnalysis");
-
-            _fixture.AddItem(userSelection, "VBStyleTesting", x);
-
-            await NewProjectGenController.Instance.UnsafeGenerateProjectAsync(userSelection);
-
-            // Build solution
-            var outputPath = Path.Combine(_fixture.TestProjectsPath, projectName);
-            var result = _fixture.BuildSolution(projectName, outputPath);
-
-            Assert.True(result.exitCode.Equals(0), $"Solution {targetProjectTemplate.Name} was not built successfully. {Environment.NewLine}Errors found: {_fixture.GetErrorLines(result.outputFile)}.{Environment.NewLine}Please see {Path.GetFullPath(result.outputFile)} for more details.");
-
-            // Clean
-            Fs.SafeDeleteDirectory(outputPath);
+            AssertBuildProjectAsync(projectPath, projectName, platform);
         }
 
         public static IEnumerable<object[]> GetProjectTemplatesForVBStyleAsync()
         {
-            JoinableTaskContext context = new JoinableTaskContext();
-            JoinableTaskCollection tasks = context.CreateCollection();
-            context.CreateFactory(tasks);
-            var result = context.Factory.Run(() => VBStyleGenerationTestsFixture.GetProjectTemplatesForVBStyleAsync());
-            return result;
-        }
-
-        private IEnumerable<ITemplateInfo> GetTemplates(string framework, string platform, TemplateType templateType)
-        {
-            return VBStyleGenerationTestsFixture.Templates
-                                         .Where(t => t.GetFrameworkList().Contains(framework)
-                                                  && t.GetPlatform() == platform && t.GetTemplateType() == templateType);
-        }
-
-        private void AddLayoutItems(UserSelection userSelection)
-        {
-            var layouts = GenComposer.GetLayoutTemplates(userSelection.ProjectType, userSelection.Framework, userSelection.Platform);
-
-            foreach (var item in layouts)
-            {
-                _fixture.AddItem(userSelection, item.Layout.Name, item.Template);
-            }
+            return VBStyleGenerationTestsFixture.GetProjectTemplatesForVBStyleAsync();
         }
     }
 }

--- a/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
+++ b/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{projectType}{framework}AllVBStyle";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, ProgrammingLanguages.CSharp, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
+++ b/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData("GetProjectTemplatesForVBStyleAsync")]
+        [MemberData("GetProjectTemplatesForVBStyle")]
         [Trait("Type", "CodeStyle")]
         public async Task GenerateAllPagesAndFeaturesAndCheckWithVBStyleAsync(string projectType, string framework, string platform)
         {
@@ -51,9 +51,9 @@ namespace Microsoft.Templates.Test
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
 
-        public static IEnumerable<object[]> GetProjectTemplatesForVBStyleAsync()
+        public static IEnumerable<object[]> GetProjectTemplatesForVBStyle()
         {
-            return VBStyleGenerationTestsFixture.GetProjectTemplatesForVBStyleAsync();
+            return VBStyleGenerationTestsFixture.GetProjectTemplatesForVBStyle();
         }
     }
 }

--- a/code/test/Templates.Test/GenTests/GenProjectTests.cs
+++ b/code/test/Templates.Test/GenTests/GenProjectTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{projectType}{framework}";
 
-            string projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, false);
+            string projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, null, null, false);
 
             // Remove configuration from the manifest
             RemoveProjectConfigInfoFromProject();
@@ -117,9 +117,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{projectType}{framework}All";
 
-            await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetDefaultName);
+            await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
         }
 
         [Theory]
@@ -135,9 +141,15 @@ namespace Microsoft.Templates.Test
                     && !t.GetIsHidden()
                     && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{projectType}{framework}AllRandom";
 
-            await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, BaseGenAndBuildFixture.GetRandomName);
+            await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
         }
 
         [Theory]

--- a/code/test/Templates.Test/GenTests/GenerationFixture.cs
+++ b/code/test/Templates.Test/GenTests/GenerationFixture.cs
@@ -68,50 +68,11 @@ namespace Microsoft.Templates.Test
             return result;
         }
 
-        public static IEnumerable<object[]> GetPageAndFeatureTemplates(string frameworkFilter)
+        public static IEnumerable<object[]> GetPageAndFeatureTemplatesForGeneration(string frameworkFilter)
         {
             InitializeTemplates(new LocalTemplatesSource("TestGen"));
-            List<object[]> result = new List<object[]>();
 
-            foreach (var language in ProgrammingLanguages.GetAllLanguages())
-            {
-                SetCurrentLanguage(language);
-                foreach (var platform in Platforms.GetAllPlatforms())
-                {
-                    SetCurrentPlatform(platform);
-                    var templateProjectTypes = GenComposer.GetSupportedProjectTypes(platform);
-
-                    var projectTypes = GenContext.ToolBox.Repo.GetProjectTypes(platform)
-                                .Where(m => templateProjectTypes.Contains(m.Name) && !string.IsNullOrEmpty(m.Description))
-                                .Select(m => m.Name);
-
-                    foreach (var projectType in projectTypes)
-                    {
-                        var projectFrameworks = GenComposer.GetSupportedFx(projectType, platform);
-
-                        var targetFrameworks = GenContext.ToolBox.Repo.GetFrameworks(platform)
-                                                    .Where(m => projectFrameworks.Contains(m.Name) && m.Name == frameworkFilter)
-                                                    .Select(m => m.Name).ToList();
-
-                        foreach (var framework in targetFrameworks)
-                        {
-                            var itemTemplates = GenContext.ToolBox.Repo.GetAll().Where(t => t.GetFrameworkList().Contains(framework)
-                                                                 && (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
-                                                                 && t.GetPlatform() == platform
-                                                                 && t.GetLanguage() == language
-                                                                 && !t.GetIsHidden());
-
-                            foreach (var itemTemplate in itemTemplates)
-                            {
-                                result.Add(new object[]
-                                    { itemTemplate.Name, projectType, framework, platform, itemTemplate.Identity, language });
-                            }
-                        }
-                    }
-                }
-            }
-
-            return result;
+            return BaseGenAndBuildFixture.GetPageAndFeatureTemplates(frameworkFilter);
         }
 
         [SuppressMessage(

--- a/code/test/Templates.Test/WACK/WindowsAppCertKitTests.cs
+++ b/code/test/Templates.Test/WACK/WindowsAppCertKitTests.cs
@@ -41,9 +41,15 @@ namespace Microsoft.Templates.Test
                      && !t.GetIsHidden()
                      && t.GetLanguage() == language;
 
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && t.GetFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && !t.GetIsHidden();
+
             var projectName = $"{projectType}{framework}Wack{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, GenerationFixture.GetDefaultName, false);
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, GenerationFixture.GetDefaultName, false);
 
             // Replace the default assets in the generated project or they will cause WACK to fail
             foreach (var assetFile in new DirectoryInfo("./TestData/NonDefaultAssets").GetFiles("*.png"))

--- a/code/tools/WtsTelemetry/WtsTelemetry/WtsTelemetry.cs
+++ b/code/tools/WtsTelemetry/WtsTelemetry/WtsTelemetry.cs
@@ -20,7 +20,7 @@ namespace WtsTelemetry
 
         [FunctionName("WtsTelemetry")]
         public static void Run(
-            [TimerTrigger("0 0 9 * * MON")]TimerInfo myTimer,
+            [TimerTrigger("0 0 0 1 * *")]TimerInfo myTimer,
             TraceWriter log, 
             [SendGrid] out Mail message)
         {

--- a/code/tools/WtsTelemetry/WtsTelemetry/WtsTelemetry.cs
+++ b/code/tools/WtsTelemetry/WtsTelemetry/WtsTelemetry.cs
@@ -20,7 +20,7 @@ namespace WtsTelemetry
 
         [FunctionName("WtsTelemetry")]
         public static void Run(
-            [TimerTrigger("0 0 0 1 * *")]TimerInfo myTimer,
+            [TimerTrigger("0 0 9 * * MON")]TimerInfo myTimer,
             TraceWriter log, 
             [SendGrid] out Mail message)
         {


### PR DESCRIPTION
Quick summary of changes
Started to look at this, and eliminated the following code clones:
- Exact match in StyleCop/VB Style tests: Changed to use BaseGenAndBuildFixture and BaseGenAndBuildTest
- Exact match in Generation and BuildFixture: Created common method for 
	GetPageAndFeatureTemplates on BaseGenAndBuildFixture
- Added exception for two igual asserts in CompositionQueryTest

Which issue does this PR relate to?
- #933 Address code clone results