### PR TITLE
Issue2789 optional contextlines in merge postactions

### DIFF
--- a/code/src/Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         private const string MacroStartDelete = "{--{";
         private const string MacroEndDelete = "}--}";
 
-        private static string[] macros = new string[] { MacroBeforeMode, MacroStartGroup, MacroEndGroup, MacroStartDocumentation, MacroEndDocumentation, MacroStartDelete, MacroEndDelete };
+        internal const string MacroStartOptionalContext = "{??{";
+        internal const string MacroEndOptionalContext = "}??}";
+
+        private static string[] macros = new string[] { MacroBeforeMode, MacroStartGroup, MacroEndGroup, MacroStartDocumentation, MacroEndDocumentation, MacroStartDelete, MacroEndDelete, MacroStartOptionalContext, MacroEndOptionalContext };
 
         private const string OpeningBrace = "{";
         private const string ClosingBrace = "}";
@@ -70,7 +73,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             foreach (var mergeLine in merge)
             {
                 // try to find line
-                if (mergeMode == MergeMode.Context)
+                if (mergeMode == MergeMode.Context || mergeMode == MergeMode.OptionalContext)
                 {
                     currentLineIndex = result.SafeIndexOf(mergeLine.WithLeadingTrivia(diffTrivia), lastLineIndex);
                 }
@@ -126,6 +129,10 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                         {
                             removalBuffer.Add(mergeLine.WithLeadingTrivia(diffTrivia));
                         }
+                        else if (mergeMode == MergeMode.OptionalContext)
+                        {
+                            currentLineIndex = lastLineIndex;
+                        }
                         else if (mergeMode == MergeMode.Context)
                         {
                             errorLine = mergeLine;
@@ -180,6 +187,14 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                 return MergeMode.Remove;
             }
             else if (mergeLine.Contains(MacroEndDelete))
+            {
+                return MergeMode.Context;
+            }
+            else if (mergeLine.Contains(MacroStartOptionalContext))
+            {
+                return MergeMode.OptionalContext;
+            }
+            else if (mergeLine.Contains(MacroEndOptionalContext))
             {
                 return MergeMode.Context;
             }

--- a/code/src/Core/PostActions/Catalog/Merge/MergeMode.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/MergeMode.cs
@@ -11,5 +11,6 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         Remove,
         Documentation,
         Context,
+        OptionalContext,
     }
 }

--- a/code/src/Core/PostActions/Catalog/Merge/PostactionFormatter.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/PostactionFormatter.cs
@@ -21,7 +21,11 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                             .Replace(IEnumerableExtensions.MacroStartDocumentation, UserFriendlyPostActionMacroStartDocumentation)
                             .Replace(IEnumerableExtensions.MacroEndDocumentation, UserFriendlyPostActionMacroEndDocumentation)
                             .Replace(IEnumerableExtensions.MacroStartGroup, UserFriendlyPostActionMacroStartGroup)
-                            .Replace(IEnumerableExtensions.MacroEndGroup, UserFriendlyPostActionMacroEndGroup);
+                            .Replace(IEnumerableExtensions.MacroEndGroup, UserFriendlyPostActionMacroEndGroup)
+                            .Replace("//" + IEnumerableExtensions.MacroStartOptionalContext, string.Empty)
+                            .Replace("//" + IEnumerableExtensions.MacroEndOptionalContext, string.Empty)
+                            .Replace("'" + IEnumerableExtensions.MacroStartOptionalContext, string.Empty)
+                            .Replace("'" + IEnumerableExtensions.MacroEndOptionalContext, string.Empty);
 
             var cleanRemovals = output.Split(new[] { Environment.NewLine }, StringSplitOptions.None).RemoveRemovals();
             output = string.Join(Environment.NewLine, cleanRemovals);

