### PR TITLE
Fix bug preventing app generation when name includes hyphen, space, etc.

### DIFF
--- a/code/src/Core/Extensions/StringExtensions.cs
+++ b/code/src/Core/Extensions/StringExtensions.cs
@@ -51,5 +51,25 @@ namespace Microsoft.Templates.Core
         {
             return value.GetMultiValue().Length > 1;
         }
+
+        // This is the same substitution as VS makes with new projects
+        public static string MakeSafeForProjectName(this string value)
+        {
+            var result = new StringBuilder();
+
+            foreach (var character in value)
+            {
+                if (char.IsLetterOrDigit(character) || character == '.')
+                {
+                    result.Append(character);
+                }
+                else
+                {
+                    result.Append('_');
+                }
+            }
+
+            return result.ToString();
+        }
     }
 }

--- a/code/src/Core/Extensions/StringExtensions.cs
+++ b/code/src/Core/Extensions/StringExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -53,23 +54,45 @@ namespace Microsoft.Templates.Core
         }
 
         // This is the same substitution as VS makes with new projects
-        public static string MakeSafeForProjectName(this string value)
+        public static string MakeSafeProjectName(this string projectName)
         {
-            var result = new StringBuilder();
-
-            foreach (var character in value)
+            if (projectName == null)
             {
-                if (char.IsLetterOrDigit(character) || character == '.')
+                return null;
+            }
+
+            var stringBuilder = new StringBuilder(projectName);
+
+            for (var i = 0; i < stringBuilder.Length; i++)
+            {
+                var unicodeCategory = char.GetUnicodeCategory(stringBuilder[i]);
+
+                var flag = unicodeCategory == UnicodeCategory.UppercaseLetter ||
+                           unicodeCategory == UnicodeCategory.LowercaseLetter ||
+                           unicodeCategory == UnicodeCategory.TitlecaseLetter ||
+                           unicodeCategory == UnicodeCategory.OtherLetter ||
+                           unicodeCategory == UnicodeCategory.LetterNumber ||
+                           stringBuilder[i] == '\u005F';
+
+                var flag1 = unicodeCategory == UnicodeCategory.NonSpacingMark ||
+                            unicodeCategory == UnicodeCategory.SpacingCombiningMark ||
+                            unicodeCategory == UnicodeCategory.ModifierLetter ||
+                            unicodeCategory == UnicodeCategory.DecimalDigitNumber;
+
+                if (i == 0)
                 {
-                    result.Append(character);
+                    if (!flag)
+                    {
+                        stringBuilder[i] = '\u005F';
+                    }
                 }
-                else
+                else if (!flag & !flag1)
                 {
-                    result.Append('_');
+                    stringBuilder[i] = '\u005F';
                 }
             }
 
-            return result.ToString();
+            return stringBuilder.ToString();
         }
     }
 }

--- a/code/src/Core/Gen/GenComposer.cs
+++ b/code/src/Core/Gen/GenComposer.cs
@@ -322,6 +322,8 @@ namespace Microsoft.Templates.Core.Gen
                 ns = GenContext.Current.ProjectName;
             }
 
+            ns = ns.MakeSafeForProjectName();
+
             genInfo.Parameters.Add(GenParams.RootNamespace, ns);
 
             // TODO: THIS SHOULD BE THE ITEM IN CONTEXT

--- a/code/src/Core/Gen/GenComposer.cs
+++ b/code/src/Core/Gen/GenComposer.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Templates.Core.Gen
                 ns = GenContext.Current.ProjectName;
             }
 
-            ns = ns.MakeSafeForProjectName();
+            ns = ns.MakeSafeProjectName();
 
             genInfo.Parameters.Add(GenParams.RootNamespace, ns);
 

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -34,6 +34,14 @@ namespace Microsoft.Templates.Test
             return language == ProgrammingLanguages.CSharp ? "CS" : "VB";
         }
 
