### PR TITLE
Update nugets and target platform version

### DIFF
--- a/templates/Uwp/Features/UserActivity.MVVMLight/_postaction.csproj
+++ b/templates/Uwp/Features/UserActivity.MVVMLight/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="AdaptiveCards">
-  <Version>1.0.3</Version>
+  <Version>1.1.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Features/UserActivity.MVVMLightVB/_postaction.vbproj
+++ b/templates/Uwp/Features/UserActivity.MVVMLightVB/_postaction.vbproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="AdaptiveCards">
-  <Version>1.0.3</Version>
+  <Version>1.1.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Features/UserActivity.Prism/_postaction.csproj
+++ b/templates/Uwp/Features/UserActivity.Prism/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="AdaptiveCards">
-  <Version>1.0.3</Version>
+  <Version>1.1.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Features/UserActivity/_postaction.csproj
+++ b/templates/Uwp/Features/UserActivity/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="AdaptiveCards">
-  <Version>1.0.3</Version>
+  <Version>1.1.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Features/UserActivityVB/_postaction.vbproj
+++ b/templates/Uwp/Features/UserActivityVB/_postaction.vbproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="AdaptiveCards">
-  <Version>1.0.3</Version>
+  <Version>1.1.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Features/VSAppCenterAnalytics/_postaction.csproj
+++ b/templates/Uwp/Features/VSAppCenterAnalytics/_postaction.csproj
@@ -5,9 +5,9 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.AppCenter.Analytics">
-  <Version>1.9.0</Version>
+  <Version>1.10.0</Version>
 </PackageReference>
 <PackageReference Include="Microsoft.AppCenter.Crashes">
-  <Version>1.9.0</Version>
+  <Version>1.10.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Features/VSAppCenterAnalyticsVB/_postaction.vbproj
+++ b/templates/Uwp/Features/VSAppCenterAnalyticsVB/_postaction.vbproj
@@ -5,9 +5,9 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.AppCenter.Analytics">
-  <Version>1.9.0</Version>
+  <Version>1.10.0</Version>
 </PackageReference>
 <PackageReference Include="Microsoft.AppCenter.Crashes">
-  <Version>1.9.0</Version>
+  <Version>1.10.0</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Chart.CodeBehind/_postaction.csproj
+++ b/templates/Uwp/Pages/Chart.CodeBehind/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Chart.CodeBehindVB/_postaction.vbproj
+++ b/templates/Uwp/Pages/Chart.CodeBehindVB/_postaction.vbproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Chart.Prism/_postaction.csproj
+++ b/templates/Uwp/Pages/Chart.Prism/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Chart/_postaction.csproj
+++ b/templates/Uwp/Pages/Chart/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/ChartVB/_postaction.vbproj
+++ b/templates/Uwp/Pages/ChartVB/_postaction.vbproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Grid.CodeBehind/_postaction.csproj
+++ b/templates/Uwp/Pages/Grid.CodeBehind/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Grid.CodeBehindVB/_postaction.vbproj
+++ b/templates/Uwp/Pages/Grid.CodeBehindVB/_postaction.vbproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Grid.Prism/_postaction.csproj
+++ b/templates/Uwp/Pages/Grid.Prism/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/Grid/_postaction.csproj
+++ b/templates/Uwp/Pages/Grid/_postaction.csproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Pages/GridVB/_postaction.vbproj
+++ b/templates/Uwp/Pages/GridVB/_postaction.vbproj
@@ -5,6 +5,6 @@
 <!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
-  <Version>1.0.1.1</Version>
+  <Version>1.0.1.2</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/Projects/Default/wts.DefaultProject.csproj
+++ b/templates/Uwp/Projects/Default/wts.DefaultProject.csproj
@@ -94,7 +94,7 @@
   </PropertyGroup>
   <ItemGroup>
 	  <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.7</Version>
+      <Version>6.1.9</Version>
     </PackageReference>
 	  <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>

--- a/templates/Uwp/Projects/Default/wts.DefaultProject.csproj
+++ b/templates/Uwp/Projects/Default/wts.DefaultProject.csproj
@@ -12,8 +12,8 @@
     <AssemblyName>wts.DefaultProject</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/templates/Uwp/Projects/DefaultPrism/wts.DefaultProject.csproj
