### PR TITLE
Set RestoreProjectStyle to PackageReference

### DIFF
--- a/templates/Uwp/Features/WinAppDriver/Param_ProjectName.Tests.WinAppDriver/Param_ProjectName.Tests.WinAppDriver.csproj
+++ b/templates/Uwp/Features/WinAppDriver/Param_ProjectName.Tests.WinAppDriver/Param_ProjectName.Tests.WinAppDriver.csproj
@@ -21,6 +21,9 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
   <!--/-:cnd:noEmit -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <OutputPath>bin\Debug\</OutputPath>


### PR DESCRIPTION
Quick summary of changes
Set RestoreProjectStyle to PackageReference for WinAppDriver tests template
- Which issue does this PR relate to?
#3005 Dev-nightly: WinAppDriver in c# is restoring packages to packages.config instead of proj file
