### PR TITLE
Issue3007 ensureencoding

### DIFF
--- a/code/src/Core/PostActions/Catalog/Merge/MergePostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/MergePostAction.cs
@@ -36,13 +36,18 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             var merge = File.ReadAllLines(Config.FilePath).ToList();
 
             var originalEncoding = GetEncoding(originalFilePath);
-            var otherEncoding = GetEncoding(Config.FilePath);
 
-            if (originalEncoding.EncodingName != otherEncoding.EncodingName
-                || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+            // Only check encoding on new project, might have changed on right click
+            if (GenContext.Current.GenerationOutputPath == GenContext.Current.DestinationPath)
             {
-                HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
-                return;
+                var otherEncoding = GetEncoding(Config.FilePath);
+
+                if (originalEncoding.EncodingName != otherEncoding.EncodingName
+                    || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+                {
+                    HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
+                    return;
+                }
             }
 
             IEnumerable<string> result = source.Merge(merge, out string errorLine);

--- a/code/src/Core/PostActions/Catalog/Merge/MergeResourceDictionaryPostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/MergeResourceDictionaryPostAction.cs
@@ -46,13 +46,18 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                 var sourceRoot = XElement.Load(originalFilePath);
 
                 var originalEncoding = GetEncoding(originalFilePath);
-                var otherEncoding = GetEncoding(Config.FilePath);
 
-                if (originalEncoding.EncodingName != otherEncoding.EncodingName
-                    || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+                // Only check encoding on new project, might have changed on right click
+                if (GenContext.Current.GenerationOutputPath == GenContext.Current.DestinationPath)
                 {
-                    HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
-                    return;
+                    var otherEncoding = GetEncoding(Config.FilePath);
+
+                    if (originalEncoding.EncodingName != otherEncoding.EncodingName
+                        || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+                    {
+                        HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
+                        return;
+                    }
                 }
 
                 foreach (var node in GetNodesToMerge(mergeRoot))

--- a/code/src/Core/PostActions/Catalog/Merge/SearchAndReplacePostAction.cs
+++ b/code/src/Core/PostActions/Catalog/Merge/SearchAndReplacePostAction.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 
 using Microsoft.Templates.Core.Extensions;
+using Microsoft.Templates.Core.Gen;
 using Microsoft.Templates.Core.Resources;
 
 namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
@@ -38,13 +39,18 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             var instructions = File.ReadAllLines(Config.FilePath).ToList();
 
             var originalEncoding = GetEncoding(originalFilePath);
-            var otherEncoding = GetEncoding(Config.FilePath);
 
-            if (originalEncoding.EncodingName != otherEncoding.EncodingName
-                || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+            // Only check encoding on new project, might have changed on right click
+            if (GenContext.Current.GenerationOutputPath == GenContext.Current.DestinationPath)
             {
-                HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
-                return;
+                var otherEncoding = GetEncoding(Config.FilePath);
+
+                if (originalEncoding.EncodingName != otherEncoding.EncodingName
+                    || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+                {
+                    HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
+                    return;
+                }
             }
 
             var search = new List<string>();

--- a/code/test/Core.Test/PostActions/Catalog/MergePostactionTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/MergePostactionTest.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             File.Copy(Path.Combine(Environment.CurrentDirectory, $"TestData\\Merge\\Source.cs"), sourceFile, true);
             File.Copy(Path.Combine(Environment.CurrentDirectory, $"TestData\\Merge\\Source_postaction.cs"), mergeFile, true);
 
+            GenContext.Current = new FakeContextProvider()
+            {
+                GenerationOutputPath = Directory.GetCurrentDirectory(),
+                DestinationPath = Directory.GetCurrentDirectory(),
+            };
+
             var mergePostAction = new MergePostAction(templateName, new MergeConfiguration(mergeFile, true));
             mergePostAction.Execute();
 
@@ -49,6 +55,12 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             var templateName = "Test";
             var sourceFile = Path.GetFullPath(@".\TestData\Merge\Source_fail.cs");
             var mergeFile = Path.GetFullPath(@".\TestData\Merge\Source_fail_postaction.cs");
+
+            GenContext.Current = new FakeContextProvider()
+            {
+                GenerationOutputPath = Directory.GetCurrentDirectory(),
+                DestinationPath = Directory.GetCurrentDirectory(),
+            };
 
             var mergePostAction = new MergePostAction(templateName, new MergeConfiguration(mergeFile, true));
 

--- a/code/test/Core.Test/PostActions/Catalog/MergeResourceDictionaryPostactionTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/MergeResourceDictionaryPostactionTest.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
 
             var config = new MergeConfiguration(postaction, true);
 
+            GenContext.Current = new FakeContextProvider()
+            {
+                GenerationOutputPath = Directory.GetCurrentDirectory(),
+                DestinationPath = Directory.GetCurrentDirectory(),
+            };
+
             var mergeResourceDictionaryPostAction = new MergeResourceDictionaryPostAction("Test", config);
             mergeResourceDictionaryPostAction.Execute();
 

--- a/code/test/Core.Test/PostActions/Catalog/SearchAndReplacePostActionTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/SearchAndReplacePostActionTest.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             File.Copy(Path.Combine(Environment.CurrentDirectory, $"TestData\\SearchReplace\\Source.cs"), sourceFile, true);
             File.Copy(Path.Combine(Environment.CurrentDirectory, $"TestData\\SearchReplace\\Source_searchreplace.cs"), mergeFile, true);
 
+            GenContext.Current = new FakeContextProvider()
+            {
+                GenerationOutputPath = Directory.GetCurrentDirectory(),
+                DestinationPath = Directory.GetCurrentDirectory(),
+            };
+
             var mergePostAction = new SearchAndReplacePostAction(templateName, new MergeConfiguration(mergeFile, true));
             mergePostAction.Execute();
 

--- a/code/test/Core.Test/PostActions/Catalog/SearchAndReplacePostActionTest.cs
+++ b/code/test/Core.Test/PostActions/Catalog/SearchAndReplacePostActionTest.cs
@@ -55,6 +55,12 @@ namespace Microsoft.Templates.Core.Test.PostActions.Catalog
             var templateName = "Test";
             var mergeFile = Path.GetFullPath(@".\TestData\SearchReplace\NoSource_searchreplace.cs");
 
+            GenContext.Current = new FakeContextProvider()
+            {
+                GenerationOutputPath = Directory.GetCurrentDirectory(),
+                DestinationPath = Directory.GetCurrentDirectory(),
+            };
+
             var mergePostAction = new SearchAndReplacePostAction(templateName, new MergeConfiguration(mergeFile, true));
 
             Exception ex = Assert.Throws<Exception>(() => mergePostAction.Execute());


### PR DESCRIPTION
Quick summary of changes
- Encoding check should only be done on new projects, not on right click
Which issue does this PR relate to?
-#3006 Ensure encoding in postactions
