### PR TITLE
Workaround for issue on MasterDetail Control 

### DIFF
--- a/templates/Uwp/Pages/MasterDetail.CaliburnMicro/Views/MasterDetailViewPage.xaml.cs
+++ b/templates/Uwp/Pages/MasterDetail.CaliburnMicro/Views/MasterDetailViewPage.xaml.cs
@@ -17,7 +17,7 @@ namespace Param_ItemNamespace.Views
         {
             if (MasterDetailsViewControl.ViewState == MasterDetailsViewState.Both)
             {
-                ViewModel.ActiveItem = ViewModel.Items.First();
+                ViewModel.ActiveItem = ViewModel.Items.FirstOrDefault();
             }
         }
     }

--- a/templates/Uwp/Pages/MasterDetail.CodeBehind/Views/MasterDetailViewPage.xaml.cs
+++ b/templates/Uwp/Pages/MasterDetail.CodeBehind/Views/MasterDetailViewPage.xaml.cs
@@ -44,7 +44,7 @@ namespace Param_ItemNamespace.Views
 
             if (MasterDetailsViewControl.ViewState == MasterDetailsViewState.Both)
             {
-                Selected = SampleItems.First();
+                Selected = SampleItems.FirstOrDefault();
             }
         }
     }

--- a/templates/Uwp/Pages/MasterDetail.CodeBehindVB/Views/MasterDetailViewPage.xaml.vb
+++ b/templates/Uwp/Pages/MasterDetail.CodeBehindVB/Views/MasterDetailViewPage.xaml.vb
@@ -36,7 +36,7 @@ Namespace Views
             Next
 
             If MasterDetailsViewControl.ViewState = MasterDetailsViewState.Both Then
-                Selected = SampleItems.First()
+                Selected = SampleItems.FirstOrDefault()
             End If
         End Sub
     End Class

--- a/templates/Uwp/Pages/MasterDetail.Prism/ViewModels/MasterDetailViewViewModel.cs
+++ b/templates/Uwp/Pages/MasterDetail.Prism/ViewModels/MasterDetailViewViewModel.cs
@@ -51,8 +51,11 @@ namespace Param_ItemNamespace.ViewModels
             {
                 SampleItems.Add(item);
             }
+        }
 
-            Selected = SampleItems.First();
+        public void SetDefaultSelection()
+        {
+            Selected = SampleItems.FirstOrDefault();
         }
     }
 }

--- a/templates/Uwp/Pages/MasterDetail.Prism/Views/MasterDetailViewPage.xaml.cs
+++ b/templates/Uwp/Pages/MasterDetail.Prism/Views/MasterDetailViewPage.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Windows.UI.Xaml.Controls;
+using Microsoft.Toolkit.Uwp.UI.Controls;
+
 
 namespace Param_ItemNamespace.Views
 {

--- a/templates/Uwp/Pages/MasterDetailVB/ViewModels/MasterDetailViewViewModel.vb
+++ b/templates/Uwp/Pages/MasterDetailVB/ViewModels/MasterDetailViewViewModel.vb
@@ -32,7 +32,7 @@ Namespace ViewModels
             Next
 
             If viewState = MasterDetailsViewState.Both Then
-                Selected = SampleItems.First()
+                Selected = SampleItems.FirstOrDefault()
             End If
         End Function
     End Class

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetail/.template.config/template.json
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetail/.template.config/template.json
@@ -1,0 +1,29 @@
+﻿{
+  "author": "Microsoft",
+  "classifications": [
+    "Universal"
+  ],
+  "name": "MVVMLight.Project.SplitView.Page.MasterDetail",
+  "tags": {
+    "language": "C#",
+    "type": "item",
+    "wts.type": "composition",
+    "wts.platform" : "Uwp",
+    "wts.version": "1.0.0",
+    "wts.compositionFilter": "$framework == MVVMLight & $projectType == SplitView & identity == wts.Page.MasterDetail"
+  },
+  "sourceName": "wts.ItemName",
+  "preferNameDirectory": true,
+  "PrimaryOutputs": [
+  ],
+  "symbols": {
+    "wts.rootNamespace": {
+      "type": "parameter",
+      "replaces": "Param_RootNamespace"
+    },
+    "wts.itemNamespace": {
+      "type": "parameter",
+      "replaces": "Param_ItemNamespace"
+    }
+  }
+}

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetail/Views/wts.ItemNamePage_postaction.xaml.cs
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetail/Views/wts.ItemNamePage_postaction.xaml.cs
@@ -1,0 +1,22 @@
+﻿//{[{
+using Windows.UI.Xaml.Navigation;
+//}]}
+
+namespace Param_ItemNamespace.Views
+{
+
+    public sealed partial class wts.ItemNamePage : Page
+    {
+        //^^
+        //{[{
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            base.OnNavigatedFrom(e);
+
+            // Workaround for issue on MasterDetail Control. Find More info at https://github.com/Microsoft/WindowsTemplateStudio/issues/2738.
+            ViewModel.Selected = null;
+        }
+        //}]}
+    }
+}

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetailVB/.template.config/template.json
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetailVB/.template.config/template.json
@@ -1,0 +1,29 @@
+﻿{
+  "author": "Microsoft",
+  "classifications": [
+    "Universal"
+  ],
+  "name": "MVVMLight.Project.SplitView.Page.MasterDetail.VB",
+  "tags": {
+    "language": "VisualBasic",
+    "type": "item",
+    "wts.type": "composition",
+    "wts.platform" : "Uwp",
+    "wts.version": "1.0.0",
+    "wts.compositionFilter": "$framework == MVVMLight & $projectType == SplitView & identity == wts.Page.MasterDetail"
+  },
+  "sourceName": "wts.ItemName",
+  "preferNameDirectory": true,
+  "PrimaryOutputs": [
+  ],
+  "symbols": {
+    "wts.rootNamespace": {
+      "type": "parameter",
+      "replaces": "Param_RootNamespace"
+    },
+    "wts.itemNamespace": {
+      "type": "parameter",
+      "replaces": "Param_ItemNamespace"
+    }
+  }
+}

