### PR TITLE
Fix rightclick on legacy project tests.

### DIFF
--- a/code/src/Core/Locations/TemplatesSourceConfig.cs
+++ b/code/src/Core/Locations/TemplatesSourceConfig.cs
@@ -49,8 +49,10 @@ namespace Microsoft.Templates.Core.Locations
         public TemplatesPackageInfo ResolvePackage(Version v, string platform, string language)
         {
             TemplatesPackageInfo match = Versions
-                        .Where(p => p.Platform == platform && p.Language == language)
-                        .Where(p => p.WizardVersions.Any(wv => wv.Major == v.Major && wv.Minor == v.Minor))
+                        .Where(p => p.Platform == platform || p.Platform == null)
+                        .Where(p => p.Language == language || p.Language == null)
+                        .Where(p => (p.WizardVersions != null && p.WizardVersions.Any(wv => wv.Major == v.Major && wv.Minor == v.Minor))
+                                 || (p.WizardVersions == null && p.Version.Major == v.Major && p.Version.Minor == v.Minor))
                         .OrderByDescending(p => p.Date).FirstOrDefault();
 
             return match;

--- a/code/test/Core.Test/Locations/RemoteTemplateSourceTests.cs
+++ b/code/test/Core.Test/Locations/RemoteTemplateSourceTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Templates.Core.Test.Locations
             await rts.LoadConfigAsync(cts.Token);
             var package = rts.Config.Latest;
 
-            cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+            cts.CancelAfter(TimeSpan.FromMilliseconds(100));
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             {
                 await rts.AcquireAsync(package, cts.Token);

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Templates.Test
             var projectName = $"{projectType}{framework}Legacy";
 
             Func<ITemplateInfo, bool> selector =
-               t => t.GetTemplateType() == TemplateType.Project
-                   && t.GetProjectTypeList().Contains(projectType)
-                   && t.GetFrameworkList().Contains(framework)
-                   && !t.GetIsHidden()
-                   && t.GetLanguage() == language;
+            t => t.GetTemplateType() == TemplateType.Project
+               && t.GetProjectTypeList().Contains(projectType)
+               && t.GetFrameworkList().Contains(framework)
+               && !t.GetIsHidden()
+               && t.GetLanguage() == language;
 
             var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, Platforms.Uwp, language, null, null, false);
 

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSourceV2.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSourceV2.cs
@@ -30,7 +30,11 @@ namespace Microsoft.Templates.Test
         {
             await AcquireAsync(packageInfo, ct);
 
-            return await base.GetContentAsync(packageInfo, workingFolder, ct);
+            var templatecontent = await base.GetContentAsync(packageInfo, workingFolder, ct);
+            // Workaround for version 2.4, as templates contain "Templates" folder
+            await Fs.SafeMoveDirectoryAsync(Path.Combine(templatecontent.Path, "Templates"), templatecontent.Path);
+
+            return templatecontent;
         }
 
         private static string GetAgentName()

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSourceV2.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/LegacyTemplatesSourceV2.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Templates.Test
             await AcquireAsync(packageInfo, ct);
 
             var templatecontent = await base.GetContentAsync(packageInfo, workingFolder, ct);
+
             // Workaround for version 2.4, as templates contain "Templates" folder
             await Fs.SafeMoveDirectoryAsync(Path.Combine(templatecontent.Path, "Templates"), templatecontent.Path);
 


### PR DESCRIPTION
Quick summary of changes
Templates from version 2.4 are not splitted and contain an extra templates folder, added code to move templates to correct folder and resolve package based on version. 

- Which issue does this PR relate to?
#2681 dev.tests.full failed

