### PR TITLE
Issue2938 changetemplateid

### DIFF
--- a/_build/ProjectTemplate-SetPublishingData.ps1
+++ b/_build/ProjectTemplate-SetPublishingData.ps1
@@ -4,12 +4,15 @@ Param(
   [string]$name,
 
   [Parameter(Mandatory=$True,Position=3)]
-  [string]$templateId,
+  [string]$csharptemplateId,
 
   [Parameter(Mandatory=$True,Position=4)]
+  [string]$visualbasictemplateId,
+
+  [Parameter(Mandatory=$True,Position=5)]
   [string]$buildNumber,
 
-  [Parameter(Mandatory=$false,Position=5)]
+  [Parameter(Mandatory=$false,Position=6)]
   [string]$description
 )
 
@@ -41,8 +44,18 @@ if($name){
       if(Test-Path($projectTemplate)){
         [xml]$templateContent = Get-Content $projectTemplate
         $templateContent.VSTemplate.TemplateData.Name = $name
-        $templateContent.VSTemplate.TemplateData.TemplateID = $templateId
-        $templateContent.VSTemplate.TemplateContent.CustomParameters.CustomParameter[1].Value = $versionNumber
+        if($templateContent.VSTemplate.TemplateData.ProjectType -eq 'CSharp')
+        {
+           $templateContent.VSTemplate.TemplateData.TemplateID = $csharptemplateId
+        }
+
+        if($templateContent.VSTemplate.TemplateData.ProjectType -eq 'VisualBasic')
+        {
+           $templateContent.VSTemplate.TemplateData.TemplateID = $visualbasictemplateId
+        }
+
+
+        $templateContent.VSTemplate.TemplateContent.CustomParameters.CustomParameter[2].Value = $versionNumber
       
         if($description)
         {
@@ -50,7 +63,7 @@ if($name){
         }
 
         $templateContent.Save($projectTemplate) 
-        Write-Host "$projectTemplate - Name, TemplateId, Version & Description applied ($name, $templateId, $versionNumber, $description)"
+        Write-Host "$projectTemplate - Name, TemplateId, Version & Description applied ($name, $csharptemplateId/$visualbasictemplateId, $versionNumber, $description)"
       }
     }
   }

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.cs-CZ.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.cs-CZ.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.de-DE.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.de-DE.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.es-ES.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.es-ES.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.fr-FR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.fr-FR.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.it-IT.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.it-IT.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.ja-JP.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.ja-JP.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.ko-KR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.ko-KR.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.pl-PL.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.pl-PL.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.pt-BR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.pt-BR.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.ru-RU.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.ru-RU.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.tr-TR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.tr-TR.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.zh-CN.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.zh-CN.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.zh-TW.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.UWP.2017.Solution/CSharp.UWP.VS2017.Solution.zh-TW.vstemplate
@@ -8,7 +8,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>5471541a-7eac-4feb-a834-0d6ca271a946</TemplateID>
+    <TemplateID>Microsoft.CSharp.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.cs-CZ.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.cs-CZ.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.de-DE.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.de-DE.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.es-ES.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.es-ES.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.fr-FR.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.fr-FR.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.it-IT.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.it-IT.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ja-JP.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ja-JP.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ko-KR.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ko-KR.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.pl-PL.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.pl-PL.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.pt-BR.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.pt-BR.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ru-RU.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ru-RU.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ru-RU.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.ru-RU.vstemplate
@@ -14,6 +14,7 @@
   </TemplateData>
   <TemplateContent>
     <CustomParameters>
+      <CustomParameter Name="$wts.platform$" Value="Uwp"/>
       <CustomParameter Name="$wts.category$" Value="Windows Universal"/>
       <CustomParameter Name="$wts.version$" Value="1.0.0.0"/>
     </CustomParameters>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.tr-TR.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.tr-TR.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.zh-CN.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.zh-CN.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.zh-TW.vstemplate
+++ b/code/src/ProjectTemplates/VBNet.UWP.VS2017.Solution/VBNet.UWP.VS2017.Solution.zh-TW.vstemplate
@@ -6,7 +6,7 @@
     <Icon>windowsTemplateStudio_Logo_256x256.ico</Icon>
     <ProjectType>VisualBasic</ProjectType>
     <SortOrder>1000</SortOrder>
-    <TemplateID>8c9d48fe-478b-483e-bbe6-954d9f1dabe2</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>


### PR DESCRIPTION
Quick summary of changes
- Change template id from guid to string containing categories and Template Name
- Set separate template id for C# and VB templates

Which issue does this PR relate to?
#2938 VS2019: Add tags to project templates