--- a/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetailVB/Views/wts.ItemNamePage_postaction.xaml.vb
+++ b/templates/Uwp/_composition/MVVMLight/Project.SplitView.Page.MasterDetailVB/Views/wts.ItemNamePage_postaction.xaml.vb
@@ -1,0 +1,19 @@
+﻿'{[{
+Imports Windows.UI.Xaml.Navigation
+'}]}
+
+Namespace Views
+    Public NotInheritable Partial Class wts.ItemNamePage
+        Inherits Page
+
+'{[{
+
+        Protected Overrides Sub OnNavigatedTo(e As NavigationEventArgs)
+            MyBase.OnNavigatedTo(e)
+
+            ' Workaround for issue on MasterDetail Control. Find More info at https://github.com/Microsoft/WindowsTemplateStudio/issues/2738
+            ViewModel.Selected = Nothing
+        End Sub
+'}]}
+    End Class
+End Namespace

--- a/templates/Uwp/_composition/Prism/Page.MasterDetail_Blank_TabbedPivot/.template.config/template.json
+++ b/templates/Uwp/_composition/Prism/Page.MasterDetail_Blank_TabbedPivot/.template.config/template.json
@@ -1,0 +1,29 @@
+﻿{
+  "author": "Microsoft",
+  "classifications": [
+    "Universal"
+  ],
+  "name": "Prism.Page.MasterDetail_Blank_TabbedPivot",
+  "tags": {
+    "language": "C#",
+    "type": "item",
+    "wts.type": "composition",
+    "wts.platform" : "Uwp",
+    "wts.version": "1.0.0",
+    "wts.compositionFilter": "$projectType == Blank|TabbedPivot & $framework == Prism & groupidentity == wts.Page.MasterDetail"
+  },
+  "sourceName": "wts.ItemName",
+  "preferNameDirectory": true,
+  "PrimaryOutputs": [
+  ],
+  "symbols": {
+    "wts.rootNamespace": {
+      "type": "parameter",
+      "replaces": "Param_RootNamespace"
+    },
+    "wts.itemNamespace": {
+      "type": "parameter",
+      "replaces": "Param_ItemNamespace"
+    }
+  }
+}

--- a/templates/Uwp/_composition/Prism/Page.MasterDetail_Blank_TabbedPivot/ViewModels/wts.ItemNameViewModel_postaction.cs
+++ b/templates/Uwp/_composition/Prism/Page.MasterDetail_Blank_TabbedPivot/ViewModels/wts.ItemNameViewModel_postaction.cs
@@ -1,0 +1,14 @@
+﻿namespace Param_ItemNamespace.ViewModels
+{
+    public class wts.ItemNameViewModel : ViewModelBase
+    {
+        public async Task LoadDataAsync()
+        {
+            //^^
+            //{[{
+
+            SetDefaultSelection();
+            //}]}
+        }
+    }
+}

--- a/templates/Uwp/_composition/Prism/Page.MasterDetail_SplitView/.template.config/template.json
+++ b/templates/Uwp/_composition/Prism/Page.MasterDetail_SplitView/.template.config/template.json
@@ -3,7 +3,7 @@
   "classifications": [
     "Universal"
   ],
-  "name": "Prism.Page.SplitView.MasterDetail",
+  "name": "Prism.Page.MasterDetail.SplitView",
   "tags": {
     "language": "C#",
     "type": "item",

--- a/templates/Uwp/_composition/Prism/Page.MasterDetail_SplitView/Views/wts.ItemNamePage_postaction.xaml
+++ b/templates/Uwp/_composition/Prism/Page.MasterDetail_SplitView/Views/wts.ItemNamePage_postaction.xaml
@@ -2,6 +2,7 @@
     <!--^^-->
     <!--{[{-->
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
+    Loaded="Page_Loaded"
     <!--}]}-->
     mc:Ignorable="d">
 

--- a/templates/Uwp/_composition/Prism/Page.MasterDetail_SplitView/Views/wts.ItemNamePage_postaction.xaml.cs
+++ b/templates/Uwp/_composition/Prism/Page.MasterDetail_SplitView/Views/wts.ItemNamePage_postaction.xaml.cs
@@ -1,0 +1,23 @@
+﻿//{[{
+using Microsoft.Toolkit.Uwp.UI.Controls;
+//}]}
+
+namespace Param_ItemNamespace.Views
+{
+    public sealed partial class wts.ItemNamePage : Page
+    {
+
+        //^^
+        //{[{
+        private void Page_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            // Workaround for issue on MasterDetail Control. Find More info at https://github.com/Microsoft/WindowsTemplateStudio/issues/2739.
+            if (MasterDetailsViewControl.ViewState == MasterDetailsViewState.Both)
+            {
+                ViewModel.SetDefaultSelection();
+            }
+        }
+
+        //}]}
+    }
+}


### PR DESCRIPTION
- Quick summary of changes
Added Workarounds for issue on MasterDetail Control using projectType SplitView and frameworks MVVMLight and Prism


- Which issue does this PR relate to?
#2739 Error when navigating to MasterDetailPage on Prism App
#2739 Error when navigating second time to MasterDetailPage on Mvvmlight App 
