### PR TITLE
Set SafeProjectName from installer and emulator

### DIFF
--- a/code/src/Core/Gen/GenComposer.cs
+++ b/code/src/Core/Gen/GenComposer.cs
@@ -319,10 +319,8 @@ namespace Microsoft.Templates.Core.Gen
 
             if (string.IsNullOrEmpty(ns))
             {
-                ns = GenContext.Current.ProjectName;
+                ns = GenContext.Current.SafeProjectName;
             }
-
-            ns = ns.MakeSafeProjectName();
 
             genInfo.Parameters.Add(GenParams.RootNamespace, ns);
 

--- a/code/src/Core/Gen/IContextProvider.cs
+++ b/code/src/Core/Gen/IContextProvider.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Templates.Core.Gen
     {
         string ProjectName { get; }
 
+        string SafeProjectName { get; }
+
         string GenerationOutputPath { get; }
 
         string DestinationPath { get; }

--- a/code/src/UI/VisualStudio/RightClickActions.cs
+++ b/code/src/UI/VisualStudio/RightClickActions.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Templates.UI.VisualStudio
 
         public string ProjectName { get; private set; }
 
+        public string SafeProjectName { get; private set; }
+
         public string GenerationOutputPath { get; private set; }
 
         public string DestinationPath { get; private set; }
@@ -120,6 +122,7 @@ namespace Microsoft.Templates.UI.VisualStudio
                 {
                     DestinationPath = GenContext.ToolBox.Shell.GetActiveProjectPath();
                     ProjectName = GenContext.ToolBox.Shell.GetActiveProjectName();
+                    SafeProjectName = GenContext.ToolBox.Shell.GetActiveProjectNamespace();
                 }
 
                 GenerationOutputPath = GenContext.GetTempGenerationPath(ProjectName);

--- a/code/src/UI/VisualStudio/SolutionWizard.cs
+++ b/code/src/UI/VisualStudio/SolutionWizard.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Templates.UI.VisualStudio
         private string _language;
         private GenerationService _generationService = GenerationService.Instance;
 
-        public string ProjectName => _replacementsDictionary["$safeprojectname$"];
+        public string SafeProjectName => _replacementsDictionary["$safeprojectname$"];
+
+        public string ProjectName => _replacementsDictionary["$projectname$"];
 
         public string DestinationPath => new DirectoryInfo(_replacementsDictionary["$destinationdirectory$"]).FullName;
 

--- a/code/test/Fakes/FakeContextProvider.cs
+++ b/code/test/Fakes/FakeContextProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Microsoft.Templates.Core;
 using Microsoft.Templates.Core.Diagnostics;
 using Microsoft.Templates.Core.Gen;
 using Microsoft.Templates.Core.PostActions.Catalog.Merge;
@@ -12,6 +13,8 @@ namespace Microsoft.Templates.Fakes
     public class FakeContextProvider : IContextProvider
     {
         public string ProjectName { get; set; }
+
+        public string SafeProjectName => ProjectName.MakeSafeProjectName();
 
         public string GenerationOutputPath { get; set; }
 

--- a/code/test/VsEmulator/Main/MainViewModel.cs
+++ b/code/test/VsEmulator/Main/MainViewModel.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Templates.VsEmulator.Main
 
         public string ProjectName { get; private set; }
 
+        public string SafeProjectName => ProjectName.MakeSafeProjectName();
+
         public string GenerationOutputPath { get;  set; }
 
         public string DestinationPath { get; private set; }


### PR DESCRIPTION
Quick summary of changes
- Set SafeProjectName and Projectname from installer and emulator
- Use projectname for file and foldernames, safeprojectname for namespaces

Which issue does this PR relate to?
- #2892 Template Studio is unable to create an app (C#) 
