### PR TITLE
Remove Microsoft.NET.Test.Sdk from Test templates as this is added by VS

### DIFF
--- a/templates/Uwp/Features/UnitTests.App.MSTest._VB/.template.config/template.json
+++ b/templates/Uwp/Features/UnitTests.App.MSTest._VB/.template.config/template.json
@@ -132,17 +132,6 @@
         "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.vbproj"
       },
       "continueOnError": "true"
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "15.9.0",
-        "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.vbproj"
-      },
-      "continueOnError": "true"
     }
   ]
 }

--- a/templates/Uwp/Features/UnitTests.App.MSTest/.template.config/template.json
+++ b/templates/Uwp/Features/UnitTests.App.MSTest/.template.config/template.json
@@ -132,17 +132,6 @@
         "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj"
       },
       "continueOnError": "true"
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "15.9.0",
-        "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj"
-      },
-      "continueOnError": "true"
     }
   ]
 }

--- a/templates/Uwp/Features/UnitTests.App.xUnit._VB/.template.config/template.json
+++ b/templates/Uwp/Features/UnitTests.App.xUnit._VB/.template.config/template.json
@@ -132,17 +132,6 @@
         "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.vbproj"
       },
       "continueOnError": "true"
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "15.9.0",
-        "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.vbproj"
-      },
-      "continueOnError": "true"
     }
   ]
 }

--- a/templates/Uwp/Features/UnitTests.App.xUnit/.template.config/template.json
+++ b/templates/Uwp/Features/UnitTests.App.xUnit/.template.config/template.json
@@ -132,17 +132,6 @@
         "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.csproj"
       },
       "continueOnError": "true"
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "15.9.0",
-        "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.csproj"
-      },
-      "continueOnError": "true"
     }
   ]
 }


### PR DESCRIPTION
- Quick summary of changes
Remove Microsoft.NET.Test.Sdk from Test templates as this is added by VS

- Which issue does this PR relate to?
#3035 Dev-Nightly: Failure adding nuget Microsoft.Net.Test.Sdk 15.9.0 to XUnit and MSTest project in VS2019
