### PR TITLE
Check for equivalent exception handling in generated apps

### DIFF
--- a/code/test/Templates.Test/GenTests/LanguageComparisonTests.cs
+++ b/code/test/Templates.Test/GenTests/LanguageComparisonTests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Templates.Test
 
                 var csCode = new StreamReader(csFile).ReadToEnd();
                 var csTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(csCode);
-                var csRoot = (Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax) csTree.GetRoot();
+                var csRoot = (Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax)csTree.GetRoot();
                 var csExceptions = csRoot.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.CatchClauseSyntax>().Select(p => p.Declaration.Type.ToString()).ToList();
 
                 var vbCode = new StreamReader(vbFile).ReadToEnd();


### PR DESCRIPTION
For #2696

Adds test to check that C# & VB versions of the same code have the equivalent exception handling.