--- a/code/test/Core.Test/Core.Test.csproj
+++ b/code/test/Core.Test/Core.Test.csproj
@@ -220,6 +220,12 @@
     <Compile Include="Naming\NamingTests.cs" />
     <Compile Include="Naming\SuggestedDirectoryNameValidatorTests.cs" />
     <Compile Include="Composition\CompositionQueryTest.cs" />
+    <None Include="TestData\Merge\Source_expectedWithOptionalContextLines.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="TestData\Merge\SourceWithOptionalContextLines.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestData\GenerationSummary_expected.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/code/test/Core.Test/PostActions/Catalog/MergeTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/MergeTest.cs
@@ -29,5 +29,20 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             Assert.Equal(expected, string.Join(string.Empty, result.ToArray()));
             Assert.Equal(errorLine, string.Empty);
         }
+
+        [Fact]
+        public void MergeWithOptionalContextLines()
+        {
+            var source = File.ReadAllLines(@".\TestData\Merge\SourceWithOptionalContextLines.cs");
+            var merge = File.ReadAllLines(@".\TestData\Merge\Source_postaction.cs");
+            var expected = File.ReadAllText(@".\TestData\Merge\Source_expectedWithOptionalContextLines.cs");
+            var result = source.Merge(merge, out string errorLine);
+
+            // Remove all new line chars to avoid differentiation with the new line characters
+            expected = expected.Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+
+            Assert.Equal(expected, string.Join(string.Empty, result.ToArray()));
+            Assert.Equal(errorLine, string.Empty);
+        }
     }
 }

--- a/code/test/Core.Test/TestData/Merge/SourceWithOptionalContextLines.cs
+++ b/code/test/Core.Test/TestData/Merge/SourceWithOptionalContextLines.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+
+using TestData.Shell;
+using TestData.BackgroundTask;
+using TestData.Services;
+
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Activation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace TestData
+{
+    //THIS COMMENT SHOULD BE REMOVED
+    /// <summary>
+    /// Provides application-specific behavior to supplement the default Application class.
+    /// </summary>
+    sealed partial class App : Application
+    {
+
+        /// <summary>
+        /// Initializes the singleton application object.  This is the first line of authored code
+        /// executed, and as such is the logical equivalent of main() or WinMain().
+        /// </summary>
+        public App()
+        {
+            this.InitializeComponent();
+            //This might be there or not
+            //This might also be there or not
+            this.EnteredBackground += App_EnteredBackground;
+            //PostActionAnchor: ENABLE QUEUE
+        }
+
+        /// <summary>
+        /// Invoked when the application is launched normally by the end user.  Other entry points
+        /// will be used such as when the application is launched to open a specific file.
+        /// </summary>
+        /// <param name = "e">Details about the launch request and process.</param>
+        protected override async void OnLaunched(LaunchActivatedEventArgs e)
+        {   
+            Frame rootFrame = Window.Current.Content as Frame;
+            // Do not repeat app initialization when the Window already has content,
+            // just ensure that the window is active
+            if (rootFrame == null)
+            {
+                // Create a Frame to act as the navigation context and navigate to the first page
+                rootFrame = new Frame();
+                rootFrame.NavigationFailed += OnNavigationFailed;
+                // Place the frame in the current Window
+                Window.Current.Content = rootFrame;
+            }
+
+            if (e.PrelaunchActivated == false)
+            {
+                if (rootFrame.Content == null)
+                {
+                    // When the navigation stack isn't restored navigate to the first page,
+                    // configuring the new page by passing required information as a navigation
+                    // parameter
+                    rootFrame.Navigate(typeof(ShellPage), e.Arguments);
+                }
+
+                // Ensure the current window is active
+                Window.Current.Activate();
+            }
+
+            Settings.SettingsViewModel.InitAppTheme();
+            BackgroundTaskService.RegisterBackgroundTasks();
+            await StateService.Instance.RestoreStateAsync(e.PreviousExecutionState, e.Arguments);
+            //This might be there or not
+            //This might also be there or not
+        }
+
+        /// <summary>
+        /// Invoked when Navigation to a certain page fails
+        /// </summary>
+        /// <param name = "sender">The Frame which failed navigation</param>
+        /// <param name = "e">Details about the navigation failure</param>
+        void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+        {
+            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+        }
+
+        private async void App_EnteredBackground(object sender, EnteredBackgroundEventArgs e)
+        {
+            var deferral = e.GetDeferral();
+            StateService.Instance.SaveStateAsync();
+            deferral.Complete();
+        }
+
+        protected override void OnActivated(IActivatedEventArgs args)
+        {
+            if (args.Kind == ActivationKind.ToastNotification)
+            {
+                var toastArgs = args as ToastNotificationActivatedEventArgs;
+                var arguments = toastArgs.Argument;
+                // TODO WTS: Handle activation from toast notification,  
+                //for more info handling activation see  
+                //https://blogs.msdn.microsoft.com/tiles_and_toasts/2015/07/08/quickstart-sending-a-local-toast-notification-and-handling-activations-from-it-windows-10/ 
+            }
+        }
+
+        private static void ThisIsAnExistingMethod()
+        {
+        }
+
+        protected override void OnBackgroundActivated(BackgroundActivatedEventArgs args)
+        {
+            BackgroundTaskService.Start(args.TaskInstance);
+        }
+    }
+}

