### PR TITLE
Remove services namespace from prism project

### DIFF
--- a/templates/Uwp/Projects/DefaultPrism/App.xaml.cs
+++ b/templates/Uwp/Projects/DefaultPrism/App.xaml.cs
@@ -6,7 +6,6 @@ using Prism.Unity.Windows;
 using Prism.Windows.AppModel;
 using Windows.ApplicationModel.Resources;
 using Windows.UI.Xaml;
-using wts.DefaultProject.Services;
 
 namespace wts.DefaultProject
 {


### PR DESCRIPTION
Quick summary of changes
- Remove services namespace from prism project

Which issue does this PR relate to?
- #2576 Build v3.0.templates.tests.full_20180919.1 failed 