+++ b/templates/Uwp/Projects/DefaultPrism/wts.DefaultProject.csproj
@@ -94,7 +94,7 @@
   </PropertyGroup>
   <ItemGroup>
 	  <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.7</Version>
+      <Version>6.1.9</Version>
     </PackageReference>
 	  <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>

--- a/templates/Uwp/Projects/DefaultPrism/wts.DefaultProject.csproj
+++ b/templates/Uwp/Projects/DefaultPrism/wts.DefaultProject.csproj
@@ -12,8 +12,8 @@
     <AssemblyName>wts.DefaultProject</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/templates/Uwp/Projects/DefaultVB/wts.DefaultProject.vbproj
+++ b/templates/Uwp/Projects/DefaultVB/wts.DefaultProject.vbproj
@@ -108,7 +108,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.7</Version>
+      <Version>6.1.9</Version>
     </PackageReference>
 	  <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>

--- a/templates/Uwp/Projects/DefaultVB/wts.DefaultProject.vbproj
+++ b/templates/Uwp/Projects/DefaultVB/wts.DefaultProject.vbproj
@@ -12,8 +12,8 @@
     <AssemblyName>wts.DefaultProject</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</ProjectTypeGuids>

--- a/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/App_postaction.xaml
+++ b/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/Views/ShellPage.xaml
@@ -13,7 +13,7 @@
     mc:Ignorable="d">
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/Views/ShellPage.xaml.cs
+++ b/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/Views/ShellPage.xaml.cs
@@ -23,7 +23,7 @@ namespace wts.ItemName.Views
 
         public NavigationView GetNavigationView()
         {
-            return winUiNavigationView;
+            return navigationView;
         }
     }
 }

--- a/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/_postaction.csproj
+++ b/templates/Uwp/_composition/CaliburnMicro/Project.SplitView/_postaction.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitView.Page.Settings/Views/ShellPage_postaction.xaml.cs
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitView.Page.Settings/Views/ShellPage_postaction.xaml.cs
@@ -11,7 +11,7 @@ namespace Param_ItemNamespace.Views
             //{[{
             if (e.SourcePageType == typeof(wts.ItemNamePage))
             {
-                Selected = winUiNavigationView.SettingsItem as WinUI.NavigationViewItem;
+                Selected = navigationView.SettingsItem as WinUI.NavigationViewItem;
                 return;
             }
 

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitView.Page.SettingsVB/Views/ShellPage_postaction.xaml.vb
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitView.Page.SettingsVB/Views/ShellPage_postaction.xaml.vb
@@ -11,7 +11,7 @@ Namespace Views
             IsBackEnabled = NavigationService.CanGoBack
             '{[{
             If e.SourcePageType = GetType(wts.ItemNamePage) Then