--- a/code/test/Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
+++ b/code/test/Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+
+using TestData.Shell;
+using TestData.BackgroundTask;
+using TestData.Services;
+
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Activation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+//USING
+
+namespace TestData
+{
+    /// <summary>
+    /// Provides application-specific behavior to supplement the default Application class.
+    /// </summary>
+    sealed partial class App : Application
+    {
+        //PROPERTY DEFINITION
+
+        /// <summary>
+        /// Initializes the singleton application object.  This is the first line of authored code
+        /// executed, and as such is the logical equivalent of main() or WinMain().
+        /// </summary>
+        public App()
+        {
+            this.InitializeComponent();
+            //This might be there or not
+            //This might also be there or not
+            //AFTER INITIALIZE!!
+            this.EnteredBackground += App_EnteredBackground;
+            //PostActionAnchor: ENABLE QUEUE
+        }
+
+        /// <summary>
+        /// Invoked when the application is launched normally by the end user.  Other entry points
+        /// will be used such as when the application is launched to open a specific file.
+        /// </summary>
+        /// <param name = "e">Details about the launch request and process.</param>
+        protected override async void OnLaunched(LaunchActivatedEventArgs e)
+        {   
+            //AFTER ONLAUNCHED!!
+            Frame rootFrame = Window.Current.Content as Frame;
+            // Do not repeat app initialization when the Window already has content,
+            // just ensure that the window is active
+            if (rootFrame == null)
+            {
+                // Create a Frame to act as the navigation context and navigate to the first page
+                rootFrame = new Frame();
+                rootFrame.NavigationFailed += OnNavigationFailed;
+                // Place the frame in the current Window
+                Window.Current.Content = rootFrame;
+            }
+
+            if (e.PrelaunchActivated == false)
+            {
+                if (rootFrame.Content == null)
+                {
+                    // When the navigation stack isn't restored navigate to the first page,
+                    // configuring the new page by passing required information as a navigation
+                    // parameter
+                    rootFrame.Navigate(typeof(ShellPage), e.Arguments);
+                }
+
+                // Ensure the current window is active
+                Window.Current.Activate();
+            }
+
+            Settings.SettingsViewModel.InitAppTheme();
+            BackgroundTaskService.RegisterBackgroundTasks();
+            await StateService.Instance.RestoreStateAsync(e.PreviousExecutionState, e.Arguments);
+
+            //BEFORE END!!
+            var s = "";
+            //This might be there or not
+            //This might also be there or not
+        }
+
+        private static void ThisIsANewMethod()
+        {
+            //INSIDE NEW METHOD!!
+        }
+
+
+        /// <summary>
+        /// Invoked when Navigation to a certain page fails
+        /// </summary>
+        /// <param name = "sender">The Frame which failed navigation</param>
+        /// <param name = "e">Details about the navigation failure</param>
+        void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+        {
+            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+        }
+
+        private async void App_EnteredBackground(object sender, EnteredBackgroundEventArgs e)
+        {
+            var deferral = e.GetDeferral();
+            StateService.Instance.SaveStateAsync();
+            deferral.Complete();
+        }
+
+        protected override void OnActivated(IActivatedEventArgs args)
+        {
+            if (args.Kind == ActivationKind.ToastNotification)
+            {
+                //INSIDE IF!!
+                var toastArgs = args as ToastNotificationActivatedEventArgs;
+                var arguments = toastArgs.Argument;
+                // TODO WTS: Handle activation from toast notification,  
+                //for more info handling activation see  
+                //https://blogs.msdn.microsoft.com/tiles_and_toasts/2015/07/08/quickstart-sending-a-local-toast-notification-and-handling-activations-from-it-windows-10/ 
+            }
+        }
+
+        private static void ThisIsAnExistingMethod()
+        {
+        }
+
+        protected override void OnBackgroundActivated(BackgroundActivatedEventArgs args)
+        {
+            BackgroundTaskService.Start(args.TaskInstance);
+        }
+    }
+}

