### PR TITLE
Corrected localized names for content grid and web to app link

### DIFF
--- a/code/tools/TemplateValidator/TemplateFolderVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateFolderVerifier.cs
@@ -75,6 +75,11 @@ namespace TemplateValidator
                             {
                                 results.Add($"'{localizedFile.FullName}' does not have the correct identity.");
                             }
+
+                            if (template.Name != localizedTemplate.Name)
+                            {
+                                results.Add($"'{localizedFile.FullName}' does not have the correct name.");
+                            }
                         }
                     }
                     else

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Propojení webu s aplikací přidruží vaši aplikaci k webu. Když pak někdo otevře odkaz na váš web, namísto otevření prohlížeče se spustí vaše aplikace.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/de-DE.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Ein Web-zu-App-Link verknüpft Ihre App mit einer Website, sodass Ihre App gestartet wird, wenn auf einen Link zu Ihrer Website geklickt wird.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/es-ES.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "El vínculo web a aplicación asocia tu aplicación a un sitio web para que cuando alguien abra un vínculo de tu sitio web.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Le lien Web vers application permet d\u0027associer votre application à un site Web lorsqu\u0027un utilisateur accède à votre site en cliquant sur ce lien.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/it-IT.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Il collegamento da Web ad app associa la tua app a un sito Web in modo da avviare la tua app quando qualcuno apre un collegamento al tuo sito Web.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Web とアプリのリンクにより、アプリと Web サイトが関連付けられます。ユーザーが Web サイトを開くと、アプリが起動されます。",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "웹-앱 링크는 앱과 웹사이트를 연결해주므로 웹사이트 링크를 누르면 앱이 실행됩니다.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Łącze między witryną i aplikacją polega na tym, że kiedy użytkownik użyje łącza do Twojej witryny.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "O link Web para App associa seu aplicativo com um site, assim quando alguém abre um link para seu site.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Привязка приложения к веб-сайту позволяет связать ваше приложение с веб-сайтом, чтобы при щелчке ссылки на веб-сайт вместо браузера открывалось ваше приложение.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Web-Uygulama bağlantısı, web sitenize yönlendiren bir bağlantı açıldığında uygulamanızı bir web sitesi ile ilişkilendirir.",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "“Web 到应用”链接可以将你的应用与网站关联起来。当用户打开你的网站链接时。",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLink.Prism/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Features/WebToAppLink.Prism/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "「Web 至應用程式」連結會將您的應用程式與網站建立關聯，如此一來，當有人開啟您網站的連結時，就會派上用場。",
     "identity": "wts.Feat.WebToAppLink.Prism"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Propojení webu s aplikací přidruží vaši aplikaci k webu. Když pak někdo otevře odkaz na váš web, namísto otevření prohlížeče se spustí vaše aplikace.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/de-DE.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Ein Web-zu-App-Link verknüpft Ihre App mit einer Website, sodass Ihre App gestartet wird, wenn auf einen Link zu Ihrer Website geklickt wird.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/es-ES.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "El vínculo web a aplicación asocia tu aplicación a un sitio web para que cuando alguien abra un vínculo de tu sitio web.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Le lien Web vers application permet d\u0027associer votre application à un site Web lorsqu\u0027un utilisateur accède à votre site en cliquant sur ce lien.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/it-IT.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Il collegamento da Web ad app associa la tua app a un sito Web in modo da avviare la tua app quando qualcuno apre un collegamento al tuo sito Web.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Web とアプリのリンクにより、アプリと Web サイトが関連付けられます。ユーザーが Web サイトを開くと、アプリが起動されます。",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "웹-앱 링크는 앱과 웹사이트를 연결해주므로 웹사이트 링크를 누르면 앱이 실행됩니다.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Łącze między witryną i aplikacją polega na tym, że kiedy użytkownik użyje łącza do Twojej witryny.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "O link Web para App associa seu aplicativo com um site, assim quando alguém abre um link para seu site.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Привязка приложения к веб-сайту позволяет связать ваше приложение с веб-сайтом, чтобы при щелчке ссылки на веб-сайт вместо браузера открывалось ваше приложение.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "Web-Uygulama bağlantısı, web sitenize yönlendiren bir bağlantı açıldığında uygulamanızı bir web sitesi ile ilişkilendirir.",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "“Web 到应用”链接可以将你的应用与网站关联起来。当用户打开你的网站链接时。",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Features/WebToAppLinkVB/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Features/WebToAppLinkVB/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
     "author": "Microsoft Community",