-                Selected = TryCast(winUiNavigationView.SettingsItem, WinUI.NavigationViewItem)
+                Selected = TryCast(navigationView.SettingsItem, WinUI.NavigationViewItem)
                 Return
             End If
 

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitView/App_postaction.xaml
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitView/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitView/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitView/Views/ShellPage.xaml
@@ -13,7 +13,7 @@
     mc:Ignorable="d">    
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitView/Views/ShellPage.xaml.cs
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitView/Views/ShellPage.xaml.cs
@@ -45,7 +45,7 @@ namespace wts.ItemName.Views
         {
             NavigationService.Frame = shellFrame;
             NavigationService.Navigated += Frame_Navigated;
-            winUiNavigationView.BackRequested += OnBackRequested;
+            navigationView.BackRequested += OnBackRequested;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
@@ -59,7 +59,7 @@ namespace wts.ItemName.Views
         private void Frame_Navigated(object sender, NavigationEventArgs e)
         {
             IsBackEnabled = NavigationService.CanGoBack;
-            Selected = winUiNavigationView.MenuItems
+            Selected = navigationView.MenuItems
                             .OfType<WinUI.NavigationViewItem>()
                             .FirstOrDefault(menuItem => IsMenuItemForPageType(menuItem, e.SourcePageType));
         }
@@ -72,7 +72,7 @@ namespace wts.ItemName.Views
 
         private void OnItemInvoked(WinUI.NavigationView sender, WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            var item = winUiNavigationView.MenuItems
+            var item = navigationView.MenuItems
                             .OfType<WinUI.NavigationViewItem>()
                             .First(menuItem => (string)menuItem.Content == (string)args.InvokedItem);
             var pageType = item.GetValue(NavHelper.NavigateToProperty) as Type;

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitView/_postaction.csproj
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitView/_postaction.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/App_postaction.xaml
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/Views/ShellPage.xaml
@@ -13,7 +13,7 @@
     mc:Ignorable="d">
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/Views/ShellPage.xaml.vb
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/Views/ShellPage.xaml.vb
@@ -47,7 +47,7 @@ Namespace Views
         Private Sub Initialize()
             NavigationService.Frame = shellFrame
             AddHandler NavigationService.Navigated, AddressOf Frame_Navigated
-            AddHandler winUiNavigationView.BackRequested, AddressOf OnBackRequested
+            AddHandler navigationView.BackRequested, AddressOf OnBackRequested
         End Sub
 
         Private Sub OnLoaded(sender As Object, e As RoutedEventArgs)
@@ -63,7 +63,7 @@ Namespace Views
 
         Private Sub Frame_Navigated(sender As Object, e As NavigationEventArgs)
             IsBackEnabled = NavigationService.CanGoBack
-            Selected = winUiNavigationView.MenuItems.OfType(Of WinUI.NavigationViewItem)().FirstOrDefault(Function(menuItem) IsMenuItemForPageType(menuItem, e.SourcePageType))
+            Selected = navigationView.MenuItems.OfType(Of WinUI.NavigationViewItem)().FirstOrDefault(Function(menuItem) IsMenuItemForPageType(menuItem, e.SourcePageType))
         End Sub
 
         Private Function IsMenuItemForPageType(menuItem As WinUI.NavigationViewItem, sourcePageType As Type) As Boolean
@@ -72,7 +72,7 @@ Namespace Views
         End Function
 
         Private Sub OnItemInvoked(sender As WinUI.NavigationView, args As WinUI.NavigationViewItemInvokedEventArgs)
-            Dim item = winUiNavigationView.MenuItems.OfType(Of WinUI.NavigationViewItem)().First(Function(menuItem) CStr(menuItem.Content) = CStr(args.InvokedItem))
+            Dim item = navigationView.MenuItems.OfType(Of WinUI.NavigationViewItem)().First(Function(menuItem) CStr(menuItem.Content) = CStr(args.InvokedItem))
             Dim pageType = TryCast(item.GetValue(NavHelper.NavigateToProperty), Type)
             NavigationService.Navigate(pageType)
         End Sub

--- a/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/_postaction.vbproj
+++ b/templates/Uwp/_composition/CodeBehind/Project.SplitViewVB/_postaction.vbproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitView/App_postaction.xaml
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitView/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitView/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitView/Views/ShellPage.xaml
@@ -19,7 +19,7 @@
     </i:Interaction.Behaviors>
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitView/Views/ShellPage.xaml.cs
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitView/Views/ShellPage.xaml.cs
@@ -13,7 +13,7 @@ namespace wts.ItemName.Views
         {
             InitializeComponent();
             DataContext = ViewModel;
-            ViewModel.Initialize(shellFrame, winUiNavigationView, KeyboardAccelerators);
+            ViewModel.Initialize(shellFrame, navigationView, KeyboardAccelerators);
         }
     }
 }

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitView/_postaction.csproj
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitView/_postaction.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/App_postaction.xaml
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/Views/ShellPage.xaml
@@ -19,7 +19,7 @@
     </i:Interaction.Behaviors>
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/Views/ShellPage.xaml.vb
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/Views/ShellPage.xaml.vb
@@ -10,7 +10,7 @@ Namespace Views
         Public Sub New()
             Me.InitializeComponent()
             DataContext = ViewModel
-            ViewModel.Initialize(shellFrame, winUiNavigationView, KeyboardAccelerators)
+            ViewModel.Initialize(shellFrame, navigationView, KeyboardAccelerators)
         End Sub
     End Class
 End Namespace