--- a/code/test/Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
+++ b/code/test/Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
@@ -16,6 +16,10 @@ namespace TestData
         public App()
         {
             this.InitializeComponent();
+            
+            //This might be there or not
+            //This might also be there or not
+            
             //Block to be included
             //AFTER INITIALIZE!!
             //End of block
@@ -35,6 +39,10 @@ namespace TestData
             var s = "";
 
             //End of block
+            
+            //This might be there or not
+            //This might also be there or not
+            
         }
 
         //Block to be included

--- a/code/test/Core.Test/TestData/Merge/Source_postaction.cs
+++ b/code/test/Core.Test/TestData/Merge/Source_postaction.cs
@@ -19,6 +19,10 @@ namespace TestData
         public App()
         {
             this.InitializeComponent();
+            //{??{
+            //This might be there or not
+            //This might also be there or not
+            //}??}
             //{[{
             //AFTER INITIALIZE!!
             //}]}
@@ -38,6 +42,10 @@ namespace TestData
             var s = "";
 
             //}]}
+            //{??{
+            //This might be there or not
+            //This might also be there or not
+            //}??}
         }
 
         //{[{

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -372,6 +372,7 @@ There are different merge directives to drive the code merging. Currently:
 * MacroStartGroup `//{[{` and MarcoEndGroup `}]}`: The content between `{[{` and `}]}` is inserted.
 * MacroStartDelete `//{--{` and MacroEndDelete = `//}--}`: The content between the directives will be removed if it exists within the merge target. If the content does not exist (or has already been deleted as part of merging another file) this will be silently ignored. 
 * MacroStartDocumentation `//{**` and MacroEndDocumentation `//**}`: The content between `{**` and `**}` is not inserted but shown in the _postaction file. This can be used give the user feedback about was the postaction intended to do when the postaction fails or when integrating right click output manually.
+* MacroStartOptionalContext `{??{` and MacroEndOptionalContext `}??}`: The content between `{??{` and `}??}` is optional, if the line is not found the next line is taken as context line.
 
 _The above merge directives all use the C# comment form (`//`) but if included in a VB file should use the VB equivalent (`'`)_
 

--- a/templates/Uwp/Features/FirstUsePrompt/Services/ActivationService_postaction.cs
+++ b/templates/Uwp/Features/FirstUsePrompt/Services/ActivationService_postaction.cs
@@ -14,7 +14,9 @@ namespace Param_ItemNamespace.Services
             //{[{
             await FirstRunDisplayService.ShowIfAppropriateAsync();
             //}]}
