### PR TITLE
Analyze configuration should treat warnings as error

### DIFF
--- a/code/src/Core/Core.csproj
+++ b/code/src/Core/Core.csproj
@@ -47,6 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>..\..\WtsRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">


### PR DESCRIPTION
## PR checklist

Quick summary of changes
Add TreatWarningsAsError to Analyze configuration

- Which issue does this PR relate to?
#2520 Core project Analyze configuration is not reporting warnings 
  