--- a/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/_postaction.vbproj
+++ b/templates/Uwp/_composition/MVVMBasic/Project.SplitViewVB/_postaction.vbproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView/App_postaction.xaml
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView/Views/ShellPage.xaml
@@ -18,7 +18,7 @@
     </i:Interaction.Behaviors>
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView/Views/ShellPage.xaml.cs
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView/Views/ShellPage.xaml.cs
@@ -18,7 +18,7 @@ namespace wts.ItemName.Views
         {
             InitializeComponent();
             DataContext = ViewModel;
-            ViewModel.Initialize(shellFrame, winUiNavigationView, KeyboardAccelerators);
+            ViewModel.Initialize(shellFrame, navigationView, KeyboardAccelerators);
         }
     }
 }

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView/_postaction.csproj
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView/_postaction.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/App_postaction.xaml
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/Views/ShellPage.xaml
@@ -18,7 +18,7 @@
     </i:Interaction.Behaviors>
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/Views/ShellPage.xaml.vb
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/Views/ShellPage.xaml.vb
@@ -14,7 +14,7 @@ Namespace Views
         Public Sub New()
             Me.InitializeComponent()
             DataContext = ViewModel
-            ViewModel.Initialize(shellFrame, winUiNavigationView, KeyboardAccelerators)
+            ViewModel.Initialize(shellFrame, navigationView, KeyboardAccelerators)
         End Sub
 
     End Class

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/_postaction.vbproj
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitViewVB/_postaction.vbproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMLight/Project/_postaction.csproj
+++ b/templates/Uwp/_composition/MVVMLight/Project/_postaction.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="MvvmLight">
-  <Version>5.4.1</Version>
+  <Version>5.4.1.1</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/MVVMLight/ProjectVB/_postaction.vbproj
+++ b/templates/Uwp/_composition/MVVMLight/ProjectVB/_postaction.vbproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="MvvmLight">
-  <Version>5.4.1</Version>
+  <Version>5.4.1.1</Version>
 </PackageReference>
 <!--}]}-->

--- a/templates/Uwp/_composition/Prism/Project.SplitView/App_postaction.xaml
+++ b/templates/Uwp/_composition/Prism/Project.SplitView/App_postaction.xaml
@@ -1,7 +1,6 @@
 ﻿    <prismUnity:PrismUnityApplication.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-<!--^^-->
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
 <!--}]}-->

--- a/templates/Uwp/_composition/Prism/Project.SplitView/Views/ShellPage.xaml
+++ b/templates/Uwp/_composition/Prism/Project.SplitView/Views/ShellPage.xaml
@@ -14,7 +14,7 @@
     mc:Ignorable="d">
 
     <winui:NavigationView
-        x:Name="winUiNavigationView"
+        x:Name="navigationView"
         IsBackButtonVisible="Visible"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"

--- a/templates/Uwp/_composition/Prism/Project.SplitView/Views/ShellPage.xaml.cs
+++ b/templates/Uwp/_composition/Prism/Project.SplitView/Views/ShellPage.xaml.cs
@@ -20,7 +20,7 @@ namespace wts.ItemName.Views
         {
             shellFrame.Content = frame;
             navigationViewHeaderBehavior.Initialize(frame);
-            ViewModel.Initialize(frame, winUiNavigationView);
+            ViewModel.Initialize(frame, navigationView);
         }
     }
 }

--- a/templates/Uwp/_composition/Prism/Project.SplitView/_postaction.csproj
+++ b/templates/Uwp/_composition/Prism/Project.SplitView/_postaction.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Nuget package references -->
 <!--{[{-->
 <PackageReference Include="Microsoft.UI.Xaml">
-  <Version>2.0.181011001</Version>
+  <Version>2.0.181018003</Version>
 </PackageReference>
 <!--}]}-->


### PR DESCRIPTION
Quick summary of changes

- Update to latest version from WinUI Library
- Set target platform version to 10.0.17763
- Set min target platform version to 10.0.17134

- Update the following nugets to latest version:
  - Microsoft.NETCore.UniversalWindowsPlatform 
  - Adaptive Cards
  - Microsoft.AppCenter.Analytics and Microsoft.AppCenter.Crashes 
  - Telerik.UI.for.UniversalWindowsPlatform 
  - MVVMLight 

Which issue does this PR relate to?

- #2488 Add navigation View
- #2719 Update nugets to latest version