+            //{??{
             await Task.CompletedTask;
+            //}??}
         }
     }
 }

--- a/templates/Uwp/Features/FirstUsePromptVB/Services/ActivationService_postaction.vb
+++ b/templates/Uwp/Features/FirstUsePromptVB/Services/ActivationService_postaction.vb
@@ -9,7 +9,9 @@ Namespace Services
             '{[{
             Await FirstRunDisplayService.ShowIfAppropriateAsync()
             '}]}
+            '{??{
             Await Task.CompletedTask
+            '}??}
         End Function
     End Class
 End Namespace

--- a/templates/Uwp/Features/HubNotifications/Services/ActivationService_postaction.cs
+++ b/templates/Uwp/Features/HubNotifications/Services/ActivationService_postaction.cs
@@ -22,8 +22,11 @@ namespace Param_ItemNamespace.Services
             //  2. Uncomment the following line (an exception will be thrown if it is executed and the above information is not provided).
             // await Singleton<HubNotificationsFeatureService>.Instance.InitializeAsync();
 //}]}
+//{??{
             await Task.CompletedTask;
+//}??}
         }
+
 
         private IEnumerable<ActivationHandler> GetActivationHandlers()
         {

--- a/templates/Uwp/Features/HubNotificationsVB/Services/ActivationService_postaction.vb
+++ b/templates/Uwp/Features/HubNotificationsVB/Services/ActivationService_postaction.vb
@@ -18,7 +18,9 @@ Namespace Services
             '  2. Uncomment the following line (an exception will be thrown if it is executed and the above information is not provided).
             ' Await Singleton(Of HubNotificationsFeatureService).Instance.InitializeAsync()
             '}]}
+            '{??{
             Await Task.CompletedTask
+            '}??}
         End Function
 
         Private Iterator Function GetActivationHandlers() As IEnumerable(Of ActivationHandler)

--- a/templates/Uwp/Features/LiveTile/Services/ActivationService_postaction.cs
+++ b/templates/Uwp/Features/LiveTile/Services/ActivationService_postaction.cs
@@ -26,7 +26,9 @@ namespace Param_ItemNamespace.Services
             //{[{
             Singleton<LiveTileFeatureService>.Instance.SampleUpdate();
             //}]}
+            //{??{
             await Task.CompletedTask;
+            //}??}
         }
 
         private IEnumerable<ActivationHandler> GetActivationHandlers()

--- a/templates/Uwp/Features/LiveTileVB/Services/ActivationService_postaction.vb
+++ b/templates/Uwp/Features/LiveTileVB/Services/ActivationService_postaction.vb
@@ -21,7 +21,9 @@ Namespace Services
             '{[{
             Singleton(Of LiveTileFeatureService).Instance.SampleUpdate()
             '}]}
+            '{??{
             Await Task.CompletedTask
+            '}??}
         End Function
 
         Private Iterator Function GetActivationHandlers() As IEnumerable(Of ActivationHandler)

--- a/templates/Uwp/Features/StoreNotifications/Services/ActivationService_postaction.cs
+++ b/templates/Uwp/Features/StoreNotifications/Services/ActivationService_postaction.cs
@@ -18,7 +18,9 @@ namespace Param_ItemNamespace.Services
             //{[{
             await Singleton<StoreNotificationsFeatureService>.Instance.InitializeAsync();
             //}]}
+            //{??{
             await Task.CompletedTask;
+            //}??}
         }
 
         private IEnumerable<ActivationHandler> GetActivationHandlers()

--- a/templates/Uwp/Features/StoreNotificationsVB/Services/ActivationService_postaction.vb
+++ b/templates/Uwp/Features/StoreNotificationsVB/Services/ActivationService_postaction.vb
@@ -14,7 +14,9 @@ Namespace Services
             '{[{
             Await Singleton(Of StoreNotificationsFeatureService).Instance.InitializeAsync()
             '}]}
