### PR TITLE
Update Nuget Reference AppCenter

### DIFF
--- a/templates/Uwp/Features/VSAppCenterAnalytics/_postaction.csproj
+++ b/templates/Uwp/Features/VSAppCenterAnalytics/_postaction.csproj
@@ -5,9 +5,9 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.AppCenter.Analytics">
-  <Version>1.7.0</Version>
+  <Version>1.9.0</Version>
 </PackageReference>
 <PackageReference Include="Microsoft.AppCenter.Crashes">
-  <Version>1.7.0</Version>
+  <Version>1.9.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Features/VSAppCenterAnalyticsVB/_postaction.vbproj
+++ b/templates/Uwp/Features/VSAppCenterAnalyticsVB/_postaction.vbproj
@@ -5,9 +5,9 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.AppCenter.Analytics">
-  <Version>1.7.0</Version>
+  <Version>1.9.0</Version>
 </PackageReference>
 <PackageReference Include="Microsoft.AppCenter.Crashes">
-  <Version>1.7.0</Version>
+  <Version>1.9.0</Version>
 </PackageReference>
 <!--}]}-->


### PR DESCRIPTION
Update AppCenter feature NuGet packages to the latest versions. #2510
Update Microsoft.AppCenter.Analytics and Microsoft.AppCenter.Crashes from 1.7.0 to 1.9.0