+        // Used to create names that include a number of characters that are valid in project names but have the potential to cause issues
+        protected static string CharactersThatMayCauseProjectNameIssues()
+        {
+            // $ is technically valid in a project name but cannot be used with WTS as it is used as an identifier in global post action file names.
+            // ^ is technically valid in project names but Visual Studio cannot open files with this in the path
+            return " -_.,'@!(£)+=";
+        }
+
         protected static string ShortProjectType(string projectType)
         {
             switch (projectType)

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
@@ -71,6 +71,32 @@ namespace Microsoft.Templates.Test
 
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro")]
+        [Trait("Type", "BuildAllPagesAndFeatures")]
+        public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
+        {
+            Func<ITemplateInfo, bool> selector =
+                t => t.GetTemplateType() == TemplateType.Project
+                     && t.GetProjectTypeList().Contains(projectType)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden()
+                     && t.GetLanguage() == language;
+
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden();
+
+            var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
+
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
+
+            AssertBuildProjectAsync(projectPath, projectName, platform);
+        }
+
+        [Theory]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro")]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimum")]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
@@ -50,19 +50,45 @@ namespace Microsoft.Templates.Test
         {
             Func<ITemplateInfo, bool> selector =
                 t => t.GetTemplateType() == TemplateType.Project
-                    && t.GetProjectTypeList().Contains(projectType)
-                    && t.GetFrameworkList().Contains(framework)
-                    && t.GetPlatform() == platform
-                    && !t.GetIsHidden()
-                    && t.GetLanguage() == language;
+                     && t.GetProjectTypeList().Contains(projectType)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden()
+                     && t.GetLanguage() == language;
 
             Func<ITemplateInfo, bool> templateSelector =
                 t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
-                    && t.GetFrameworkList().Contains(framework)
-                    && t.GetPlatform() == platform
-                    && !t.GetIsHidden();
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}All{ShortLanguageName(language)}";
+
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
+
+            AssertBuildProjectAsync(projectPath, projectName, platform);
+        }
+
+        [Theory]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind")]
+        [Trait("Type", "BuildAllPagesAndFeatures")]
+        public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
+        {
+            Func<ITemplateInfo, bool> selector =
+                t => t.GetTemplateType() == TemplateType.Project
+                     && t.GetProjectTypeList().Contains(projectType)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden()
+                     && t.GetLanguage() == language;
+
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden();
+
+            var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
 
             var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
@@ -70,6 +70,32 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic")]
+        [Trait("Type", "BuildAllPagesAndFeatures")]
+        public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
+        {
+            Func<ITemplateInfo, bool> selector =
+                t => t.GetTemplateType() == TemplateType.Project
+                     && t.GetProjectTypeList().Contains(projectType)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden()
+                     && t.GetLanguage() == language;
+
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden();
+
+            var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
+
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
+
+            AssertBuildProjectAsync(projectPath, projectName, platform);
+        }
+
+        [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
@@ -70,6 +70,32 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight")]
+        [Trait("Type", "BuildAllPagesAndFeatures")]
+        public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
+        {
+            Func<ITemplateInfo, bool> selector =
+                t => t.GetTemplateType() == TemplateType.Project
+                     && t.GetProjectTypeList().Contains(projectType)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden()
+                     && t.GetLanguage() == language;
+
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden();
+
+            var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
+
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
+
+            AssertBuildProjectAsync(projectPath, projectName, platform);
+        }
+
+        [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
@@ -71,6 +71,32 @@ namespace Microsoft.Templates.Test
 
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism")]
+        [Trait("Type", "BuildAllPagesAndFeatures")]
+        public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
+        {
+            Func<ITemplateInfo, bool> selector =
+                t => t.GetTemplateType() == TemplateType.Project
+                     && t.GetProjectTypeList().Contains(projectType)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden()
+                     && t.GetLanguage() == language;
+
+            Func<ITemplateInfo, bool> templateSelector =
+                t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                     && t.GetFrameworkList().Contains(framework)
+                     && t.GetPlatform() == platform
+                     && !t.GetIsHidden();
+
+            var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
+
+            var projectPath = await AssertGenerateProjectAsync(selector, projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
+
+            AssertBuildProjectAsync(projectPath, projectName, platform);
+        }
+
+        [Theory]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism")]
         [Trait("Type", "BuildRandomNames")]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMinimum")]

--- a/code/test/Templates.Test/CodeStyleEnforcementTests.cs
+++ b/code/test/Templates.Test/CodeStyleEnforcementTests.cs
@@ -45,6 +45,34 @@ namespace Microsoft.Templates.Test
         }
 
         [Fact]
+        public void EnsureTemplatesDefineNamespacesCorrectly()
+        {
+            var result = new List<string>();
+
+            void EnsureDoNotUse(string shouldNotUse, string fileExtension)
+            {
+                var (success, failMessage) = CodeIsNotUsed(shouldNotUse, fileExtension);
+
+                if (!success)
+                {
+                    result.Add(failMessage + " It should use 'Param_RootNamespace' instead.");
+                }
+            }
+
+            // The placeholder "Param_RootNamespace" should be used instead, to ensure that all namespaces are created equally
+            EnsureDoNotUse("namespace wts.DefaultProject", "*.cs");
+            EnsureDoNotUse("namespace wts.DefaultProject", "*.vb");
+            EnsureDoNotUse("namespace Param_ProjectName", "*.cs");
+            EnsureDoNotUse("namespace Param_ProjectName", "*.vb");
+            EnsureDoNotUse("using wts.DefaultProject", "*.cs");
+            EnsureDoNotUse("Imports wts.DefaultProject", "*.vb");
+            EnsureDoNotUse("using Param_ProjectName", "*.cs");
+            EnsureDoNotUse("Imports Param_ProjectName", "*.vb");
+
+            Assert.True(!result.Any(), string.Join(Environment.NewLine, result));
+        }
+
+        [Fact]
         public void EnsureCodeDoesNotUseOldTodoCommentIdentifier()
         {
             void EnsureUwpTemplatesNotUsed(string fileExtension)

--- a/templates/Uwp/Features/SettingsStorage/Param_ProjectName/Helpers/SettingsStorageExtensions.cs
+++ b/templates/Uwp/Features/SettingsStorage/Param_ProjectName/Helpers/SettingsStorageExtensions.cs
@@ -4,9 +4,9 @@ using System.Threading.Tasks;
 
 using Windows.Storage;
 using Windows.Storage.Streams;
-using Param_ProjectName.Core.Helpers;
+using Param_RootNamespace.Core.Helpers;
 
-namespace Param_ItemNamespace.Helpers
+namespace Param_RootNamespace.Helpers
 {
     // Use these extension methods to store and retrieve local and roaming app data
     // More details regarding storing and retrieving app data at https://docs.microsoft.com/windows/uwp/app-settings/store-and-retrieve-app-data

--- a/templates/Uwp/Projects/Default/.template.config/template.json
+++ b/templates/Uwp/Projects/Default/.template.config/template.json
@@ -30,6 +30,10 @@
       "replaces": "Param_ProjectName",
       "fileRename": "Param_ProjectName"
     },
+    "wts.rootNamespace": {
+      "type": "parameter",
+      "replaces": "Param_RootNamespace"
+    },
     "wts.userName":
     {
       "type": "parameter",

--- a/templates/Uwp/Projects/Default/Activation/ActivationHandler.cs
+++ b/templates/Uwp/Projects/Default/Activation/ActivationHandler.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace wts.DefaultProject.Activation
+namespace Param_RootNamespace.Activation
 {
     // For more information on application activation see https://github.com/Microsoft/WindowsTemplateStudio/blob/master/docs/activation.md
     internal abstract class ActivationHandler

--- a/templates/Uwp/Projects/Default/Activation/DefaultLaunchActivationHandler.cs
+++ b/templates/Uwp/Projects/Default/Activation/DefaultLaunchActivationHandler.cs
@@ -2,9 +2,9 @@
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Activation;
 
-using wts.DefaultProject.Services;
+using Param_RootNamespace.Services;
 
-namespace wts.DefaultProject.Activation
+namespace Param_RootNamespace.Activation
 {
     internal class DefaultLaunchActivationHandler : ActivationHandler<LaunchActivatedEventArgs>
     {

--- a/templates/Uwp/Projects/Default/App.xaml.cs
+++ b/templates/Uwp/Projects/Default/App.xaml.cs
@@ -2,9 +2,9 @@
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 
-using wts.DefaultProject.Services;
+using Param_RootNamespace.Services;
 
-namespace wts.DefaultProject
+namespace Param_RootNamespace
 {
     public sealed partial class App : Application
     {

--- a/templates/Uwp/Projects/Default/Helpers/ResourceExtensions.cs
+++ b/templates/Uwp/Projects/Default/Helpers/ResourceExtensions.cs
@@ -2,7 +2,7 @@
 using System.Runtime.InteropServices;
 using Windows.ApplicationModel.Resources;
 
-namespace wts.DefaultProject.Helpers
+namespace Param_RootNamespace.Helpers
 {
     internal static class ResourceExtensions
     {

--- a/templates/Uwp/Projects/Default/Services/ActivationService.cs
+++ b/templates/Uwp/Projects/Default/Services/ActivationService.cs
@@ -7,9 +7,9 @@ using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-using wts.DefaultProject.Activation;
+using Param_RootNamespace.Activation;
 
-namespace wts.DefaultProject.Services
+namespace Param_RootNamespace.Services
 {
     // For more information on application activation see https://github.com/Microsoft/WindowsTemplateStudio/blob/master/docs/activation.md
     internal class ActivationService

--- a/templates/Uwp/Projects/Default/wts.DefaultProject.csproj
+++ b/templates/Uwp/Projects/Default/wts.DefaultProject.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{7CF740F7-735F-48EA-8B7B-3FFA4902371C}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>wts.DefaultProject</RootNamespace>
+    <RootNamespace>Param_RootNamespace</RootNamespace>
     <AssemblyName>wts.DefaultProject</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
@@ -18,7 +18,6 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
-    <PackageCertificateKeyFile>wts.DefaultProject_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/templates/Uwp/Projects/DefaultPrism/.template.config/template.json
+++ b/templates/Uwp/Projects/DefaultPrism/.template.config/template.json
@@ -31,6 +31,10 @@
       "replaces": "Param_ProjectName",
       "fileRename": "Param_ProjectName"
     },
+    "wts.rootNamespace": {
+      "type": "parameter",
+      "replaces": "Param_RootNamespace"
+    },
     "wts.userName":
     {
       "type": "parameter",

--- a/templates/Uwp/Projects/DefaultPrism/App.xaml.cs
+++ b/templates/Uwp/Projects/DefaultPrism/App.xaml.cs
@@ -7,7 +7,7 @@ using Prism.Windows.AppModel;
 using Windows.ApplicationModel.Resources;
 using Windows.UI.Xaml;
 
-namespace wts.DefaultProject
+namespace Param_RootNamespace
 {
     [Windows.UI.Xaml.Data.Bindable]
     public sealed partial class App : PrismUnityApplication

--- a/templates/Uwp/Projects/DefaultPrism/Constants/PageTokens.cs
+++ b/templates/Uwp/Projects/DefaultPrism/Constants/PageTokens.cs
@@ -1,4 +1,4 @@
-﻿namespace wts.DefaultProject
+﻿namespace Param_RootNamespace
 {
     internal static class PageTokens
     {

--- a/templates/Uwp/Projects/DefaultPrism/Helpers/ResourceExtensions.cs
+++ b/templates/Uwp/Projects/DefaultPrism/Helpers/ResourceExtensions.cs
@@ -2,7 +2,7 @@
 using System.Runtime.InteropServices;
 using Windows.ApplicationModel.Resources;
 
-namespace wts.DefaultProject.Helpers
+namespace Param_RootNamespace.Helpers
 {
     internal static class ResourceExtensions
     {

--- a/templates/Uwp/Projects/DefaultPrism/wts.DefaultProject.csproj
+++ b/templates/Uwp/Projects/DefaultPrism/wts.DefaultProject.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{7CF740F7-735F-48EA-8B7B-3FFA4902371C}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>wts.DefaultProject</RootNamespace>
+    <RootNamespace>Param_RootNamespace</RootNamespace>
     <AssemblyName>wts.DefaultProject</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
@@ -18,7 +18,6 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
-    <PackageCertificateKeyFile>wts.DefaultProject_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/templates/Uwp/Projects/DefaultVB/.template.config/template.json
+++ b/templates/Uwp/Projects/DefaultVB/.template.config/template.json
@@ -30,6 +30,10 @@
       "replaces": "Param_ProjectName",
       "fileRename": "Param_ProjectName"
     },
+    "wts.rootNamespace": {
+      "type": "parameter",
+      "replaces": "Param_RootNamespace"
+    },
     "wts.userName":
     {
       "type": "parameter",

--- a/templates/Uwp/Projects/DefaultVB/Activation/DefaultLaunchActivationHandler.vb
+++ b/templates/Uwp/Projects/DefaultVB/Activation/DefaultLaunchActivationHandler.vb
@@ -1,4 +1,4 @@
-﻿Imports wts.DefaultProject.Services
+﻿Imports Param_RootNamespace.Services
 
 Namespace Activation
     Friend Class DefaultLaunchActivationHandler

--- a/templates/Uwp/Projects/DefaultVB/App.xaml.vb
+++ b/templates/Uwp/Projects/DefaultVB/App.xaml.vb
@@ -1,4 +1,4 @@
-﻿Imports wts.DefaultProject.Services
+﻿Imports Param_RootNamespace.Services
 
 NotInheritable Partial Class App
     Inherits Application

--- a/templates/Uwp/Projects/DefaultVB/Services/ActivationService.vb
+++ b/templates/Uwp/Projects/DefaultVB/Services/ActivationService.vb
@@ -1,7 +1,7 @@
 ﻿Imports Windows.System
 Imports Windows.UI.Core
 
-Imports wts.DefaultProject.Activation
+Imports Param_RootNamespace.Activation
 
 Namespace Services
     ' For more information on application activation see https://github.com/Microsoft/WindowsTemplateStudio/blob/master/docs/activation.vb.md

--- a/templates/Uwp/Projects/DefaultVB/wts.DefaultProject.vbproj
+++ b/templates/Uwp/Projects/DefaultVB/wts.DefaultProject.vbproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{7CF740F7-735F-48EA-8B7B-3FFA4902371C}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>wts.DefaultProject</RootNamespace>
+    <RootNamespace>Param_RootNamespace</RootNamespace>
     <AssemblyName>wts.DefaultProject</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
@@ -18,7 +18,6 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
-    <PackageCertificateKeyFile>wts.DefaultProject_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/templates/Uwp/Test/Test.AddCoreProject/Param_ProjectName.Core/Param_ProjectName.Core.csproj
+++ b/templates/Uwp/Test/Test.AddCoreProject/Param_ProjectName.Core/Param_ProjectName.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Param_RootNamespace.Core</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/templates/Uwp/Test/Test.AddCoreProjectVB/Param_ProjectName.Core/Param_ProjectName.Core.vbproj
+++ b/templates/Uwp/Test/Test.AddCoreProjectVB/Param_ProjectName.Core/Param_ProjectName.Core.vbproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Param_RootNamespace.Core</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/templates/Uwp/_composition/_shared/Project.AddCoreProject/Param_ProjectName.Core/Param_ProjectName.Core.csproj
+++ b/templates/Uwp/_composition/_shared/Project.AddCoreProject/Param_ProjectName.Core/Param_ProjectName.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Param_RootNamespace.Core</RootNamespace>
   </PropertyGroup>
 
    <ItemGroup>

--- a/templates/Uwp/_composition/_shared/Project.AddCoreProjectVB/Param_ProjectName.Core/Param_ProjectName.Core.vbproj
+++ b/templates/Uwp/_composition/_shared/Project.AddCoreProjectVB/Param_ProjectName.Core/Param_ProjectName.Core.vbproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Param_RootNamespace.Core</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For #2892

Avoids using project names directly in a namespace without first making "safe"

Makes existing templates consistent.
Ensures converting project name to namespace follows standard VS conventions.
Added tests to verify the above and can generate apps with project names that include non-alphanumeric characters.

Some of this had already been done for #299 

X-Ref #1784 which covers updating the wizard to warn about project names that can cause problems.

The ability to support project names that included a hyphen (and possibly other non-alphanumeric characters) apparently worked before 3.0 was released. I can't confirm this but if true, there is a case for this going in a **HOTFIX**. 