+            '{??{
             Await Task.CompletedTask
+            '}??}
         End Function
 
         Private Iterator Function GetActivationHandlers() As IEnumerable(Of ActivationHandler)

--- a/templates/Uwp/Features/UserActivity.MVVMLight/Services/ActivationService_postaction.cs
+++ b/templates/Uwp/Features/UserActivity.MVVMLight/Services/ActivationService_postaction.cs
@@ -15,7 +15,9 @@ namespace Param_ItemNamespace.Services
             // TODO WTS: This is a sample to demonstrate how to add a UserActivity. Please adapt and move this method call to where you consider convenient in your app.
             await UserActivityService.AddSampleUserActivity();
             //}]}
+            //{??{
             await Task.CompletedTask;
+            //}??}
         }
     }
 }

--- a/templates/Uwp/Features/UserActivity.MVVMLightVB/Services/ActivationService_postaction.vb
+++ b/templates/Uwp/Features/UserActivity.MVVMLightVB/Services/ActivationService_postaction.vb
@@ -10,7 +10,9 @@ Namespace Services
             ' TODO WTS: This is a sample to demonstrate how to add a UserActivity. Please adapt and move this method call to where you consider convenient in your app.
             Await UserActivityService.AddSampleUserActivity()
             '}]}
+            '{??{
             Await Task.CompletedTask
+            '}??}
         End Function
     End Class
 End Namespace

--- a/templates/Uwp/Features/UserActivity/Services/ActivationService_postaction.cs
+++ b/templates/Uwp/Features/UserActivity/Services/ActivationService_postaction.cs
@@ -15,7 +15,9 @@ namespace Param_ItemNamespace.Services
             // TODO WTS: This is a sample to demonstrate how to add a UserActivity. Please adapt and move this method call to where you consider convenient in your app.
             await UserActivityService.AddSampleUserActivity();
             //}]}
+            //{??{
             await Task.CompletedTask;
+            //}??}
         }
     }
 }

--- a/templates/Uwp/Features/UserActivityVB/Services/ActivationService_postaction.vb
+++ b/templates/Uwp/Features/UserActivityVB/Services/ActivationService_postaction.vb
@@ -10,7 +10,9 @@ Namespace Services
             ' TODO WTS: This is a sample to demonstrate how to add a UserActivity. Please adapt and move this method call to where you consider convenient in your app.
             Await UserActivityService.AddSampleUserActivity()
             '}]}
+            '{??{
             Await Task.CompletedTask
+            '}??}
         End Function
     End Class
 End Namespace

--- a/templates/Uwp/Features/WhatsNewPrompt/Services/ActivationService_postaction.cs
+++ b/templates/Uwp/Features/WhatsNewPrompt/Services/ActivationService_postaction.cs
@@ -14,7 +14,9 @@ namespace Param_ItemNamespace.Services
             //{[{
             await WhatsNewDisplayService.ShowIfAppropriateAsync();
             //}]}
+            //{??{
             await Task.CompletedTask;
+            //}??}
         }
     }
 }

--- a/templates/Uwp/Features/WhatsNewPromptVB/Services/ActivationService_postaction.vb
+++ b/templates/Uwp/Features/WhatsNewPromptVB/Services/ActivationService_postaction.vb
@@ -9,7 +9,9 @@ Namespace Services
             '{[{
             Await WhatsNewDisplayService.ShowIfAppropriateAsync()
             '}]}
+            '{??{
             Await Task.CompletedTask
+            '}??}
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
## PR checklist
Quick summary of changes
- Add possibility to define optional context lines in the _postaction file, for cases where a context line might have been removed by another template. 

 Which issue does this PR relate to?
#2789 Failed Merge Postaction when adding first Settings, then Azure Notifications 