-    "name": "Web to app link",
+    "name": "Web to App link",
     "description": "「Web 至應用程式」連結會將您的應用程式與網站建立關聯，如此一來，當有人開啟您網站的連結時，就會派上用場。",
     "identity": "wts.Feat.WebToAppLink.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Tato stránka umožňuje přidat vlastní položky formou adaptivní mřížky.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/de-DE.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Auf dieser Seite können Sie benutzerdefinierte Elemente in Form eines adaptiven Rasters hinzufügen.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/es-ES.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite agregar elementos personalizados en la forma de una cuadrícula adaptable.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Cette page vous permet d'ajouter du contenu personnalisé affiché en grille adaptative.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/it-IT.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Questa pagina ti permette di aggiungere elementi personalizzati sotto forma di una griglia adattiva.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "このページでは、適応型グリッドのフォーム内にカスタム アイテムを追加できます。",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "이 페이지에서 맞춤형 항목을 Adaptive Grid 형태로 추가할 수 있습니다.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Ta strona pozwala dodawać własne elementy w postaci adaptacyjnej siatki.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite adicionar itens personalizados na forma de uma Grade adaptável.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Эта страница разрешает добавление пользовательских элементов в виде адаптивной сетки.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Bu sayfa, özel öğeleri Uyarlamalı Kılavuz biçiminde eklemenizi sağlar.",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "此页面允许你通过自适应网格的形式添加自定义项。",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "本頁面允許您以 Adaptive Grid 格式新增自訂項目。",
   "identity": "wts.Page.ContentGrid.CaliburnMicro"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Tato stránka umožňuje přidat vlastní položky formou adaptivní mřížky.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/de-DE.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Auf dieser Seite können Sie benutzerdefinierte Elemente in Form eines adaptiven Rasters hinzufügen.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/es-ES.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite agregar elementos personalizados en la forma de una cuadrícula adaptable.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Cette page vous permet d'ajouter du contenu personnalisé affiché en grille adaptative.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/it-IT.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Questa pagina ti permette di aggiungere elementi personalizzati sotto forma di una griglia adattiva.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "このページでは、適応型グリッドのフォーム内にカスタム アイテムを追加できます。",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "이 페이지에서 맞춤형 항목을 Adaptive Grid 형태로 추가할 수 있습니다.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Ta strona pozwala dodawać własne elementy w postaci adaptacyjnej siatki.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite adicionar itens personalizados na forma de uma Grade adaptável.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Эта страница разрешает добавление пользовательских элементов в виде адаптивной сетки.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Bu sayfa, özel öğeleri Uyarlamalı Kılavuz biçiminde eklemenizi sağlar.",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "此页面允许你通过自适应网格的形式添加自定义项。",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "本頁面允許您以 Adaptive Grid 格式新增自訂項目。",
   "identity": "wts.Page.ContentGrid.CodeBehind"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Tato stránka umožňuje přidat vlastní položky formou adaptivní mřížky.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/de-DE.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Auf dieser Seite können Sie benutzerdefinierte Elemente in Form eines adaptiven Rasters hinzufügen.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/es-ES.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite agregar elementos personalizados en la forma de una cuadrícula adaptable.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Cette page vous permet d'ajouter du contenu personnalisé affiché en grille adaptative.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/it-IT.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Questa pagina ti permette di aggiungere elementi personalizzati sotto forma di una griglia adattiva.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "このページでは、適応型グリッドのフォーム内にカスタム アイテムを追加できます。",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "이 페이지에서 맞춤형 항목을 Adaptive Grid 형태로 추가할 수 있습니다.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Ta strona pozwala dodawać własne elementy w postaci adaptacyjnej siatki.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite adicionar itens personalizados na forma de uma Grade adaptável.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Эта страница разрешает добавление пользовательских элементов в виде адаптивной сетки.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Bu sayfa, özel öğeleri Uyarlamalı Kılavuz biçiminde eklemenizi sağlar.",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "此页面允许你通过自适应网格的形式添加自定义项。",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehindVB/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "本頁面允許您以 Adaptive Grid 格式新增自訂項目。",
   "identity": "wts.Page.ContentGrid.CodeBehind.VB"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Tato stránka umožňuje přidat vlastní položky formou adaptivní mřížky.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/de-DE.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Auf dieser Seite können Sie benutzerdefinierte Elemente in Form eines adaptiven Rasters hinzufügen.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/es-ES.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite agregar elementos personalizados en la forma de una cuadrícula adaptable.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Cette page vous permet d'ajouter du contenu personnalisé affiché en grille adaptative.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/it-IT.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Questa pagina ti permette di aggiungere elementi personalizzati sotto forma di una griglia adattiva.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "このページでは、適応型グリッドのフォーム内にカスタム アイテムを追加できます。",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "이 페이지에서 맞춤형 항목을 Adaptive Grid 형태로 추가할 수 있습니다.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Ta strona pozwala dodawać własne elementy w postaci adaptacyjnej siatki.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite adicionar itens personalizados na forma de uma Grade adaptável.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Эта страница разрешает добавление пользовательских элементов в виде адаптивной сетки.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Bu sayfa, özel öğeleri Uyarlamalı Kılavuz biçiminde eklemenizi sağlar.",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "此页面允许你通过自适应网格的形式添加自定义项。",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "本頁面允許您以 Adaptive Grid 格式新增自訂項目。",
   "identity": "wts.Page.ContentGrid.Prism"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Tato stránka umožňuje přidat vlastní položky formou adaptivní mřížky.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/de-DE.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Auf dieser Seite können Sie benutzerdefinierte Elemente in Form eines adaptiven Rasters hinzufügen.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/es-ES.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite agregar elementos personalizados en la forma de una cuadrícula adaptable.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Cette page vous permet d'ajouter du contenu personnalisé affiché en grille adaptative.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/it-IT.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Questa pagina ti permette di aggiungere elementi personalizzati sotto forma di una griglia adattiva.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "このページでは、適応型グリッドのフォーム内にカスタム アイテムを追加できます。",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "이 페이지에서 맞춤형 항목을 Adaptive Grid 형태로 추가할 수 있습니다.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Ta strona pozwala dodawać własne elementy w postaci adaptacyjnej siatki.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite adicionar itens personalizados na forma de uma Grade adaptável.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Эта страница разрешает добавление пользовательских элементов в виде адаптивной сетки.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Bu sayfa, özel öğeleri Uyarlamalı Kılavuz biçiminde eklemenizi sağlar.",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "此页面允许你通过自适应网格的形式添加自定义项。",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGrid/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "本頁面允許您以 Adaptive Grid 格式新增自訂項目。",
   "identity": "wts.Page.ContentGrid"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/cs-CZ.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/cs-CZ.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Tato stránka umožňuje přidat vlastní položky formou adaptivní mřížky.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/de-DE.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/de-DE.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Auf dieser Seite können Sie benutzerdefinierte Elemente in Form eines adaptiven Rasters hinzufügen.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/es-ES.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/es-ES.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite agregar elementos personalizados en la forma de una cuadrícula adaptable.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/fr-FR.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/fr-FR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Cette page vous permet d'ajouter du contenu personnalisé affiché en grille adaptative.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/it-IT.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/it-IT.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Questa pagina ti permette di aggiungere elementi personalizzati sotto forma di una griglia adattiva.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/ja-JP.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/ja-JP.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "このページでは、適応型グリッドのフォーム内にカスタム アイテムを追加できます。",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/ko-KR.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/ko-KR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "이 페이지에서 맞춤형 항목을 Adaptive Grid 형태로 추가할 수 있습니다.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/pl-PL.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/pl-PL.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Ta strona pozwala dodawać własne elementy w postaci adaptacyjnej siatki.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/pt-BR.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/pt-BR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Esta página permite adicionar itens personalizados na forma de uma Grade adaptável.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/ru-RU.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/ru-RU.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Эта страница разрешает добавление пользовательских элементов в виде адаптивной сетки.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/tr-TR.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/tr-TR.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "Bu sayfa, özel öğeleri Uyarlamalı Kılavuz biçiminde eklemenizi sağlar.",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/zh-CN.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/zh-CN.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "此页面允许你通过自适应网格的形式添加自定义项。",
   "identity": "wts.Page.ContentGrid.VB"
 }

--- a/templates/Uwp/Pages/ContentGridVB/.template.config/zh-TW.template.json
+++ b/templates/Uwp/Pages/ContentGridVB/.template.config/zh-TW.template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Microsoft Community",
-  "name": "ContentGrid",
+  "name": "Content Grid",
   "description": "本頁面允許您以 Adaptive Grid 格式新增自訂項目。",
   "identity": "wts.Page.ContentGrid.VB"
 }


### PR DESCRIPTION
Quick summary of changes
- Correct localized names for content grid and web to app link
- Added test to avoid regression

Which issue does this PR relate to?
- #2898 Content Grid is missing space in localized files