### PR TITLE
Further Web API improvements

### DIFF
--- a/_utils/List-CSharp-Templates-Without-VisualBasic-Equivalents.ps1
+++ b/_utils/List-CSharp-Templates-Without-VisualBasic-Equivalents.ps1
@@ -2,7 +2,7 @@
 # Any output indicates missing VB templates.
 
 # Get list of all templates
-$allTemplates = Get-ChildItem ..\templates\* -Recurse -include template.json | where { $_.FullName -notmatch "\\templates\\Uwp\\Test\\" } | % { Write-Output $_.FullName }
+$allTemplates = Get-ChildItem ..\templates\* -Recurse -include template.json | where { $_.FullName -notmatch "\\templates\\Uwp\\SC\\" } | % { Write-Output $_.FullName }
 Foreach ($t in $allTemplates)
 {
     if ($t -like '*_shared\Page.AddConnectedAnimationService*')

--- a/templates/Uwp/SC/_comp/T.SC.WebApi/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.WebApi/.template.config/template.json
@@ -11,7 +11,7 @@
     "wts.outputToParent": "true",
     "wts.platform" : "Uwp",
     "wts.version": "1.0.0",
-    "wts.compositionFilter": "identity == wts.Service.WebApi & $feature == wts.Feat.StyleCop",
+    "wts.compositionFilter": "groupIdentity == wts.Service.WebApi & $feature == wts.Feat.StyleCop",
     "wts.licenses": "[StyleCop.Analyzers](https://licenses.nuget.org/Apache-2.0)"
   },
   "sourceName": "wts.ItemName",

--- a/templates/Uwp/Services/WebApi.Prism/.template.config/template.json
+++ b/templates/Uwp/Services/WebApi.Prism/.template.config/template.json
@@ -42,29 +42,5 @@
       "type": "parameter",
       "replaces": "Param_RootNamespace"
     }
-  },
-  "postActions": [
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.AspNetCore.App",
-        "version": "2.1.11",
-        "projectPath": "Param_ProjectName.WebApi\\Param_ProjectName.WebApi.csproj"
-      },
-      "continueOnError": "true"
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Swashbuckle.AspNetCore",
-        "version" : "4.0.1",
-        "projectPath": "Param_ProjectName.WebApi\\Param_ProjectName.WebApi.csproj"
-      },
-      "continueOnError": "true"
-    }
-  ]
+  }
 }

--- a/templates/Uwp/Services/WebApi/.template.config/template.json
+++ b/templates/Uwp/Services/WebApi/.template.config/template.json
@@ -42,29 +42,5 @@
       "type": "parameter",
       "replaces": "Param_RootNamespace"
     }
-  },
-  "postActions": [
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.AspNetCore.App",
-        "version": "2.1.11",
-        "projectPath": "Param_ProjectName.WebApi\\Param_ProjectName.WebApi.csproj"
-      },
-      "continueOnError": "true"
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Swashbuckle.AspNetCore",
-        "version" : "4.0.1",
-        "projectPath": "Param_ProjectName.WebApi\\Param_ProjectName.WebApi.csproj"
-      },
-      "continueOnError": "true"
-    }
-  ]
+  }
 }

--- a/templates/Uwp/_comp/_shared/Services.WebApi/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Services.WebApi/.template.config/template.json
@@ -40,17 +40,6 @@
       "manualInstructions": [ ],
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
-        "packageId" : "Microsoft.AspNetCore.App",
-        "version": "2.1.11",
-        "projectPath": "Param_ProjectName.WebApi\\Param_ProjectName.WebApi.csproj"
-      },
-      "continueOnError": "true"
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
         "packageId" : "Swashbuckle.AspNetCore",
         "version" : "4.0.1",
         "projectPath": "Param_ProjectName.WebApi\\Param_ProjectName.WebApi.csproj"

--- a/templates/Uwp/_comp/_shared/Services.WebApi/Param_ProjectName.WebApi/Param_ProjectName.WebApi.csproj
+++ b/templates/Uwp/_comp/_shared/Services.WebApi/Param_ProjectName.WebApi/Param_ProjectName.WebApi.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\Param_ProjectName.Core\Param_ProjectName.Core.csproj" />
   </ItemGroup>
   
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" /> 
+  </ItemGroup>
+  
 </Project>

--- a/templates/Uwp/_comp/_shared/Services.WebApi/Param_ProjectName.WebApi/Properties/launchSettings.json
+++ b/templates/Uwp/_comp/_shared/Services.WebApi/Param_ProjectName.WebApi/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:53848",
-      "sslPort": 53849
+      "sslPort": 44340
     }
   },
   "profiles": {
@@ -17,7 +17,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Param_ProjectName.MobileAppService": {
+    "Param_ProjectName.WebApi": {
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "swagger",


### PR DESCRIPTION
For #3181 
(and a continuation from #3227)

- Adds a metapackage reference (no version number) to `Microsoft.AspNetCore.App`
- also fixed automated testing of WebApi project with StyleCop

**Note**
I'm having issues with SSL in a dev environment on my machine and so can't test this fully at the moment.
Equivalent Web API project created as part of a Xamarin app also has the same error, so hoping this is something on my machine and not in the templates. I'm not aware of having changed anything that might impact this so hoping it's not an issue with the templates.