### PR TITLE
Initialize WindowManagerService on UI thread for Prism

### DIFF
--- a/templates/Uwp/_composition/Prism/Feature.MultiView/App.xaml_postaction.cs
+++ b/templates/Uwp/_composition/Prism/Feature.MultiView/App.xaml_postaction.cs
@@ -5,10 +5,11 @@
 protected override async Task OnInitializeAsync(IActivatedEventArgs args)
 {
     //{[{
-    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal,
-    () =>
-    {
-        WindowManagerService.Current.Initialize();
-    });
+    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
+        Windows.UI.Core.CoreDispatcherPriority.Normal,
+        () =>
+        {
+            WindowManagerService.Current.Initialize();
+        });
     //}]}
 }

--- a/templates/Uwp/_composition/Prism/Feature.MultiView/App.xaml_postaction.cs
+++ b/templates/Uwp/_composition/Prism/Feature.MultiView/App.xaml_postaction.cs
@@ -5,6 +5,10 @@
 protected override async Task OnInitializeAsync(IActivatedEventArgs args)
 {
     //{[{
-    WindowManagerService.Current.Initialize();
+    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal,
+    () =>
+    {
+        WindowManagerService.Current.Initialize();
+    });
     //}]}
 }


### PR DESCRIPTION
This PR ensures the WindowsManagerService can be initialized successfully regardless of the order is which the other feature templates are added to the OnInitializeAsync method.

## PR checklist

Quick summary of changes

- Which issue does this PR relate to?
This is related to issue #2533 

