### PR TITLE
Added support for VS 2019

### DIFF
--- a/code/src/Installer.2017/source.extension.vsixmanifest
+++ b/code/src/Installer.2017/source.extension.vsixmanifest
@@ -12,16 +12,15 @@
         <Tags>Windows Template Studio UWP XAML MVVM</Tags>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework 4.7 or higher" d:Source="Manual" Version="[4.7,)" d:InstallSource="Download" Location="http://go.microsoft.com/fwlink/?LinkId=825319" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0,16.0)" />
-        <Dependency d:Source="Installed" Version="[15.0.26730,16.0)" d:InstallSource="Download" Id="8EAF6C8E-1283-4EEE-AB6E-F0F087BFCBFD" DisplayName="Visual Studio 2017 Update 3 or higher" Location="https://www.visualstudio.com/downloads" />
+        <Dependency d:Source="Installed" Version="[15.0.26730,)" d:InstallSource="Download" Id="8EAF6C8E-1283-4EEE-AB6E-F0F087BFCBFD" DisplayName="Visual Studio 2017 Update 3 or higher" Location="https://www.visualstudio.com/downloads" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.UWP.Support" Version="[15.0,16.0)" DisplayName="Universal Windows Platform tools" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.UWP.Support" Version="[15.0,)" DisplayName="Universal Windows Platform tools" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="Core" Path="|Core|" AssemblyName="|Core;AssemblyName|" />


### PR DESCRIPTION
This adds support for Visual Studio 2019 by bumping the version range on both installation target and prerequisites. Removed dependency on MPF which is no longer needed.

Thanks,
Mads Kristensen
Visual Studio Extensibility

## PR checklist

Quick summary of changes

- Which issue does this PR relate to?
- Anything that requires particular review or attention?
- Do all automated tests pass?
- Have automated tests been added for new features?
- If you've changed the UI: 
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).
- If you've included a new template: 
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/Microsoft/WindowsTemplateStudio/wiki/Template-Verification-Checklist).
- Have you raised issues for any needed follow-on work?
- Have docs been updated?
- If breaking changes or different ways of doing things have been introduced, have they been communicated widely?
