### PR TITLE
Remove AppDesignerFolder from proj file

### DIFF
--- a/templates/Uwp/Projects/Default._VB/wts.DefaultProject.vbproj
+++ b/templates/Uwp/Projects/Default._VB/wts.DefaultProject.vbproj
@@ -7,7 +7,6 @@
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{7CF740F7-735F-48EA-8B7B-3FFA4902371C}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Param_RootNamespace</RootNamespace>
     <AssemblyName>wts.DefaultProject</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>


### PR DESCRIPTION
For #3296

Removes project setting that applies to C# and not VB.

No other/related changes necessary.