### PR TITLE
Adapt legacy tests to work with splitted packages.

### DIFF
--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyFixture.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyFixture.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Templates.Test
         public override string GetTestRunPath() => $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\LEG\\{testExecutionTimeStamp}\\";
 
         public TemplatesSource Source => new LegacyTemplatesSourceV2(ProgrammingLanguages.CSharp);
+
+        public TemplatesSource VBSource => new LegacyTemplatesSourceV2(ProgrammingLanguages.VisualBasic);
+
         public TemplatesSource LocalSource => new LocalTemplatesSource("BldRClickLegacy");
 
         private static bool syncExecuted;
@@ -53,11 +56,7 @@ namespace Microsoft.Templates.Test
 
                     foreach (var framework in targetFrameworks)
                     {
-                        // TODO: Re-enable for MVVMLight and SplitView once 2.5 is released
-                        if (framework != "MVVMLight" && projectType != "SplitView")
-                        {
-                            result.Add(new object[] { projectType, framework, Platforms.Uwp, language });
-                        }
+                        result.Add(new object[] { projectType, framework, Platforms.Uwp, language });
                     }
                 }
             }
@@ -90,6 +89,16 @@ namespace Microsoft.Templates.Test
          "VSTHRD002:Synchronously waiting on tasks or awaiters may cause deadlocks",
          Justification = "Required for unit testing.")]
         public void ChangeTemplatesSource(TemplatesSource source, string language, string platform)
+        {
+            GenContext.Bootstrap(source, new FakeGenShell(platform, language), new Version(GenContext.ToolBox.WizardVersion), platform, language);
+            GenContext.ToolBox.Repo.SynchronizeAsync(true, true).Wait();
+        }
+
+        [SuppressMessage(
+         "Usage",
+         "VSTHRD002:Synchronously waiting on tasks or awaiters may cause deadlocks",
+         Justification = "Required for unit testing.")]
+        public void ChangeToLocalTemplatesSource(TemplatesSource source, string language, string platform)
         {
             GenContext.Bootstrap(source, new FakeGenShell(platform, language), platform, language);
             GenContext.ToolBox.Repo.SynchronizeAsync(true, true).Wait();

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
@@ -32,6 +32,13 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "BuildRightClickLegacy")]
         public async Task BuildEmptyLegacyProjectWithAllRightClickItemsAsync(string projectType, string framework, string platform, string language)
         {
+            var fixture = _fixture as BuildRightClickWithLegacyFixture;
+
+            if (language == ProgrammingLanguages.VisualBasic)
+            {
+                fixture.ChangeTemplatesSource(fixture.VBSource, language, Platforms.Uwp);
+            }
+
             var projectName = $"{projectType}{framework}Legacy";
 
             Func<ITemplateInfo, bool> selector =
@@ -43,8 +50,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, Platforms.Uwp, language, null, null, false);
 
-            var fixture = _fixture as BuildRightClickWithLegacyFixture;
-            fixture.ChangeTemplatesSource(fixture.LocalSource, language, Platforms.Uwp);
+            fixture.ChangeToLocalTemplatesSource(fixture.LocalSource, language, Platforms.Uwp);
 
             var rightClickTemplates = _fixture.Templates().Where(
                                           t => (t.GetTemplateType() == TemplateType.Feature || t.GetTemplateType() == TemplateType.Page)


### PR DESCRIPTION
- Quick summary of changes
Adapt legacy tests to work with splitted packages. 
Re-enable legacy tests for MVVMLight and SplitView
- Which issue does this PR relate to?
#2760 Legacy tests failed on full tests build
#2586 Re-enable rightclick with legacy project tests for MVVMLight and SplitView