### PR TITLE
Do not open proj files from right click addition

### DIFF
--- a/code/src/Core/PostActions/Catalog/NewItemGeneration/CopyFilesToProjectPostAction.cs
+++ b/code/src/Core/PostActions/Catalog/NewItemGeneration/CopyFilesToProjectPostAction.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog
 {
     public class CopyFilesToProjectPostAction : PostAction<TempGenerationResult>
     {
-        private List<string> excludeFromOpeningExtensions = new List<string>() { ".png", ".jpg", ".bmp", ".ico" };
+        private List<string> excludeFromOpeningExtensions = new List<string>() { ".png", ".jpg", ".bmp", ".ico", ".csproj", ".vbproj" };
 
         public CopyFilesToProjectPostAction(TempGenerationResult config)
             : base(config)


### PR DESCRIPTION
Quick summary of changes
- Do not open proj files from right click addition

Which issue does this PR relate to?
- #3065 Adding Test App features fails when using right click
