### PR TITLE
Changed download parameter name

### DIFF
--- a/code/tools/WtsTool/CommandOptions/RemoteSourceDownloadOptions.cs
+++ b/code/tools/WtsTool/CommandOptions/RemoteSourceDownloadOptions.cs
@@ -29,7 +29,7 @@ namespace WtsTool.CommandOptions
         [Option('p', "platform", Default = null, HelpText = "Download a concrete version of templates package for the specified environment, platform and language. Downloads the most recent matching version.", SetName = "Version")]
         public string Platform { get; set; }
 
-        [Option('l', "language", Default = null, HelpText = "Download a concrete version of templates package for the specified environment, platform and language. Downloads the most recent matching version.", SetName = "Version")]
+        [Option('s', "language", Default = null, HelpText = "Download a concrete version of templates package for the specified environment, platform and language. Downloads the most recent matching version.", SetName = "Version")]
         public string Language { get; set; }
     }
 }

--- a/code/tools/WtsTool/CommandOptions/RemoteSourceDownloadOptions.cs
+++ b/code/tools/WtsTool/CommandOptions/RemoteSourceDownloadOptions.cs
@@ -29,7 +29,7 @@ namespace WtsTool.CommandOptions
         [Option('p', "platform", Default = null, HelpText = "Download a concrete version of templates package for the specified environment, platform and language. Downloads the most recent matching version.", SetName = "Version")]
         public string Platform { get; set; }
 
-        [Option('s', "language", Default = null, HelpText = "Download a concrete version of templates package for the specified environment, platform and language. Downloads the most recent matching version.", SetName = "Version")]
+        [Option('s', "source-language", Default = null, HelpText = "Download a concrete version of templates package for the specified environment, platform and language. Downloads the most recent matching version.", SetName = "Version")]
         public string Language { get; set; }
     }
 }


### PR DESCRIPTION
## PR checklist
Quick summary of changes
-l was already used for latest, so had to use another letter
- Which issue does this PR relate to?
#1478 Split templates

