### PR TITLE
Change PrimaryOutputPaths format

### DIFF
--- a/_utils/code-snippets.json
+++ b/_utils/code-snippets.json
@@ -156,7 +156,7 @@
 		"prefix": "wts.primaryOutput",
 		"body": [
 		"{",
-		"  \"path\": \".\\\\\\FolderName\\\\\\FileName.extension\"",
+		"  \"path\": \"FolderName/FileName.extension\"",
 		"}"
 		],
 		"description": "Add a primary output block to be added on WTS template.json"
@@ -165,7 +165,7 @@
 		"prefix": "wts.primaryOutputToParent",
 		"body": [
 		"{",
-		"  \"path\": \".\\\\\\Param_ProjectName\\\\\\FolderName\\\\\\FileName.extension\"",
+		"  \"path\": \"Param_ProjectName/FolderName/FileName.extension\"",
 		"}"
 		],
 		"description": "Add a primary output to parent block to be added on WTS template.json"

--- a/code/tools/TemplateValidator/TemplateJsonVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateJsonVerifier.cs
@@ -108,6 +108,8 @@ namespace TemplateValidator
 
                 var templateRoot = filePath.Replace("\\.template.config\\template.json", string.Empty);
 
+                EnsureValidPrimaryOutputPaths(template, results);
+
                 EnsureAllDefinedPrimaryOutputsExist(template, templateRoot, results);
 
                 EnsureAllDefinedGuidsAreUsed(template, templateRoot, results);
@@ -553,6 +555,20 @@ namespace TemplateValidator
                 if (template.PostActions != null && template.PostActions.Any(p => p.ActionId == "0B814718-16A3-4F7F-89F1-69C0F9170EAD"))
                 {
                     results.Add($"Missing license on template {template.Identity}");
+                }
+            }
+        }
+
+        private static void EnsureValidPrimaryOutputPaths(ValidationTemplateInfo template, List<string> results)
+        {
+            if (template.PrimaryOutputs != null)
+            {
+                foreach (var primaryOutput in template.PrimaryOutputs)
+                {
+                    if (primaryOutput.Path.Contains("\\"))
+                    {
+                        results.Add($"Primary output '{primaryOutput.Path}' should use '/' instead of '\\'.");
+                    }
                 }
             }
         }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -130,13 +130,13 @@ The replacements are done based on the configuration established in the `templat
   "preferNameDirectory": true,
   "PrimaryOutputs": [                             //The primary outputs are the list of items that are returned to the caller after the generation.
     {
-      "path": ".\\Views\\BlankViewPage.xaml"
+      "path": "Views/BlankViewPage.xaml"
     },
     {
-      "path": ".\\Views\\BlankViewPage.xaml.cs"
+      "path": "Views/BlankViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\BlankViewViewModel.cs"
+      "path": "ViewModels/BlankViewViewModel.cs"
     }
   ],
   "symbols": {                                    //Symbols define a collection of replacements to be done while generating.

--- a/templates/Uwp/Features/3DLauncher._VB/.template.config/template.json
+++ b/templates/Uwp/Features/3DLauncher._VB/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Assets\\3dlogo.glb"
+      "path": "Assets/3dlogo.glb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/3DLauncher/.template.config/template.json
+++ b/templates/Uwp/Features/3DLauncher/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Assets\\3dlogo.glb"
+      "path": "Assets/3dlogo.glb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/AppDotConfig._VB/.template.config/template.json
+++ b/templates/Uwp/Features/AppDotConfig._VB/.template.config/template.json
@@ -28,7 +28,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\App.config"
+      "path": "Param_ProjectName/App.config"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/AppDotConfig/.template.config/template.json
+++ b/templates/Uwp/Features/AppDotConfig/.template.config/template.json
@@ -28,7 +28,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\App.config"
+      "path": "Param_ProjectName/App.config"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/BackgroundTask.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/BackgroundTask.Prism/.template.config/template.json
@@ -26,19 +26,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Services\\BackgroundTaskService.cs"
+      "path": "Param_ProjectName/Services/BackgroundTaskService.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Services\\IBackgroundTaskService.cs"
+      "path": "Param_ProjectName/Services/IBackgroundTaskService.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\BackgroundTasks\\BackgroundTask.cs"
+      "path": "Param_ProjectName/BackgroundTasks/BackgroundTask.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\BackgroundTasks\\BackgroundTaskFeature.cs"
+      "path": "Param_ProjectName/BackgroundTasks/BackgroundTaskFeature.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\TaskExtensions.cs"
+      "path": "Param_ProjectName.Core/Helpers/TaskExtensions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/BackgroundTask._VB/.template.config/template.json
+++ b/templates/Uwp/Features/BackgroundTask._VB/.template.config/template.json
@@ -26,16 +26,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Services\\BackgroundTaskService.vb"
+      "path": "Param_ProjectName/Services/BackgroundTaskService.vb"
     },
     {
-      "path": ".\\Param_ProjectName\\BackgroundTasks\\BackgroundTask.vb"
+      "path": "Param_ProjectName/BackgroundTasks/BackgroundTask.vb"
     },
     {
-      "path": ".\\Param_ProjectName\\BackgroundTasks\\BackgroundTaskFeature.vb"
+      "path": "Param_ProjectName/BackgroundTasks/BackgroundTaskFeature.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\TaskExtensions.vb"
+      "path": "Param_ProjectName.Core/Helpers/TaskExtensions.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/BackgroundTask/.template.config/template.json
+++ b/templates/Uwp/Features/BackgroundTask/.template.config/template.json
@@ -26,16 +26,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Services\\BackgroundTaskService.cs"
+      "path": "Param_ProjectName/Services/BackgroundTaskService.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\BackgroundTasks\\BackgroundTask.cs"
+      "path": "Param_ProjectName/BackgroundTasks/BackgroundTask.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\BackgroundTasks\\BackgroundTaskFeature.cs"
+      "path": "Param_ProjectName/BackgroundTasks/BackgroundTaskFeature.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\TaskExtensions.cs"
+      "path": "Param_ProjectName.Core/Helpers/TaskExtensions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DeepLinking.MVVMLight._VB/.template.config/template.json
+++ b/templates/Uwp/Features/DeepLinking.MVVMLight._VB/.template.config/template.json
@@ -28,22 +28,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\SchemeActivationConfig.vb"
+      "path": "Activation/SchemeActivationConfig.vb"
     },
     {
-      "path": ".\\Activation\\SchemeActivationData.vb"
+      "path": "Activation/SchemeActivationData.vb"
     },
     {
-      "path": ".\\Activation\\SchemeActivationHandler.vb"
+      "path": "Activation/SchemeActivationHandler.vb"
     },
     {
-      "path": ".\\ViewModels\\SchemeActivationSampleViewModel.vb"
+      "path": "ViewModels/SchemeActivationSampleViewModel.vb"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml"
+      "path": "Views/SchemeActivationSamplePage.xaml"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml.vb"
+      "path": "Views/SchemeActivationSamplePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DeepLinking.MVVMLight/.template.config/template.json
+++ b/templates/Uwp/Features/DeepLinking.MVVMLight/.template.config/template.json
@@ -28,22 +28,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\SchemeActivationConfig.cs"
+      "path": "Activation/SchemeActivationConfig.cs"
     },
     {
-      "path": ".\\Activation\\SchemeActivationData.cs"
+      "path": "Activation/SchemeActivationData.cs"
     },
     {
-      "path": ".\\Activation\\SchemeActivationHandler.cs"
+      "path": "Activation/SchemeActivationHandler.cs"
     },
     {
-      "path": ".\\ViewModels\\SchemeActivationSampleViewModel.cs"
+      "path": "ViewModels/SchemeActivationSampleViewModel.cs"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml"
+      "path": "Views/SchemeActivationSamplePage.xaml"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml.cs"
+      "path": "Views/SchemeActivationSamplePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DeepLinking.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/DeepLinking.Prism/.template.config/template.json
@@ -28,19 +28,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\SchemeActivationConfig.cs"
+      "path": "Activation/SchemeActivationConfig.cs"
     },
     {
-      "path": ".\\Activation\\SchemeActivationData.cs"
+      "path": "Activation/SchemeActivationData.cs"
     },
     {
-      "path": ".\\ViewModels\\SchemeActivationSampleViewModel.cs"
+      "path": "ViewModels/SchemeActivationSampleViewModel.cs"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml"
+      "path": "Views/SchemeActivationSamplePage.xaml"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml.cs"
+      "path": "Views/SchemeActivationSamplePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DeepLinking._VB/.template.config/template.json
+++ b/templates/Uwp/Features/DeepLinking._VB/.template.config/template.json
@@ -28,19 +28,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\SchemeActivationConfig.vb"
+      "path": "Activation/SchemeActivationConfig.vb"
     },
     {
-      "path": ".\\Activation\\SchemeActivationData.vb"
+      "path": "Activation/SchemeActivationData.vb"
     },
     {
-      "path": ".\\Activation\\SchemeActivationHandler.vb"
+      "path": "Activation/SchemeActivationHandler.vb"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml"
+      "path": "Views/SchemeActivationSamplePage.xaml"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml.vb"
+      "path": "Views/SchemeActivationSamplePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DeepLinking/.template.config/template.json
+++ b/templates/Uwp/Features/DeepLinking/.template.config/template.json
@@ -28,19 +28,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\SchemeActivationConfig.cs"
+      "path": "Activation/SchemeActivationConfig.cs"
     },
     {
-      "path": ".\\Activation\\SchemeActivationData.cs"
+      "path": "Activation/SchemeActivationData.cs"
     },
     {
-      "path": ".\\Activation\\SchemeActivationHandler.cs"
+      "path": "Activation/SchemeActivationHandler.cs"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml"
+      "path": "Views/SchemeActivationSamplePage.xaml"
     },
     {
-      "path": ".\\Views\\SchemeActivationSamplePage.xaml.cs"
+      "path": "Views/SchemeActivationSamplePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DragAndDrop.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Features/DragAndDrop.CodeBehind._VB/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\DragAndDrop\\DropConfiguration.vb"
+      "path": "Services/DragAndDrop/DropConfiguration.vb"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\ListViewDropConfiguration.vb"
+      "path": "Services/DragAndDrop/ListViewDropConfiguration.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DragAndDrop.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Features/DragAndDrop.CodeBehind/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\DragAndDrop\\DropConfiguration.cs"
+      "path": "Services/DragAndDrop/DropConfiguration.cs"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\ListViewDropConfiguration.cs"
+      "path": "Services/DragAndDrop/ListViewDropConfiguration.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DragAndDrop._VB/.template.config/template.json
+++ b/templates/Uwp/Features/DragAndDrop._VB/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\DragAndDrop\\DropConfiguration.vb"
+      "path": "Services/DragAndDrop/DropConfiguration.vb"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\ListViewDropConfiguration.vb"
+      "path": "Services/DragAndDrop/ListViewDropConfiguration.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/DragAndDrop/.template.config/template.json
+++ b/templates/Uwp/Features/DragAndDrop/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\DragAndDrop\\DropConfiguration.cs"
+      "path": "Services/DragAndDrop/DropConfiguration.cs"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\ListViewDropConfiguration.cs"
+      "path": "Services/DragAndDrop/ListViewDropConfiguration.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/FirstUsePrompt.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/FirstUsePrompt.Prism/.template.config/template.json
@@ -26,15 +26,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\FirstRunDisplayService.cs"
+      "path": "Services/FirstRunDisplayService.cs"
     },
     {
-      "path": ".\\Services\\IFirstRunDisplayService.cs"
-    },    {
-      "path": ".\\Views\\FirstRunDialog.xaml"
+      "path": "Services/IFirstRunDisplayService.cs"
+    },    
+    {
+      "path": "Views/FirstRunDialog.xaml"
     },
     {
-      "path": ".\\Views\\FirstRunDialog.xaml.cs"
+      "path": "Views/FirstRunDialog.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/FirstUsePrompt._VB/.template.config/template.json
+++ b/templates/Uwp/Features/FirstUsePrompt._VB/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\FirstRunDisplayService.vb"
+      "path": "Services/FirstRunDisplayService.vb"
     },
     {
-      "path": ".\\Views\\FirstRunDialog.xaml"
+      "path": "Views/FirstRunDialog.xaml"
     },
     {
-      "path": ".\\Views\\FirstRunDialog.xaml.vb"
+      "path": "Views/FirstRunDialog.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/FirstUsePrompt/.template.config/template.json
+++ b/templates/Uwp/Features/FirstUsePrompt/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\FirstRunDisplayService.cs"
+      "path": "Services/FirstRunDisplayService.cs"
     },
     {
-      "path": ".\\Views\\FirstRunDialog.xaml"
+      "path": "Views/FirstRunDialog.xaml"
     },
     {
-      "path": ".\\Views\\FirstRunDialog.xaml.cs"
+      "path": "Views/FirstRunDialog.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/HubNotifications.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/HubNotifications.Prism/.template.config/template.json
@@ -29,10 +29,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\HubNotificationsFeatureService.cs"
+      "path": "Services/HubNotificationsFeatureService.cs"
     },
     {
-      "path": ".\\Services\\IHubNotificationsFeatureService.cs"
+      "path": "Services/IHubNotificationsFeatureService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/HubNotifications._VB/.template.config/template.json
+++ b/templates/Uwp/Features/HubNotifications._VB/.template.config/template.json
@@ -29,7 +29,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\HubNotificationsFeatureService.vb"
+      "path": "Services/HubNotificationsFeatureService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/HubNotifications/.template.config/template.json
+++ b/templates/Uwp/Features/HubNotifications/.template.config/template.json
@@ -29,7 +29,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\HubNotificationsFeatureService.cs"
+      "path": "Services/HubNotificationsFeatureService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/LiveTile.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/LiveTile.Prism/.template.config/template.json
@@ -30,13 +30,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ILiveTileFeatureService.cs"
+      "path": "Services/ILiveTileFeatureService.cs"
     },
     {
-      "path": ".\\Services\\LiveTileFeatureService.cs"
+      "path": "Services/LiveTileFeatureService.cs"
     },
     {
-      "path": ".\\Services\\LiveTileFeatureService.Samples.cs"
+      "path": "Services/LiveTileFeatureService.Samples.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/LiveTile._VB/.template.config/template.json
+++ b/templates/Uwp/Features/LiveTile._VB/.template.config/template.json
@@ -30,10 +30,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\LiveTileFeatureService.vb"
+      "path": "Services/LiveTileFeatureService.vb"
     },
     {
-      "path": ".\\Services\\LiveTileFeatureService.Samples.vb"
+      "path": "Services/LiveTileFeatureService.Samples.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/LiveTile/.template.config/template.json
+++ b/templates/Uwp/Features/LiveTile/.template.config/template.json
@@ -30,10 +30,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\LiveTileFeatureService.cs"
+      "path": "Services/LiveTileFeatureService.cs"
     },
     {
-      "path": ".\\Services\\LiveTileFeatureService.Samples.cs"
+      "path": "Services/LiveTileFeatureService.Samples.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/MultiView._VB/.template.config/template.json
+++ b/templates/Uwp/Features/MultiView._VB/.template.config/template.json
@@ -29,10 +29,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ViewLifetimeControl.vb"
+      "path": "Services/ViewLifetimeControl.vb"
     },
     {
-      "path": ".\\Services\\WindowManagerService.vb"
+      "path": "Services/WindowManagerService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/MultiView/.template.config/template.json
+++ b/templates/Uwp/Features/MultiView/.template.config/template.json
@@ -29,10 +29,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ViewLifetimeControl.cs"
+      "path": "Services/ViewLifetimeControl.cs"
     },
     {
-      "path": ".\\Services\\WindowManagerService.cs"
+      "path": "Services/WindowManagerService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/SettingsStorage._VB/.template.config/template.json
+++ b/templates/Uwp/Features/SettingsStorage._VB/.template.config/template.json
@@ -28,10 +28,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Helpers\\SettingsStorageExtensions.vb"
+      "path": "Param_ProjectName/Helpers/SettingsStorageExtensions.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\Json.vb"
+      "path": "Param_ProjectName.Core/Helpers/Json.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/SettingsStorage/.template.config/template.json
+++ b/templates/Uwp/Features/SettingsStorage/.template.config/template.json
@@ -28,10 +28,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Helpers\\SettingsStorageExtensions.cs"
+      "path": "Param_ProjectName/Helpers/SettingsStorageExtensions.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\Json.cs"
+      "path": "Param_ProjectName.Core/Helpers/Json.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ShareSource._VB/.template.config/template.json
+++ b/templates/Uwp/Features/ShareSource._VB/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\ShareSourceFeatureData.vb"
+      "path": "Models/ShareSourceFeatureData.vb"
     },
     {
-      "path": ".\\Models\\ShareSourceFeatureItem.vb"
+      "path": "Models/ShareSourceFeatureItem.vb"
     },
     {
-      "path": ".\\Helpers\\DataRequestExtensions.vb"
+      "path": "Helpers/DataRequestExtensions.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ShareSource/.template.config/template.json
+++ b/templates/Uwp/Features/ShareSource/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\ShareSourceFeatureData.cs"
+      "path": "Models/ShareSourceFeatureData.cs"
     },
     {
-      "path": ".\\Models\\ShareSourceFeatureItem.cs"
+      "path": "Models/ShareSourceFeatureItem.cs"
     },
     {
-      "path": ".\\Helpers\\DataRequestExtensions.cs"
+      "path": "Helpers/DataRequestExtensions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ShareTarget.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Features/ShareTarget.CodeBehind._VB/.template.config/template.json
@@ -25,22 +25,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\SharedDataStorageItemsModel.vb"
+      "path": "Models/SharedDataStorageItemsModel.vb"
     },
     {
-      "path": ".\\Models\\SharedDataModelBase.vb"
+      "path": "Models/SharedDataModelBase.vb"
     },
     {
-      "path": ".\\Models\\SharedDataWebLinkModel.vb"
+      "path": "Models/SharedDataWebLinkModel.vb"
     },
     {
-      "path": ".\\TemplateSelectors\\SharedContentTemplateSelector.vb"
+      "path": "TemplateSelectors/SharedContentTemplateSelector.vb"
     },
     {
-      "path": ".\\Views\\ShareTargetFeaturePage.xaml"
+      "path": "Views/ShareTargetFeaturePage.xaml"
     },
     {
-      "path": ".\\Views\\ShareTargetFeaturePage.xaml.vb"
+      "path": "Views/ShareTargetFeaturePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ShareTarget.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Features/ShareTarget.CodeBehind/.template.config/template.json
@@ -25,22 +25,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\SharedDataStorageItemsModel.cs"
+      "path": "Models/SharedDataStorageItemsModel.cs"
     },
     {
-      "path": ".\\Models\\SharedDataModelBase.cs"
+      "path": "Models/SharedDataModelBase.cs"
     },
     {
-      "path": ".\\Models\\SharedDataWebLinkModel.cs"
+      "path": "Models/SharedDataWebLinkModel.cs"
     },
     {
-      "path": ".\\TemplateSelectors\\SharedContentTemplateSelector.cs"
+      "path": "TemplateSelectors/SharedContentTemplateSelector.cs"
     },
     {
-      "path": ".\\Views\\ShareTargetFeaturePage.xaml"
+      "path": "Views/ShareTargetFeaturePage.xaml"
     },
     {
-      "path": ".\\Views\\ShareTargetFeaturePage.xaml.cs"
+      "path": "Views/ShareTargetFeaturePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ShareTarget.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/ShareTarget.Prism/.template.config/template.json
@@ -25,25 +25,25 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\SharedDataStorageItemsViewModel.cs"
+      "path": "ViewModels/SharedDataStorageItemsViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\SharedDataViewModelBase.cs"
+      "path": "ViewModels/SharedDataViewModelBase.cs"
     },
     {
-      "path": ".\\ViewModels\\SharedDataWebLinkViewModel.cs"
+      "path": "ViewModels/SharedDataWebLinkViewModel.cs"
     },
     {
-      "path": ".\\Helpers\\ShareOperationExtensions.cs"
+      "path": "Helpers/ShareOperationExtensions.cs"
     },
     {
-      "path": ".\\ViewModels\\ShareTargetFeatureViewModel.cs"
+      "path": "ViewModels/ShareTargetFeatureViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShareTargetFeaturePage.xaml"
+      "path": "Views/ShareTargetFeaturePage.xaml"
     },
     {
-      "path": ".\\Views\\ShareTargetFeaturePage.xaml.cs"
+      "path": "Views/ShareTargetFeaturePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ShareTarget._VB/.template.config/template.json
+++ b/templates/Uwp/Features/ShareTarget._VB/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\SharedDataStorageItemsViewModel.vb"
+      "path": "ViewModels/SharedDataStorageItemsViewModel.vb"
     },
     {
-      "path": ".\\ViewModels\\SharedDataViewModelBase.vb"
+      "path": "ViewModels/SharedDataViewModelBase.vb"
     },
     {
-      "path": ".\\ViewModels\\SharedDataWebLinkViewModel.vb"
+      "path": "ViewModels/SharedDataWebLinkViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ShareTarget/.template.config/template.json
+++ b/templates/Uwp/Features/ShareTarget/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\SharedDataStorageItemsViewModel.cs"
+      "path": "ViewModels/SharedDataStorageItemsViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\SharedDataViewModelBase.cs"
+      "path": "ViewModels/SharedDataViewModelBase.cs"
     },
     {
-      "path": ".\\ViewModels\\SharedDataWebLinkViewModel.cs"
+      "path": "ViewModels/SharedDataWebLinkViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/StoreNotifications.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/StoreNotifications.Prism/.template.config/template.json
@@ -29,10 +29,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\StoreNotificationsFeatureService.cs"
+      "path": "Services/StoreNotificationsFeatureService.cs"
     },
     {
-      "path": ".\\Services\\IStoreNotificationsFeatureService.cs"
+      "path": "Services/IStoreNotificationsFeatureService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/StoreNotifications._VB/.template.config/template.json
+++ b/templates/Uwp/Features/StoreNotifications._VB/.template.config/template.json
@@ -29,7 +29,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\StoreNotificationsFeatureService.vb"
+      "path": "Services/StoreNotificationsFeatureService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/StoreNotifications/.template.config/template.json
+++ b/templates/Uwp/Features/StoreNotifications/.template.config/template.json
@@ -29,7 +29,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\StoreNotificationsFeatureService.cs"
+      "path": "Services/StoreNotificationsFeatureService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/SuspendAndResume._VB/.template.config/template.json
+++ b/templates/Uwp/Features/SuspendAndResume._VB/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\SuspendAndResumeService.vb"
+      "path": "Services/SuspendAndResumeService.vb"
     },
     {
-      "path": ".\\Services\\SuspendAndResumeArgs.vb"
+      "path": "Services/SuspendAndResumeArgs.vb"
     },
     {
-      "path": ".\\Services\\SuspensionState.vb"
+      "path": "Services/SuspensionState.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/SuspendAndResume/.template.config/template.json
+++ b/templates/Uwp/Features/SuspendAndResume/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\SuspendAndResumeService.cs"
+      "path": "Services/SuspendAndResumeService.cs"
     },
     {
-      "path": ".\\Services\\SuspendAndResumeArgs.cs"
+      "path": "Services/SuspendAndResumeArgs.cs"
     },
     {
-      "path": ".\\Services\\SuspensionState.cs"
+      "path": "Services/SuspensionState.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ThemeSelection._VB/.template.config/template.json
+++ b/templates/Uwp/Features/ThemeSelection._VB/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ThemeSelectorService.vb"
+      "path": "Services/ThemeSelectorService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ThemeSelection/.template.config/template.json
+++ b/templates/Uwp/Features/ThemeSelection/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ThemeSelectorService.cs"
+      "path": "Services/ThemeSelectorService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ToastNotifications.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/ToastNotifications.Prism/.template.config/template.json
@@ -29,13 +29,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ToastNotificationsFeatureService.cs"
+      "path": "Services/ToastNotificationsFeatureService.cs"
     },
     {
-      "path": ".\\Services\\IToastNotificationsFeatureService.cs"
+      "path": "Services/IToastNotificationsFeatureService.cs"
     },
     {
-      "path": ".\\Services\\ToastNotificationsFeatureService.Samples.cs"
+      "path": "Services/ToastNotificationsFeatureService.Samples.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ToastNotifications._VB/.template.config/template.json
+++ b/templates/Uwp/Features/ToastNotifications._VB/.template.config/template.json
@@ -29,10 +29,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ToastNotificationsFeatureService.vb"
+      "path": "Services/ToastNotificationsFeatureService.vb"
     },
     {
-      "path": ".\\Services\\ToastNotificationsFeatureService.Samples.vb"
+      "path": "Services/ToastNotificationsFeatureService.Samples.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/ToastNotifications/.template.config/template.json
+++ b/templates/Uwp/Features/ToastNotifications/.template.config/template.json
@@ -29,10 +29,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ToastNotificationsFeatureService.cs"
+      "path": "Services/ToastNotificationsFeatureService.cs"
     },
     {
-      "path": ".\\Services\\ToastNotificationsFeatureService.Samples.cs"
+      "path": "Services/ToastNotificationsFeatureService.Samples.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/UserActivity.MVVMLight._VB/.template.config/template.json
+++ b/templates/Uwp/Features/UserActivity.MVVMLight._VB/.template.config/template.json
@@ -30,13 +30,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserActivityData.vb"
+      "path": "Services/UserActivityData.vb"
     },
     {
-      "path": ".\\Services\\UserActivityService.vb"
+      "path": "Services/UserActivityService.vb"
     },
     {
-      "path": ".\\Services\\UserActivityService.Sample.vb"
+      "path": "Services/UserActivityService.Sample.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/UserActivity.MVVMLight/.template.config/template.json
+++ b/templates/Uwp/Features/UserActivity.MVVMLight/.template.config/template.json
@@ -30,13 +30,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserActivityData.cs"
+      "path": "Services/UserActivityData.cs"
     },
     {
-      "path": ".\\Services\\UserActivityService.cs"
+      "path": "Services/UserActivityService.cs"
     },
     {
-      "path": ".\\Services\\UserActivityService.Sample.cs"
+      "path": "Services/UserActivityService.Sample.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/UserActivity.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/UserActivity.Prism/.template.config/template.json
@@ -30,13 +30,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserActivityData.cs"
+      "path": "Services/UserActivityData.cs"
     },
     {
-      "path": ".\\Services\\UserActivityService.cs"
+      "path": "Services/UserActivityService.cs"
     },
     {
-      "path": ".\\Services\\UserActivityService.Sample.cs"
+      "path": "Services/UserActivityService.Sample.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/UserActivity._VB/.template.config/template.json
+++ b/templates/Uwp/Features/UserActivity._VB/.template.config/template.json
@@ -30,13 +30,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserActivityData.vb"
+      "path": "Services/UserActivityData.vb"
     },
     {
-      "path": ".\\Services\\UserActivityService.vb"
+      "path": "Services/UserActivityService.vb"
     },
     {
-      "path": ".\\Services\\UserActivityService.Sample.vb"
+      "path": "Services/UserActivityService.Sample.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/UserActivity/.template.config/template.json
+++ b/templates/Uwp/Features/UserActivity/.template.config/template.json
@@ -30,13 +30,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserActivityData.cs"
+      "path": "Services/UserActivityData.cs"
     },
     {
-      "path": ".\\Services\\UserActivityService.cs"
+      "path": "Services/UserActivityService.cs"
     },
     {
-      "path": ".\\Services\\UserActivityService.Sample.cs"
+      "path": "Services/UserActivityService.Sample.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/WebToAppLink._VB/.template.config/template.json
+++ b/templates/Uwp/Features/WebToAppLink._VB/.template.config/template.json
@@ -28,7 +28,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\WebToAppLinkActivationHandler.vb"
+      "path": "Activation/WebToAppLinkActivationHandler.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/WebToAppLink/.template.config/template.json
+++ b/templates/Uwp/Features/WebToAppLink/.template.config/template.json
@@ -28,7 +28,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\WebToAppLinkActivationHandler.cs"
+      "path": "Activation/WebToAppLinkActivationHandler.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/WhatsNewPrompt.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/WhatsNewPrompt.Prism/.template.config/template.json
@@ -26,16 +26,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WhatsNewDialog.xaml"
+      "path": "Views/WhatsNewDialog.xaml"
     },
     {
-      "path": ".\\Views\\WhatsNewDialog.xaml.cs"
+      "path": "Views/WhatsNewDialog.xaml.cs"
     },
     {
-      "path": ".\\Services\\WhatsNewDisplayService.cs"
+      "path": "Services/WhatsNewDisplayService.cs"
     },
     {
-      "path": ".\\Services\\IWhatsNewDisplayService.cs"
+      "path": "Services/IWhatsNewDisplayService.cs"
     }  ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Features/WhatsNewPrompt._VB/.template.config/template.json
+++ b/templates/Uwp/Features/WhatsNewPrompt._VB/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WhatsNewDialog.xaml"
+      "path": "Views/WhatsNewDialog.xaml"
     },
     {
-      "path": ".\\Views\\WhatsNewDialog.xaml.vb"
+      "path": "Views/WhatsNewDialog.xaml.vb"
     },
     {
-      "path": ".\\Services\\WhatsNewDisplayService.vb"
+      "path": "Services/WhatsNewDisplayService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Features/WhatsNewPrompt/.template.config/template.json
+++ b/templates/Uwp/Features/WhatsNewPrompt/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WhatsNewDialog.xaml"
+      "path": "Views/WhatsNewDialog.xaml"
     },
     {
-      "path": ".\\Views\\WhatsNewDialog.xaml.cs"
+      "path": "Views/WhatsNewDialog.xaml.cs"
     },
     {
-      "path": ".\\Services\\WhatsNewDisplayService.cs"
+      "path": "Services/WhatsNewDisplayService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Blank.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Blank.CodeBehind._VB/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\BlankViewPage.xaml"
+      "path": "Views/BlankViewPage.xaml"
     },
     {
-      "path": ".\\Views\\BlankViewPage.xaml.vb"
+      "path": "Views/BlankViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Blank.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/Blank.CodeBehind/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\BlankViewPage.xaml"
+      "path": "Views/BlankViewPage.xaml"
     },
     {
-      "path": ".\\Views\\BlankViewPage.xaml.cs"
+      "path": "Views/BlankViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Blank._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Blank._VB/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\BlankViewPage.xaml"
+      "path": "Views/BlankViewPage.xaml"
     },
     {
-      "path": ".\\Views\\BlankViewPage.xaml.vb"
+      "path": "Views/BlankViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\BlankViewViewModel.vb"
+      "path": "ViewModels/BlankViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Blank/.template.config/template.json
+++ b/templates/Uwp/Pages/Blank/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\BlankViewPage.xaml"
+      "path": "Views/BlankViewPage.xaml"
     },
     {
-      "path": ".\\Views\\BlankViewPage.xaml.cs"
+      "path": "Views/BlankViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\BlankViewViewModel.cs"
+      "path": "ViewModels/BlankViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Camera.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/Camera.CaliburnMicro/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\CameraViewPage.xaml"
+      "path": "Views/CameraViewPage.xaml"
     },
     {
-      "path": ".\\Views\\CameraViewPage.xaml.cs"
+      "path": "Views/CameraViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\CameraViewViewModel.cs"
+      "path": "ViewModels/CameraViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Camera.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Camera.CodeBehind._VB/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\CameraViewPage.xaml"
+      "path": "Views/CameraViewPage.xaml"
     },
     {
-      "path": ".\\Views\\CameraViewPage.xaml.vb"
+      "path": "Views/CameraViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Camera.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/Camera.CodeBehind/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\CameraViewPage.xaml"
+      "path": "Views/CameraViewPage.xaml"
     },
     {
-      "path": ".\\Views\\CameraViewPage.xaml.cs"
+      "path": "Views/CameraViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Camera.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/Camera.Prism/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\CameraViewPage.xaml"
+      "path": "Views/CameraViewPage.xaml"
     },
     {
-      "path": ".\\Views\\CameraViewPage.xaml.cs"
+      "path": "Views/CameraViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\CameraViewViewModel.cs"
+      "path": "ViewModels/CameraViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Camera._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Camera._VB/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\CameraViewPage.xaml"
+      "path": "Views/CameraViewPage.xaml"
     },
     {
-      "path": ".\\Views\\CameraViewPage.xaml.vb"
+      "path": "Views/CameraViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\CameraViewViewModel.vb"
+      "path": "ViewModels/CameraViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Camera/.template.config/template.json
+++ b/templates/Uwp/Pages/Camera/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\CameraViewPage.xaml"
+      "path": "Views/CameraViewPage.xaml"
     },
     {
-      "path": ".\\Views\\CameraViewPage.xaml.cs"
+      "path": "Views/CameraViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\CameraViewViewModel.cs"
+      "path": "ViewModels/CameraViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Chart.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Chart.CodeBehind._VB/.template.config/template.json
@@ -27,10 +27,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ChartViewPage.xaml"
+      "path": "Views/ChartViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ChartViewPage.xaml.vb"
+      "path": "Views/ChartViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Chart.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/Chart.CodeBehind/.template.config/template.json
@@ -27,10 +27,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ChartViewPage.xaml"
+      "path": "Views/ChartViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ChartViewPage.xaml.cs"
+      "path": "Views/ChartViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Chart.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/Chart.Prism/.template.config/template.json
@@ -28,16 +28,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Views\\ChartViewPage.xaml"
+      "path": "Param_ProjectName/Views/ChartViewPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\ChartViewPage.xaml.cs"
+      "path": "Param_ProjectName/Views/ChartViewPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\ChartViewViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/ChartViewViewModel.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\DataPoint.cs"
+      "path": "Param_ProjectName.Core/Models/DataPoint.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Chart._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Chart._VB/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ChartViewPage.xaml"
+      "path": "Views/ChartViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ChartViewPage.xaml.vb"
+      "path": "Views/ChartViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\ChartViewViewModel.vb"
+      "path": "ViewModels/ChartViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Chart/.template.config/template.json
+++ b/templates/Uwp/Pages/Chart/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ChartViewPage.xaml"
+      "path": "Views/ChartViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ChartViewPage.xaml.cs"
+      "path": "Views/ChartViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\ChartViewViewModel.cs"
+      "path": "ViewModels/ChartViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/.template.config/template.json
@@ -27,22 +27,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml"
+      "path": "Views/ContentGridViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml.cs"
+      "path": "Views/ContentGridViewDetailPage.xaml.cs"
     },
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml"
+      "path": "Views/ContentGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml.cs"
+      "path": "Views/ContentGridViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\ContentGridViewDetailViewModel.cs"
+      "path": "ViewModels/ContentGridViewDetailViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\ContentGridViewViewModel.cs"
+      "path": "ViewModels/ContentGridViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind._VB/.template.config/template.json
@@ -27,16 +27,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml"
+      "path": "Views/ContentGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml.vb"
+      "path": "Views/ContentGridViewPage.xaml.vb"
     },
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml"
+      "path": "Views/ContentGridViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml.vb"
+      "path": "Views/ContentGridViewDetailPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/.template.config/template.json
@@ -27,16 +27,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml"
+      "path": "Views/ContentGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml.cs"
+      "path": "Views/ContentGridViewPage.xaml.cs"
     },
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml"
+      "path": "Views/ContentGridViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml.cs"
+      "path": "Views/ContentGridViewDetailPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ContentGrid.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/ContentGrid.Prism/.template.config/template.json
@@ -28,22 +28,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Views\\ContentGridViewDetailPage.xaml"
+      "path": "Param_ProjectName/Views/ContentGridViewDetailPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\ContentGridViewDetailPage.xaml.cs"
+      "path": "Param_ProjectName/Views/ContentGridViewDetailPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\ContentGridViewPage.xaml"
+      "path": "Param_ProjectName/Views/ContentGridViewPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\ContentGridViewPage.xaml.cs"
+      "path": "Param_ProjectName/Views/ContentGridViewPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\ContentGridViewDetailViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/ContentGridViewDetailViewModel.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\ContentGridViewViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/ContentGridViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ContentGrid._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/ContentGrid._VB/.template.config/template.json
@@ -27,22 +27,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\ContentGridViewViewModel.vb"
+      "path": "ViewModels/ContentGridViewViewModel.vb"
     },
     {
-      "path": ".\\ViewModels\\ContentGridViewDetailViewModel.vb"
+      "path": "ViewModels/ContentGridViewDetailViewModel.vb"
     },
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml"
+      "path": "Views/ContentGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewPage.xaml.vb"
+      "path": "Views/ContentGridViewPage.xaml.vb"
     },
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml"
+      "path": "Views/ContentGridViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ContentGridViewDetailPage.xaml.vb"
+      "path": "Views/ContentGridViewDetailPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ContentGrid/.template.config/template.json
+++ b/templates/Uwp/Pages/ContentGrid/.template.config/template.json
@@ -27,22 +27,22 @@
     "preferNameDirectory": true,
     "PrimaryOutputs": [
       {
-        "path": ".\\Views\\ContentGridViewDetailPage.xaml"
+        "path": "Views/ContentGridViewDetailPage.xaml"
       },
       {
-        "path": ".\\Views\\ContentGridViewDetailPage.xaml.cs"
+        "path": "Views/ContentGridViewDetailPage.xaml.cs"
       },
       {
-        "path": ".\\Views\\ContentGridViewPage.xaml"
+        "path": "Views/ContentGridViewPage.xaml"
       },
       {
-        "path": ".\\Views\\ContentGridViewPage.xaml.cs"
+        "path": "Views/ContentGridViewPage.xaml.cs"
       },
       {
-        "path": ".\\ViewModels\\ContentGridViewDetailViewModel.cs"
+        "path": "ViewModels/ContentGridViewDetailViewModel.cs"
       },
       {
-        "path": ".\\ViewModels\\ContentGridViewViewModel.cs"
+        "path": "ViewModels/ContentGridViewViewModel.cs"
       }
     ],
   "symbols": {

--- a/templates/Uwp/Pages/DataGrid.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/DataGrid.CodeBehind._VB/.template.config/template.json
@@ -28,10 +28,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\DataGridViewPage.xaml"
+      "path": "Views/DataGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\DataGridViewPage.xaml.vb"
+      "path": "Views/DataGridViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/DataGrid.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/DataGrid.CodeBehind/.template.config/template.json
@@ -28,10 +28,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\DataGridViewPage.xaml"
+      "path": "Views/DataGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\DataGridViewPage.xaml.cs"
+      "path": "Views/DataGridViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/DataGrid.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/DataGrid.Prism/.template.config/template.json
@@ -29,13 +29,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Views\\DataGridViewPage.xaml"
+      "path": "Param_ProjectName/Views/DataGridViewPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\DataGridViewPage.xaml.cs"
+      "path": "Param_ProjectName/Views/DataGridViewPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\DataGridViewViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/DataGridViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/DataGrid._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/DataGrid._VB/.template.config/template.json
@@ -28,13 +28,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\DataGridViewPage.xaml"
+      "path": "Views/DataGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\DataGridViewPage.xaml.vb"
+      "path": "Views/DataGridViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\DataGridViewViewModel.vb"
+      "path": "ViewModels/DataGridViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/DataGrid/.template.config/template.json
+++ b/templates/Uwp/Pages/DataGrid/.template.config/template.json
@@ -28,13 +28,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\DataGridViewPage.xaml"
+      "path": "Views/DataGridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\DataGridViewPage.xaml.cs"
+      "path": "Views/DataGridViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\DataGridViewViewModel.cs"
+      "path": "ViewModels/DataGridViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Grid.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Grid.CodeBehind._VB/.template.config/template.json
@@ -27,10 +27,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\GridViewPage.xaml"
+      "path": "Views/GridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\GridViewPage.xaml.vb"
+      "path": "Views/GridViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Grid.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/Grid.CodeBehind/.template.config/template.json
@@ -27,10 +27,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\GridViewPage.xaml"
+      "path": "Views/GridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\GridViewPage.xaml.cs"
+      "path": "Views/GridViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Grid.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/Grid.Prism/.template.config/template.json
@@ -28,13 +28,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Views\\GridViewPage.xaml"
+      "path": "Param_ProjectName/Views/GridViewPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\GridViewPage.xaml.cs"
+      "path": "Param_ProjectName/Views/GridViewPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\GridViewViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/GridViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Grid._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Grid._VB/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\GridViewPage.xaml"
+      "path": "Views/GridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\GridViewPage.xaml.vb"
+      "path": "Views/GridViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\GridViewViewModel.vb"
+      "path": "ViewModels/GridViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Grid/.template.config/template.json
+++ b/templates/Uwp/Pages/Grid/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\GridViewPage.xaml"
+      "path": "Views/GridViewPage.xaml"
     },
     {
-      "path": ".\\Views\\GridViewPage.xaml.cs"
+      "path": "Views/GridViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\GridViewViewModel.cs"
+      "path": "ViewModels/GridViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ImageGallery.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/ImageGallery.CaliburnMicro/.template.config/template.json
@@ -28,28 +28,28 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ConnectedAnimationService.cs"
+      "path": "Services/ConnectedAnimationService.cs"
     },
     {
-      "path": ".\\Services\\IConnectedAnimationService.cs"
+      "path": "Services/IConnectedAnimationService.cs"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml"
+      "path": "Views/ImageGalleryViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml.cs"
+      "path": "Views/ImageGalleryViewPage.xaml.cs"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml"
+      "path": "Views/ImageGalleryViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml.cs"
+      "path": "Views/ImageGalleryViewDetailPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\ImageGalleryViewViewModel.cs"
+      "path": "ViewModels/ImageGalleryViewViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\ImageGalleryViewDetailViewModel.cs"
+      "path": "ViewModels/ImageGalleryViewDetailViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ImageGallery.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/ImageGallery.CodeBehind._VB/.template.config/template.json
@@ -28,16 +28,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml"
+      "path": "Views/ImageGalleryViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml.vb"
+      "path": "Views/ImageGalleryViewPage.xaml.vb"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml"
+      "path": "Views/ImageGalleryViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml.vb"
+      "path": "Views/ImageGalleryViewDetailPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ImageGallery.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/ImageGallery.CodeBehind/.template.config/template.json
@@ -28,16 +28,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml"
+      "path": "Views/ImageGalleryViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml.cs"
+      "path": "Views/ImageGalleryViewPage.xaml.cs"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml"
+      "path": "Views/ImageGalleryViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml.cs"
+      "path": "Views/ImageGalleryViewDetailPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ImageGallery.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/ImageGallery.Prism/.template.config/template.json
@@ -28,61 +28,61 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Views\\ImageGalleryViewPage.xaml"
+      "path": "Param_ProjectName/Views/ImageGalleryViewPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\ImageGalleryViewPage.xaml.cs"
+      "path": "Param_ProjectName/Views/ImageGalleryViewPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\ImageGalleryViewDetailPage.xaml"
+      "path": "Param_ProjectName/Views/ImageGalleryViewDetailPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\ImageGalleryViewDetailPage.xaml.cs"
+      "path": "Param_ProjectName/Views/ImageGalleryViewDetailPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\ImageGalleryViewViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/ImageGalleryViewViewModel.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\ImageGalleryViewDetailViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/ImageGalleryViewDetailViewModel.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleImage.cs"
+      "path": "Param_ProjectName.Core/Models/SampleImage.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Helpers\\ImagesNavigationHelper.cs"
+      "path": "Param_ProjectName/Helpers/ImagesNavigationHelper.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\PlaceholderImage.png"
+      "path": "Param_ProjectName/Assets/PlaceholderImage.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto1.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto1.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto2.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto2.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto3.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto3.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto4.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto4.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto5.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto5.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto6.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto6.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto7.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto7.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto8.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto8.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto9.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto9.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto10.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto10.png"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ImageGallery._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/ImageGallery._VB/.template.config/template.json
@@ -28,22 +28,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml"
+      "path": "Views/ImageGalleryViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml.vb"
+      "path": "Views/ImageGalleryViewPage.xaml.vb"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml"
+      "path": "Views/ImageGalleryViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml.vb"
+      "path": "Views/ImageGalleryViewDetailPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\ImageGalleryViewViewModel.vb"
+      "path": "ViewModels/ImageGalleryViewViewModel.vb"
     },
     {
-      "path": ".\\ViewModels\\ImageGalleryViewDetailViewModel.vb"
+      "path": "ViewModels/ImageGalleryViewDetailViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/ImageGallery/.template.config/template.json
+++ b/templates/Uwp/Pages/ImageGallery/.template.config/template.json
@@ -28,22 +28,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml"
+      "path": "Views/ImageGalleryViewPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewPage.xaml.cs"
+      "path": "Views/ImageGalleryViewPage.xaml.cs"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml"
+      "path": "Views/ImageGalleryViewDetailPage.xaml"
     },
     {
-      "path": ".\\Views\\ImageGalleryViewDetailPage.xaml.cs"
+      "path": "Views/ImageGalleryViewDetailPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\ImageGalleryViewViewModel.cs"
+      "path": "ViewModels/ImageGalleryViewViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\ImageGalleryViewDetailViewModel.cs"
+      "path": "ViewModels/ImageGalleryViewDetailViewModel.cs"
     }
   ],
     "symbols": {

--- a/templates/Uwp/Pages/InkDraw.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDraw.CaliburnMicro/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml"
+      "path": "Views/InkDrawViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml.cs"
+      "path": "Views/InkDrawViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkDrawViewViewModel.cs"
+      "path": "ViewModels/InkDrawViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDraw.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDraw.CodeBehind._VB/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml"
+      "path": "Views/InkDrawViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml.vb"
+      "path": "Views/InkDrawViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDraw.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDraw.CodeBehind/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml"
+      "path": "Views/InkDrawViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml.cs"
+      "path": "Views/InkDrawViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDraw.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDraw.Prism/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml"
+      "path": "Views/InkDrawViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml.cs"
+      "path": "Views/InkDrawViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkDrawViewViewModel.cs"
+      "path": "ViewModels/InkDrawViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDraw._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDraw._VB/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml"
+      "path": "Views/InkDrawViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml.vb"
+      "path": "Views/InkDrawViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\InkDrawViewViewModel.vb"
+      "path": "ViewModels/InkDrawViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDraw/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDraw/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml"
+      "path": "Views/InkDrawViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawViewPage.xaml.cs"
+      "path": "Views/InkDrawViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkDrawViewViewModel.cs"
+      "path": "ViewModels/InkDrawViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDrawPicture.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDrawPicture.CaliburnMicro/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml"
+      "path": "Views/InkDrawPictureViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml.cs"
+      "path": "Views/InkDrawPictureViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkDrawPictureViewViewModel.cs"
+      "path": "ViewModels/InkDrawPictureViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDrawPicture.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDrawPicture.CodeBehind._VB/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml"
+      "path": "Views/InkDrawPictureViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml.vb"
+      "path": "Views/InkDrawPictureViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDrawPicture.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDrawPicture.CodeBehind/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml"
+      "path": "Views/InkDrawPictureViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml.cs"
+      "path": "Views/InkDrawPictureViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDrawPicture.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDrawPicture.Prism/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml"
+      "path": "Views/InkDrawPictureViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml.cs"
+      "path": "Views/InkDrawPictureViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkDrawPictureViewViewModel.cs"
+      "path": "ViewModels/InkDrawPictureViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDrawPicture._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDrawPicture._VB/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml"
+      "path": "Views/InkDrawPictureViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml.vb"
+      "path": "Views/InkDrawPictureViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\InkDrawPictureViewViewModel.vb"
+      "path": "ViewModels/InkDrawPictureViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkDrawPicture/.template.config/template.json
+++ b/templates/Uwp/Pages/InkDrawPicture/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml"
+      "path": "Views/InkDrawPictureViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkDrawPictureViewPage.xaml.cs"
+      "path": "Views/InkDrawPictureViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkDrawPictureViewViewModel.cs"
+      "path": "ViewModels/InkDrawPictureViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkSmartCanvas.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/InkSmartCanvas.CaliburnMicro/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml"
+      "path": "Views/InkSmartCanvasViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml.cs"
+      "path": "Views/InkSmartCanvasViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkSmartCanvasViewViewModel.cs"
+      "path": "ViewModels/InkSmartCanvasViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkSmartCanvas.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/InkSmartCanvas.CodeBehind._VB/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml"
+      "path": "Views/InkSmartCanvasViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml.vb"
+      "path": "Views/InkSmartCanvasViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkSmartCanvas.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/InkSmartCanvas.CodeBehind/.template.config/template.json
@@ -26,10 +26,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml"
+      "path": "Views/InkSmartCanvasViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml.cs"
+      "path": "Views/InkSmartCanvasViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkSmartCanvas.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/InkSmartCanvas.Prism/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml"
+      "path": "Views/InkSmartCanvasViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml.cs"
+      "path": "Views/InkSmartCanvasViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkSmartCanvasViewViewModel.cs"
+      "path": "ViewModels/InkSmartCanvasViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkSmartCanvas._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/InkSmartCanvas._VB/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml"
+      "path": "Views/InkSmartCanvasViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml.vb"
+      "path": "Views/InkSmartCanvasViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\InkSmartCanvasViewViewModel.vb"
+      "path": "ViewModels/InkSmartCanvasViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/InkSmartCanvas/.template.config/template.json
+++ b/templates/Uwp/Pages/InkSmartCanvas/.template.config/template.json
@@ -26,13 +26,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml"
+      "path": "Views/InkSmartCanvasViewPage.xaml"
     },
     {
-      "path": ".\\Views\\InkSmartCanvasViewPage.xaml.cs"
+      "path": "Views/InkSmartCanvasViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\InkSmartCanvasViewViewModel.cs"
+      "path": "ViewModels/InkSmartCanvasViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Map.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/Map.CaliburnMicro/.template.config/template.json
@@ -26,22 +26,22 @@
   "PrimaryOutputs":
   [
     {
-      "path": ".\\Views\\IMapPageView.cs"
+      "path": "Views/IMapPageView.cs"
     },
     {
-      "path": ".\\Views\\MapPagePage.xaml"
+      "path": "Views/MapPagePage.xaml"
     },
     {
-      "path": ".\\Views\\MapPagePage.xaml.cs"
+      "path": "Views/MapPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\MapPageViewModel.cs"
+      "path": "ViewModels/MapPageViewModel.cs"
     },
     {
-      "path": ".\\Assets\\map.png"
+      "path": "Assets/map.png"
     },
     {
-      "path": ".\\Services\\LocationService.cs"
+      "path": "Services/LocationService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Map.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Map.CodeBehind._VB/.template.config/template.json
@@ -25,16 +25,16 @@
   "PrimaryOutputs":
   [
     {
-      "path": ".\\Views\\MapPagePage.xaml"
+      "path": "Views/MapPagePage.xaml"
     },
     {
-      "path": ".\\Views\\MapPagePage.xaml.vb"
+      "path": "Views/MapPagePage.xaml.vb"
     },
     {
-      "path": ".\\Assets\\map.png"
+      "path": "Assets/map.png"
     },
     {
-      "path": ".\\Services\\LocationService.vb"
+      "path": "Services/LocationService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Map.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/Map.CodeBehind/.template.config/template.json
@@ -25,16 +25,16 @@
   "PrimaryOutputs":
   [
     {
-      "path": ".\\Views\\MapPagePage.xaml"
+      "path": "Views/MapPagePage.xaml"
     },
     {
-      "path": ".\\Views\\MapPagePage.xaml.cs"
+      "path": "Views/MapPagePage.xaml.cs"
     },
     {
-      "path": ".\\Assets\\map.png"
+      "path": "Assets/map.png"
     },
     {
-      "path": ".\\Services\\LocationService.cs"
+      "path": "Services/LocationService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Map.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/Map.Prism/.template.config/template.json
@@ -26,25 +26,25 @@
   "PrimaryOutputs":
   [
     {
-      "path": ".\\Views\\MapPagePage.xaml"
+      "path": "Views/MapPagePage.xaml"
     },
     {
-      "path": ".\\Views\\MapPagePage.xaml.cs"
+      "path": "Views/MapPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\MapPageViewModel.cs"
+      "path": "ViewModels/MapPageViewModel.cs"
     },
     {
-      "path": ".\\Assets\\map.png"
+      "path": "Assets/map.png"
     },
     {
-      "path": ".\\Services\\LocationService.cs"
+      "path": "Services/LocationService.cs"
     },
     {
-      "path": ".\\Services\\ILocationService.cs"
+      "path": "Services/ILocationService.cs"
     },
     {
-      "path": ".\\Behaviors\\BindableMapIconBehavior.cs"
+      "path": "Behaviors/BindableMapIconBehavior.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Map._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Map._VB/.template.config/template.json
@@ -26,19 +26,19 @@
   "PrimaryOutputs":
   [
     {
-      "path": ".\\Views\\MapPagePage.xaml"
+      "path": "Views/MapPagePage.xaml"
     },
     {
-      "path": ".\\Views\\MapPagePage.xaml.vb"
+      "path": "Views/MapPagePage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\MapPageViewModel.vb"
+      "path": "ViewModels/MapPageViewModel.vb"
     },
     {
-      "path": ".\\Assets\\map.png"
+      "path": "Assets/map.png"
     },
     {
-      "path": ".\\Services\\LocationService.vb"
+      "path": "Services/LocationService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Map/.template.config/template.json
+++ b/templates/Uwp/Pages/Map/.template.config/template.json
@@ -26,19 +26,19 @@
   "PrimaryOutputs":
   [
     {
-      "path": ".\\Views\\MapPagePage.xaml"
+      "path": "Views/MapPagePage.xaml"
     },
     {
-      "path": ".\\Views\\MapPagePage.xaml.cs"
+      "path": "Views/MapPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\MapPageViewModel.cs"
+      "path": "ViewModels/MapPageViewModel.cs"
     },
     {
-      "path": ".\\Assets\\map.png"
+      "path": "Assets/map.png"
     },
     {
-      "path": ".\\Services\\LocationService.cs"
+      "path": "Services/LocationService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MasterDetail.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/MasterDetail.CaliburnMicro/.template.config/template.json
@@ -27,28 +27,28 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml"
+      "path": "Views/MasterDetailViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml.cs"
+      "path": "Views/MasterDetailViewPage.xaml.cs"
     },
     {
-      "path": ".\\Views\\MasterDetailViewDetail\\DetailsView.xaml"
+      "path": "Views/MasterDetailViewDetail/DetailsView.xaml"
     },
     {
-      "path": ".\\Views\\MasterDetailViewDetail\\DetailsView.xaml.cs"
+      "path": "Views/MasterDetailViewDetail/DetailsView.xaml.cs"
     },
     {
-      "path": ".\\Views\\MasterDetailViewDetail\\MasterView.xaml"
+      "path": "Views/MasterDetailViewDetail/MasterView.xaml"
     },
     {
-      "path": ".\\Views\\MasterDetailViewDetail\\MasterView.xaml.cs"
+      "path": "Views/MasterDetailViewDetail/MasterView.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\MasterDetailViewViewModel.cs"
+      "path": "ViewModels/MasterDetailViewViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\MasterDetailViewDetailViewModel.cs"
+      "path": "ViewModels/MasterDetailViewDetailViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MasterDetail.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/MasterDetail.CodeBehind._VB/.template.config/template.json
@@ -27,10 +27,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml"
+      "path": "Views/MasterDetailViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml.vb"
+      "path": "Views/MasterDetailViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MasterDetail.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/MasterDetail.CodeBehind/.template.config/template.json
@@ -27,10 +27,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml"
+      "path": "Views/MasterDetailViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml.cs"
+      "path": "Views/MasterDetailViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MasterDetail.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/MasterDetail.Prism/.template.config/template.json
@@ -28,13 +28,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Views\\MasterDetailViewPage.xaml"
+      "path": "Param_ProjectName/Views/MasterDetailViewPage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\MasterDetailViewPage.xaml.cs"
+      "path": "Param_ProjectName/Views/MasterDetailViewPage.xaml.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\MasterDetailViewViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/MasterDetailViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MasterDetail._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/MasterDetail._VB/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml"
+      "path": "Views/MasterDetailViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml.vb"
+      "path": "Views/MasterDetailViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\MasterDetailViewViewModel.vb"
+      "path": "ViewModels/MasterDetailViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MasterDetail/.template.config/template.json
+++ b/templates/Uwp/Pages/MasterDetail/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml"
+      "path": "Views/MasterDetailViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MasterDetailViewPage.xaml.cs"
+      "path": "Views/MasterDetailViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\MasterDetailViewViewModel.cs"
+      "path": "ViewModels/MasterDetailViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MediaPlayer.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/MediaPlayer.CodeBehind._VB/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml"
+      "path": "Views/MediaPlayerViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml.vb"
+      "path": "Views/MediaPlayerViewPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MediaPlayer.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/MediaPlayer.CodeBehind/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml"
+      "path": "Views/MediaPlayerViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml.cs"
+      "path": "Views/MediaPlayerViewPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MediaPlayer.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/MediaPlayer.Prism/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml"
+      "path": "Views/MediaPlayerViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml.cs"
+      "path": "Views/MediaPlayerViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\MediaPlayerViewViewModel.cs"
+      "path": "ViewModels/MediaPlayerViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MediaPlayer._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/MediaPlayer._VB/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml"
+      "path": "Views/MediaPlayerViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml.vb"
+      "path": "Views/MediaPlayerViewPage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\MediaPlayerViewViewModel.vb"
+      "path": "ViewModels/MediaPlayerViewViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/MediaPlayer/.template.config/template.json
+++ b/templates/Uwp/Pages/MediaPlayer/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml"
+      "path": "Views/MediaPlayerViewPage.xaml"
     },
     {
-      "path": ".\\Views\\MediaPlayerViewPage.xaml.cs"
+      "path": "Views/MediaPlayerViewPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\MediaPlayerViewViewModel.cs"
+      "path": "ViewModels/MediaPlayerViewViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Settings.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/Settings.CaliburnMicro/.template.config/template.json
@@ -28,16 +28,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\EnumToBooleanConverter.cs"
+      "path": "Helpers/EnumToBooleanConverter.cs"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml"
+      "path": "Views/SettingsPagePage.xaml"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml.cs"
+      "path": "Views/SettingsPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\SettingsPageViewModel.cs"
+      "path": "ViewModels/SettingsPageViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Settings.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Settings.CodeBehind._VB/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\EnumToBooleanConverter.vb"
+      "path": "Helpers/EnumToBooleanConverter.vb"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml"
+      "path": "Views/SettingsPagePage.xaml"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml.vb"
+      "path": "Views/SettingsPagePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Settings.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/Settings.CodeBehind/.template.config/template.json
@@ -28,13 +28,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\EnumToBooleanConverter.cs"
+      "path": "Helpers/EnumToBooleanConverter.cs"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml"
+      "path": "Views/SettingsPagePage.xaml"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml.cs"
+      "path": "Views/SettingsPagePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Settings.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/Settings.Prism/.template.config/template.json
@@ -28,16 +28,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\EnumToBooleanConverter.cs"
+      "path": "Helpers/EnumToBooleanConverter.cs"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml"
+      "path": "Views/SettingsPagePage.xaml"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml.cs"
+      "path": "Views/SettingsPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\SettingsPageViewModel.cs"
+      "path": "ViewModels/SettingsPageViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Settings._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/Settings._VB/.template.config/template.json
@@ -27,16 +27,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\EnumToBooleanConverter.vb"
+      "path": "Helpers/EnumToBooleanConverter.vb"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml"
+      "path": "Views/SettingsPagePage.xaml"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml.vb"
+      "path": "Views/SettingsPagePage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\SettingsPageViewModel.vb"
+      "path": "ViewModels/SettingsPageViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/Settings/.template.config/template.json
+++ b/templates/Uwp/Pages/Settings/.template.config/template.json
@@ -28,16 +28,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\EnumToBooleanConverter.cs"
+      "path": "Helpers/EnumToBooleanConverter.cs"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml"
+      "path": "Views/SettingsPagePage.xaml"
     },
     {
-      "path": ".\\Views\\SettingsPagePage.xaml.cs"
+      "path": "Views/SettingsPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\SettingsPageViewModel.cs"
+      "path": "ViewModels/SettingsPageViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TabbedPivot.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/TabbedPivot.CaliburnMicro/.template.config/template.json
@@ -25,22 +25,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml"
+      "path": "Views/TabbedPivotPagePage.xaml"
     },
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml.cs"
+      "path": "Views/TabbedPivotPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\TabbedPivotPageViewModel.cs"
+      "path": "ViewModels/TabbedPivotPageViewModel.cs"
     },
     {
-      "path": ".\\Views\\ExampleTabPage.xaml"
+      "path": "Views/ExampleTabPage.xaml"
     },
     {
-      "path": ".\\Views\\ExampleTabPage.xaml.cs"
+      "path": "Views/ExampleTabPage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\ExampleTabViewModel.cs"
+      "path": "ViewModels/ExampleTabViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TabbedPivot.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/TabbedPivot.CodeBehind._VB/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml"
+      "path": "Views/TabbedPivotPagePage.xaml"
     },
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml.vb"
+      "path": "Views/TabbedPivotPagePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TabbedPivot.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/TabbedPivot.CodeBehind/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml"
+      "path": "Views/TabbedPivotPagePage.xaml"
     },
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml.cs"
+      "path": "Views/TabbedPivotPagePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TabbedPivot._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/TabbedPivot._VB/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml"
+      "path": "Views/TabbedPivotPagePage.xaml"
     },
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml.vb"
+      "path": "Views/TabbedPivotPagePage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\TabbedPivotPageViewModel.vb"
+      "path": "ViewModels/TabbedPivotPageViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TabbedPivot/.template.config/template.json
+++ b/templates/Uwp/Pages/TabbedPivot/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml"
+      "path": "Views/TabbedPivotPagePage.xaml"
     },
     {
-      "path": ".\\Views\\TabbedPivotPagePage.xaml.cs"
+      "path": "Views/TabbedPivotPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\TabbedPivotPageViewModel.cs"
+      "path": "ViewModels/TabbedPivotPageViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TreeView.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/TreeView.CodeBehind._VB/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\TemplateSelectors\\SampleDataTemplateSelector.vb"
+      "path": "TemplateSelectors/SampleDataTemplateSelector.vb"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.vb"
+      "path": "Views/wts.ItemNamePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TreeView.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/TreeView.CodeBehind/.template.config/template.json
@@ -27,13 +27,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\TemplateSelectors\\SampleDataTemplateSelector.cs"
+      "path": "TemplateSelectors/SampleDataTemplateSelector.cs"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.cs"
+      "path": "Views/wts.ItemNamePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TreeView.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/TreeView.Prism/.template.config/template.json
@@ -28,19 +28,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Behaviors\\TreeViewCollapseBehavior.cs"
+      "path": "Param_ProjectName/Behaviors/TreeViewCollapseBehavior.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\TemplateSelectors\\SampleDataTemplateSelector.cs"
+      "path": "Param_ProjectName/TemplateSelectors/SampleDataTemplateSelector.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\wts.ItemNameViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/wts.ItemNameViewModel.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\wts.ItemNamePage.xaml"
+      "path": "Param_ProjectName/Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Param_ProjectName\\Views\\wts.ItemNamePage.xaml.cs"
+      "path": "Param_ProjectName/Views/wts.ItemNamePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TreeView._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/TreeView._VB/.template.config/template.json
@@ -27,19 +27,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Behaviors\\TreeViewCollapseBehavior.vb"
+      "path": "Behaviors/TreeViewCollapseBehavior.vb"
     },
     {
-      "path": ".\\TemplateSelectors\\SampleDataTemplateSelector.vb"
+      "path": "TemplateSelectors/SampleDataTemplateSelector.vb"
     },
     {
-      "path": ".\\ViewModels\\wts.ItemNameViewModel.vb"
+      "path": "ViewModels/wts.ItemNameViewModel.vb"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.vb"
+      "path": "Views/wts.ItemNamePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/TreeView/.template.config/template.json
+++ b/templates/Uwp/Pages/TreeView/.template.config/template.json
@@ -27,19 +27,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Behaviors\\TreeViewCollapseBehavior.cs"
+      "path": "Behaviors/TreeViewCollapseBehavior.cs"
     },
     {
-      "path": ".\\TemplateSelectors\\SampleDataTemplateSelector.cs"
+      "path": "TemplateSelectors/SampleDataTemplateSelector.cs"
     },
     {
-      "path": ".\\ViewModels\\wts.ItemNameViewModel.cs"
+      "path": "ViewModels/wts.ItemNameViewModel.cs"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.cs"
+      "path": "Views/wts.ItemNamePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/WebView.CaliburnMicro/.template.config/template.json
+++ b/templates/Uwp/Pages/WebView.CaliburnMicro/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WebViewPagePage.xaml"
+      "path": "Views/WebViewPagePage.xaml"
     },
     {
-      "path": ".\\Views\\WebViewPagePage.xaml.cs"
+      "path": "Views/WebViewPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\WebViewPageViewModel.cs"
+      "path": "ViewModels/WebViewPageViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/WebView.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/WebView.CodeBehind._VB/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WebViewPagePage.xaml"
+      "path": "Views/WebViewPagePage.xaml"
     },
     {
-      "path": ".\\Views\\WebViewPagePage.xaml.vb"
+      "path": "Views/WebViewPagePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/WebView.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Pages/WebView.CodeBehind/.template.config/template.json
@@ -25,10 +25,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WebViewPagePage.xaml"
+      "path": "Views/WebViewPagePage.xaml"
     },
     {
-      "path": ".\\Views\\WebViewPagePage.xaml.cs"
+      "path": "Views/WebViewPagePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/WebView.Prism/.template.config/template.json
+++ b/templates/Uwp/Pages/WebView.Prism/.template.config/template.json
@@ -25,19 +25,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WebViewPagePage.xaml"
+      "path": "Views/WebViewPagePage.xaml"
     },
     {
-      "path": ".\\Views\\WebViewPagePage.xaml.cs"
+      "path": "Views/WebViewPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\WebViewPageViewModel.cs"
+      "path": "ViewModels/WebViewPageViewModel.cs"
     },
     {
-      "path": ".\\Services\\IWebViewService.cs"
+      "path": "Services/IWebViewService.cs"
     },
     {
-      "path": ".\\Services\\WebViewService.cs"
+      "path": "Services/WebViewService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/WebView._VB/.template.config/template.json
+++ b/templates/Uwp/Pages/WebView._VB/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WebViewPagePage.xaml"
+      "path": "Views/WebViewPagePage.xaml"
     },
     {
-      "path": ".\\Views\\WebViewPagePage.xaml.vb"
+      "path": "Views/WebViewPagePage.xaml.vb"
     },
     {
-      "path": ".\\ViewModels\\WebViewPageViewModel.vb"
+      "path": "ViewModels/WebViewPageViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Pages/WebView/.template.config/template.json
+++ b/templates/Uwp/Pages/WebView/.template.config/template.json
@@ -25,13 +25,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\WebViewPagePage.xaml"
+      "path": "Views/WebViewPagePage.xaml"
     },
     {
-      "path": ".\\Views\\WebViewPagePage.xaml.cs"
+      "path": "Views/WebViewPagePage.xaml.cs"
     },
     {
-      "path": ".\\ViewModels\\WebViewPageViewModel.cs"
+      "path": "ViewModels/WebViewPageViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/StyleCop/.template.config/template.json
+++ b/templates/Uwp/SC/StyleCop/.template.config/template.json
@@ -24,10 +24,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName/GlobalSuppressions.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.Core/GlobalSuppressions.cs"
     }
   ],
   "symbols": {
@@ -49,7 +49,7 @@
       "args": {
         "packageId" : "StyleCop.Analyzers",
         "version" : "1.0.2",
-        "projectPath": ".\\Param_ProjectName\\Param_ProjectName.csproj"
+        "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
     },
@@ -60,7 +60,7 @@
       "args": {
         "packageId" : "StyleCop.Analyzers",
         "version" : "1.0.2",
-        "projectPath": ".\\Param_ProjectName.Core\\Param_ProjectName.Core.csproj"
+        "projectPath": "Param_ProjectName.Core\\Param_ProjectName.Core.csproj"
       },
       "continueOnError": true
     }

--- a/templates/Uwp/SC/VBStyleAnalysis/.template.config/template.json
+++ b/templates/Uwp/SC/VBStyleAnalysis/.template.config/template.json
@@ -24,10 +24,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName/WTSVBRules.ruleset"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName.Core/WTSVBRules.ruleset"
     }
   ],
   "symbols": {
@@ -49,7 +49,7 @@
       "args": {
         "packageId": "VBStyleAnalyzer",
         "version": "0.1.12",
-        "projectPath": ".\\Param_ProjectName\\Param_ProjectName.vbproj"
+        "projectPath": "Param_ProjectName\\Param_ProjectName.vbproj"
       },
       "continueOnError": true
     },
@@ -60,7 +60,7 @@
       "args": {
         "packageId": "VBStyleAnalyzer",
         "version": "0.1.12",
-        "projectPath": ".\\Param_ProjectName.Core\\Param_ProjectName.Core.vbproj"
+        "projectPath": "Param_ProjectName.Core\\Param_ProjectName.Core.vbproj"
       },
       "continueOnError": true
     },
@@ -71,7 +71,7 @@
       "args": {
         "packageId" : "SonarAnalyzer.VisualBasic",
         "version" : "7.2.0.5463",
-        "projectPath": ".\\Param_ProjectName\\Param_ProjectName.vbproj"
+        "projectPath": "Param_ProjectName\\Param_ProjectName.vbproj"
       },
       "continueOnError": true
     },
@@ -82,7 +82,7 @@
       "args": {
         "packageId" : "SonarAnalyzer.VisualBasic",
         "version" : "7.2.0.5463",
-        "projectPath": ".\\Param_ProjectName.Core\\Param_ProjectName.Core.vbproj"
+        "projectPath": "Param_ProjectName.Core\\Param_ProjectName.Core.vbproj"
       },
       "continueOnError": true
     }

--- a/templates/Uwp/SC/_comp/T.SC.A.MSTest._VB/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.A.MSTest._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Tests.MSTest\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName.Tests.MSTest/WTSVBRules.ruleset"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.A.MSTest/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.A.MSTest/.template.config/template.json
@@ -22,7 +22,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Tests.MSTest\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.Tests.MSTest/GlobalSuppressions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.A.xUnit._VB/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.A.xUnit._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Tests.xUnit\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName.Tests.xUnit/WTSVBRules.ruleset"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.A.xUnit/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.A.xUnit/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Tests.xUnit\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.Tests.xUnit/GlobalSuppressions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.C.MSTest._VB/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.C.MSTest._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core.Tests.MSTest\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName.Core.Tests.MSTest/WTSVBRules.ruleset"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.C.MSTest/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.C.MSTest/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core.Tests.MSTest\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.Core.Tests.MSTest/GlobalSuppressions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.C.NUnit._VB/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.C.NUnit._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core.Tests.NUnit\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName.Core.Tests.NUnit/WTSVBRules.ruleset"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.C.NUnit/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.C.NUnit/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core.Tests.NUnit\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.Core.Tests.NUnit/GlobalSuppressions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.C.xUnit._VB/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.C.xUnit._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core.Tests.xUnit\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName.Core.Tests.xUnit/WTSVBRules.ruleset"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.C.xUnit/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.C.xUnit/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core.Tests.xUnit\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.Core.Tests.xUnit/GlobalSuppressions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.WebApi/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.WebApi/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.WebApi\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.WebApi/GlobalSuppressions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.WinAD._VB/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.WinAD._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Tests.WinAppDriver\\WTSVBRules.ruleset"
+      "path": "Param_ProjectName.Tests.WinAppDriver/WTSVBRules.ruleset"
     }
   ],
   "symbols": {

--- a/templates/Uwp/SC/_comp/T.SC.WinAD/.template.config/template.json
+++ b/templates/Uwp/SC/_comp/T.SC.WinAD/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Tests.WinAppDriver\\GlobalSuppressions.cs"
+      "path": "Param_ProjectName.Tests.WinAppDriver/GlobalSuppressions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/HttpDataService._VB/.template.config/template.json
+++ b/templates/Uwp/Services/HttpDataService._VB/.template.config/template.json
@@ -28,7 +28,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\HttpDataService.vb"
+      "path": "Param_ProjectName.Core/Services/HttpDataService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/HttpDataService/.template.config/template.json
+++ b/templates/Uwp/Services/HttpDataService/.template.config/template.json
@@ -29,7 +29,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\HttpDataService.cs"
+      "path": "Param_ProjectName.Core/Services/HttpDataService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/IdentityForcedLogin.CodeBehind._VB/.template.config/template.json
+++ b/templates/Uwp/Services/IdentityForcedLogin.CodeBehind._VB/.template.config/template.json
@@ -31,10 +31,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\LogInPage.xaml"
+      "path": "Views/LogInPage.xaml"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml.vb"
+      "path": "Views/LogInPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/IdentityForcedLogin.CodeBehind/.template.config/template.json
+++ b/templates/Uwp/Services/IdentityForcedLogin.CodeBehind/.template.config/template.json
@@ -31,10 +31,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\LogInPage.xaml"
+      "path": "Views/LogInPage.xaml"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml.cs"
+      "path": "Views/LogInPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/IdentityForcedLogin._VB/.template.config/template.json
+++ b/templates/Uwp/Services/IdentityForcedLogin._VB/.template.config/template.json
@@ -31,13 +31,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\LogInViewModel.vb"
+      "path": "ViewModels/LogInViewModel.vb"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml"
+      "path": "Views/LogInPage.xaml"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml.vb"
+      "path": "Views/LogInPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/IdentityForcedLogin/.template.config/template.json
+++ b/templates/Uwp/Services/IdentityForcedLogin/.template.config/template.json
@@ -31,13 +31,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\LogInViewModel.cs"
+      "path": "ViewModels/LogInViewModel.cs"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml"
+      "path": "Views/LogInPage.xaml"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml.cs"
+      "path": "Views/LogInPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/IdentityOptionalLogin.Prism/.template.config/template.json
+++ b/templates/Uwp/Services/IdentityOptionalLogin.Prism/.template.config/template.json
@@ -31,10 +31,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\AuthenticationHelper.cs"
+      "path": "Helpers/AuthenticationHelper.cs"
     },
     {
-      "path": ".\\Helpers\\Restricted.cs"
+      "path": "Helpers/Restricted.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/SampleData.Prism/.template.config/template.json
+++ b/templates/Uwp/Services/SampleData.Prism/.template.config/template.json
@@ -27,19 +27,19 @@
     "preferNameDirectory": true,
     "PrimaryOutputs": [
       {
-          "path": ".\\Param_ProjectName.Core\\Services\\ISampleDataService.cs"
+          "path": "Param_ProjectName.Core/Services/ISampleDataService.cs"
       },
       {
-        "path": ".\\Param_ProjectName.Core\\Services\\SampleDataService.cs"
+        "path": "Param_ProjectName.Core/Services/SampleDataService.cs"
       },
       {
-        "path": ".\\Param_ProjectName.Core\\Models\\SampleCompany.cs"
+        "path": "Param_ProjectName.Core/Models/SampleCompany.cs"
       },
       {
-        "path": ".\\Param_ProjectName.Core\\Models\\SampleOrder.cs"
+        "path": "Param_ProjectName.Core/Models/SampleOrder.cs"
       },
       {
-        "path": ".\\Param_ProjectName.Core\\Models\\SampleOrderDetail.cs"
+        "path": "Param_ProjectName.Core/Models/SampleOrderDetail.cs"
       }
     ],
     "symbols": {

--- a/templates/Uwp/Services/SampleData._VB/.template.config/template.json
+++ b/templates/Uwp/Services/SampleData._VB/.template.config/template.json
@@ -27,16 +27,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\SampleDataService.vb"
+      "path": "Param_ProjectName.Core/Services/SampleDataService.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleCompany.vb"
+      "path": "Param_ProjectName.Core/Models/SampleCompany.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleOrder.vb"
+      "path": "Param_ProjectName.Core/Models/SampleOrder.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleOrderDetail.vb"
+      "path": "Param_ProjectName.Core/Models/SampleOrderDetail.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/SampleData/.template.config/template.json
+++ b/templates/Uwp/Services/SampleData/.template.config/template.json
@@ -27,16 +27,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\SampleDataService.cs"
+      "path": "Param_ProjectName.Core/Services/SampleDataService.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleCompany.cs"
+      "path": "Param_ProjectName.Core/Models/SampleCompany.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleOrder.cs"
+      "path": "Param_ProjectName.Core/Models/SampleOrder.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleOrderDetail.cs"
+      "path": "Param_ProjectName.Core/Models/SampleOrderDetail.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/SqlServerDataService.Prism/.template.config/template.json
+++ b/templates/Uwp/Services/SqlServerDataService.Prism/.template.config/template.json
@@ -30,7 +30,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\SqlServerDataService.cs"
+      "path": "Param_ProjectName.Core/Services/SqlServerDataService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/SqlServerDataService._VB/.template.config/template.json
+++ b/templates/Uwp/Services/SqlServerDataService._VB/.template.config/template.json
@@ -30,7 +30,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\SqlServerDataService.vb"
+      "path": "Param_ProjectName.Core/Services/SqlServerDataService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/SqlServerDataService/.template.config/template.json
+++ b/templates/Uwp/Services/SqlServerDataService/.template.config/template.json
@@ -30,7 +30,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\SqlServerDataService.cs"
+      "path": "Param_ProjectName.Core/Services/SqlServerDataService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/WebApi.Prism/.template.config/template.json
+++ b/templates/Uwp/Services/WebApi.Prism/.template.config/template.json
@@ -31,7 +31,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.WebApi\\Models\\ItemRepository.cs"
+      "path": "Param_ProjectName.WebApi/Models/ItemRepository.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/WebApi/.template.config/template.json
+++ b/templates/Uwp/Services/WebApi/.template.config/template.json
@@ -31,7 +31,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.WebApi\\Models\\ItemRepository.cs"
+      "path": "Param_ProjectName.WebApi/Models/ItemRepository.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/XamlStylerConfig._VB/.template.config/template.json
+++ b/templates/Uwp/Services/XamlStylerConfig._VB/.template.config/template.json
@@ -29,7 +29,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Settings.XamlStyler"
+      "path": "Param_ProjectName/Settings.XamlStyler"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Services/XamlStylerConfig/.template.config/template.json
+++ b/templates/Uwp/Services/XamlStylerConfig/.template.config/template.json
@@ -29,7 +29,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Settings.XamlStyler"
+      "path": "Param_ProjectName/Settings.XamlStyler"
     }
   ],
   "symbols": {

--- a/templates/Uwp/Testing/UnitTests.App.MSTest._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.MSTest._VB/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "guids": [ "6b17846a-9301-4daa-a8c3-05d101541451" ],
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.vbproj" }
+    { "path": "Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.vbproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.App.MSTest/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.MSTest/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "guids": [ "6b17846a-9301-4daa-a8c3-05d101541451" ],
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj" }
+    { "path": "Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.csproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.App.xUnit._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.xUnit._VB/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "guids": [ "6b17846a-9301-4daa-a8c3-05d101541451" ],
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.vbproj" }
+    { "path": "Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.vbproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.App.xUnit/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.xUnit/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "guids": [ "6b17846a-9301-4daa-a8c3-05d101541451" ],
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.csproj" }
+    { "path": "Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.csproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.Core.MSTest._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.Core.MSTest._VB/.template.config/template.json
@@ -26,7 +26,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core.Tests.MSTest\\Param_ProjectName.Core.Tests.MSTest.vbproj" }
+    { "path": "Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest.vbproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.Core.MSTest/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.Core.MSTest/.template.config/template.json
@@ -26,7 +26,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core.Tests.MSTest\\Param_ProjectName.Core.Tests.MSTest.csproj" }
+    { "path": "Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest.csproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.Core.NUnit._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.Core.NUnit._VB/.template.config/template.json
@@ -26,7 +26,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core.Tests.NUnit\\Param_ProjectName.Core.Tests.NUnit.vbproj" }
+    { "path": "Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit.vbproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.Core.NUnit/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.Core.NUnit/.template.config/template.json
@@ -26,7 +26,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core.Tests.NUnit\\Param_ProjectName.Core.Tests.NUnit.csproj" }
+    { "path": "Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit.csproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.Core.xUnit._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.Core.xUnit._VB/.template.config/template.json
@@ -26,7 +26,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core.Tests.xUnit\\Param_ProjectName.Core.Tests.xUnit.vbproj" }
+    { "path": "Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit.vbproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/UnitTests.Core.xUnit/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.Core.xUnit/.template.config/template.json
@@ -26,7 +26,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core.Tests.xUnit\\Param_ProjectName.Core.Tests.xUnit.csproj" }
+    { "path": "Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit.csproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/WinAppDriver._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/WinAppDriver._VB/.template.config/template.json
@@ -26,7 +26,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Tests.WinAppDriver\\Param_ProjectName.Tests.WinAppDriver.vbproj" }
+    { "path": "Param_ProjectName.Tests.WinAppDriver/Param_ProjectName.Tests.WinAppDriver.vbproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/Testing/WinAppDriver/.template.config/template.json
+++ b/templates/Uwp/Testing/WinAppDriver/.template.config/template.json
@@ -27,7 +27,7 @@
   "preferNameDirectory": true,
   "guids": [ "6b17846a-9301-4daa-a8c3-05d101541451" ],
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Tests.WinAppDriver\\Param_ProjectName.Tests.WinAppDriver.csproj" }
+    { "path": "Param_ProjectName.Tests.WinAppDriver/Param_ProjectName.Tests.WinAppDriver.csproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/_comp/CaliburnMicro/Feat.DeepLinking/.template.config/template.json
+++ b/templates/Uwp/_comp/CaliburnMicro/Feat.DeepLinking/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\SchemeActivationSampleViewModel.cs"
+      "path": "ViewModels/SchemeActivationSampleViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CaliburnMicro/Feat.ShareTarget/.template.config/template.json
+++ b/templates/Uwp/_comp/CaliburnMicro/Feat.ShareTarget/.template.config/template.json
@@ -21,25 +21,25 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\wts.ItemNameViewModel.cs"
+      "path": "ViewModels/wts.ItemNameViewModel.cs"
     },
     {
-      "path": ".\\Views\\SharedDataStorageItemsView.xaml"
+      "path": "Views/SharedDataStorageItemsView.xaml"
     },
     {
-      "path": ".\\Views\\SharedDataStorageItemsView.xaml.cs"
+      "path": "Views/SharedDataStorageItemsView.xaml.cs"
     },
     {
-      "path": ".\\Views\\SharedDataWebLinkView.xaml"
+      "path": "Views/SharedDataWebLinkView.xaml"
     },
     {
-      "path": ".\\Views\\SharedDataWebLinkView.xaml.cs"
+      "path": "Views/SharedDataWebLinkView.xaml.cs"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.cs"
+      "path": "Views/wts.ItemNamePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CaliburnMicro/Project.SplitView.TabbedNav/.template.config/template.json
+++ b/templates/Uwp/_comp/CaliburnMicro/Project.SplitView.TabbedNav/.template.config/template.json
@@ -21,19 +21,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.cs"
+      "path": "Helpers/NavHelper.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.cs"
+      "path": "ViewModels/ShellViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     },
     {
-      "path": ".\\Views\\IShellView.cs"
+      "path": "Views/IShellView.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Project.AddNavigationService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Project.AddNavigationService._VB/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\NavigationService.vb"
+      "path": "Services/NavigationService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Project.AddNavigationService/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Project.AddNavigationService/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\NavigationService.cs"
+      "path": "Services/NavigationService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Project.MenuBar._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Project.MenuBar._VB/.template.config/template.json
@@ -20,22 +20,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\MenuNavigationHelper.vb"
+      "path": "Helpers/MenuNavigationHelper.vb"
     },
     {
-      "path": ".\\Services\\NavigationService.vb"
+      "path": "Services/NavigationService.vb"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml"
+      "path": "Views/ShellContentDialog.xaml"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml.vb"
+      "path": "Views/ShellContentDialog.xaml.vb"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.vb"
+      "path": "Views/ShellPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Project.MenuBar/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Project.MenuBar/.template.config/template.json
@@ -20,22 +20,22 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\MenuNavigationHelper.cs"
+      "path": "Helpers/MenuNavigationHelper.cs"
     },
     {
-      "path": ".\\Services\\NavigationService.cs"
+      "path": "Services/NavigationService.cs"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml"
+      "path": "Views/ShellContentDialog.xaml"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml.cs"
+      "path": "Views/ShellContentDialog.xaml.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav._VB/.template.config/template.json
@@ -21,13 +21,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.vb"
+      "path": "Helpers/NavHelper.vb"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.vb"
+      "path": "Views/ShellPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav/.template.config/template.json
@@ -21,13 +21,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.cs"
+      "path": "Helpers/NavHelper.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Service.IdentityCommon._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Service.IdentityCommon._VB/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\UserData.vb"
+      "path": "Models/UserData.vb"
     },
     {
-      "path": ".\\Services\\UserDataService.vb"
+      "path": "Services/UserDataService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/CodeBehind/Service.IdentityCommon/.template.config/template.json
+++ b/templates/Uwp/_comp/CodeBehind/Service.IdentityCommon/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\UserData.cs"
+      "path": "Models/UserData.cs"
     },
     {
-      "path": ".\\Services\\UserDataService.cs"
+      "path": "Services/UserDataService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Feat.DeepLinking._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Feat.DeepLinking._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\SchemeActivationSampleViewModel.vb"
+      "path": "ViewModels/SchemeActivationSampleViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Feat.DeepLinking/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Feat.DeepLinking/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\SchemeActivationSampleViewModel.cs"
+      "path": "ViewModels/SchemeActivationSampleViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Feat.ShareTarget._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Feat.ShareTarget._VB/.template.config/template.json
@@ -19,13 +19,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\wts.ItemNameViewModel.vb"
+      "path": "ViewModels/wts.ItemNameViewModel.vb"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.vb"
+      "path": "Views/wts.ItemNamePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Feat.ShareTarget/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Feat.ShareTarget/.template.config/template.json
@@ -19,13 +19,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\wts.ItemNameViewModel.cs"
+      "path": "ViewModels/wts.ItemNameViewModel.cs"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.cs"
+      "path": "Views/wts.ItemNamePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project.AddNavigationService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project.AddNavigationService._VB/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\NavigationService.vb"
+      "path": "Services/NavigationService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project.AddNavigationService/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project.AddNavigationService/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\NavigationService.cs"
+      "path": "Services/NavigationService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project.MenuBar._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project.MenuBar._VB/.template.config/template.json
@@ -20,28 +20,28 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\MenuNavigationHelper.vb"
+      "path": "Helpers/MenuNavigationHelper.vb"
     },
     {
-      "path": ".\\Services\\NavigationService.vb"
+      "path": "Services/NavigationService.vb"
     },
     {
-      "path": ".\\ViewModels\\ShellContentDialogViewModel.vb"
+      "path": "ViewModels/ShellContentDialogViewModel.vb"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.vb"
+      "path": "ViewModels/ShellViewModel.vb"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml"
+      "path": "Views/ShellContentDialog.xaml"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml.vb"
+      "path": "Views/ShellContentDialog.xaml.vb"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.vb"
+      "path": "Views/ShellPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project.MenuBar/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project.MenuBar/.template.config/template.json
@@ -20,28 +20,28 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\MenuNavigationHelper.cs"
+      "path": "Helpers/MenuNavigationHelper.cs"
     },
     {
-      "path": ".\\Services\\NavigationService.cs"
+      "path": "Services/NavigationService.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellContentDialogViewModel.cs"
+      "path": "ViewModels/ShellContentDialogViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.cs"
+      "path": "ViewModels/ShellViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml"
+      "path": "Views/ShellContentDialog.xaml"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml.cs"
+      "path": "Views/ShellContentDialog.xaml.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav._VB/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.vb"
+      "path": "Helpers/NavHelper.vb"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.vb"
+      "path": "ViewModels/ShellViewModel.vb"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.vb"
+      "path": "Views/ShellPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.cs"
+      "path": "Helpers/NavHelper.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.cs"
+      "path": "ViewModels/ShellViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project._VB/.template.config/template.json
@@ -20,10 +20,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\Observable.vb"
+      "path": "Helpers/Observable.vb"
     },
     {
-      "path": ".\\Helpers\\RelayCommand.vb"
+      "path": "Helpers/RelayCommand.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Project/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Project/.template.config/template.json
@@ -20,10 +20,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\Observable.cs"
+      "path": "Helpers/Observable.cs"
     },
     {
-      "path": ".\\Helpers\\RelayCommand.cs"
+      "path": "Helpers/RelayCommand.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Service.IdentityCommon._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Service.IdentityCommon._VB/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserDataService.vb"
+      "path": "Services/UserDataService.vb"
     },
     {
-      "path": ".\\ViewModels\\UserViewModel.vb"
+      "path": "ViewModels/UserViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMBasic/Service.IdentityCommon/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMBasic/Service.IdentityCommon/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserDataService.cs"
+      "path": "Services/UserDataService.cs"
     },
     {
-      "path": ".\\ViewModels\\UserViewModel.cs"
+      "path": "ViewModels/UserViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Feat.ShareTarget._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Feat.ShareTarget._VB/.template.config/template.json
@@ -19,13 +19,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\wts.ItemNameViewModel.vb"
+      "path": "ViewModels/wts.ItemNameViewModel.vb"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.vb"
+      "path": "Views/wts.ItemNamePage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Feat.ShareTarget/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Feat.ShareTarget/.template.config/template.json
@@ -19,13 +19,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\wts.ItemNameViewModel.cs"
+      "path": "ViewModels/wts.ItemNameViewModel.cs"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml"
+      "path": "Views/wts.ItemNamePage.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNamePage.xaml.cs"
+      "path": "Views/wts.ItemNamePage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project.AddNavigationService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project.AddNavigationService._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\NavigationServiceEx.vb"
+      "path": "Services/NavigationServiceEx.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project.AddNavigationService/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project.AddNavigationService/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\NavigationServiceEx.cs"
+      "path": "Services/NavigationServiceEx.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project.MenuBar._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project.MenuBar._VB/.template.config/template.json
@@ -20,28 +20,28 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\MenuNavigationHelper.vb"
+      "path": "Helpers/MenuNavigationHelper.vb"
     },
     {
-      "path": ".\\Services\\NavigationServiceEx.vb"
+      "path": "Services/NavigationServiceEx.vb"
     },
     {
-      "path": ".\\ViewModels\\ShellContentDialogViewModel.vb"
+      "path": "ViewModels/ShellContentDialogViewModel.vb"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.vb"
+      "path": "ViewModels/ShellViewModel.vb"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml"
+      "path": "Views/ShellContentDialog.xaml"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml.vb"
+      "path": "Views/ShellContentDialog.xaml.vb"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.vb"
+      "path": "Views/ShellPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project.MenuBar/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project.MenuBar/.template.config/template.json
@@ -20,28 +20,28 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\MenuNavigationHelper.cs"
+      "path": "Helpers/MenuNavigationHelper.cs"
     },
     {
-      "path": ".\\Services\\NavigationServiceEx.cs"
+      "path": "Services/NavigationServiceEx.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellContentDialogViewModel.cs"
+      "path": "ViewModels/ShellContentDialogViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.cs"
+      "path": "ViewModels/ShellViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml"
+      "path": "Views/ShellContentDialog.xaml"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml.cs"
+      "path": "Views/ShellContentDialog.xaml.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav._VB/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.vb"
+      "path": "Helpers/NavHelper.vb"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.vb"
+      "path": "ViewModels/ShellViewModel.vb"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.vb"
+      "path": "Views/ShellPage.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.cs"
+      "path": "Helpers/NavHelper.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.cs"
+      "path": "ViewModels/ShellViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project._VB/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\ViewModelLocator.vb"
+      "path": "ViewModels/ViewModelLocator.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Project/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Project/.template.config/template.json
@@ -21,7 +21,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\ViewModelLocator.cs"
+      "path": "ViewModels/ViewModelLocator.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Service.IdentityCommon._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Service.IdentityCommon._VB/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserDataService.vb"
+      "path": "Services/UserDataService.vb"
     },
     {
-      "path": ".\\ViewModels\\UserViewModel.vb"
+      "path": "ViewModels/UserViewModel.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/MVVMLight/Service.IdentityCommon/.template.config/template.json
+++ b/templates/Uwp/_comp/MVVMLight/Service.IdentityCommon/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\UserDataService.cs"
+      "path": "Services/UserDataService.cs"
     },
     {
-      "path": ".\\ViewModels\\UserViewModel.cs"
+      "path": "ViewModels/UserViewModel.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/Prism/Project.MenuBar/.template.config/template.json
+++ b/templates/Uwp/_comp/Prism/Project.MenuBar/.template.config/template.json
@@ -20,28 +20,28 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\IMenuNavigationService.cs"
+      "path": "Services/IMenuNavigationService.cs"
     },
     {
-      "path": ".\\Services\\MenuNavigationService.cs"
+      "path": "Services/MenuNavigationService.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellContentDialogViewModel.cs"
+      "path": "ViewModels/ShellContentDialogViewModel.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.cs"
+      "path": "ViewModels/ShellViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml"
+      "path": "Views/ShellContentDialog.xaml"
     },
     {
-      "path": ".\\Views\\ShellContentDialog.xaml.cs"
+      "path": "Views/ShellContentDialog.xaml.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/Prism/Project.SplitView.TabbedNav/.template.config/template.json
+++ b/templates/Uwp/_comp/Prism/Project.SplitView.TabbedNav/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\NavHelper.cs"
+      "path": "Helpers/NavHelper.cs"
     },
     {
-      "path": ".\\ViewModels\\ShellViewModel.cs"
+      "path": "ViewModels/ShellViewModel.cs"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml"
+      "path": "Views/ShellPage.xaml"
     },
     {
-      "path": ".\\Views\\ShellPage.xaml.cs"
+      "path": "Views/ShellPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/Prism/Service.IdentityCommon/.template.config/template.json
+++ b/templates/Uwp/_comp/Prism/Service.IdentityCommon/.template.config/template.json
@@ -20,25 +20,25 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Services\\IUserDataService.cs"
+      "path": "Param_ProjectName/Services/IUserDataService.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Services\\UserDataService.cs"
+      "path": "Param_ProjectName/Services/UserDataService.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\ViewModels\\UserViewModel.cs"
+      "path": "Param_ProjectName/ViewModels/UserViewModel.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\IIdentityService.cs"
+      "path": "Param_ProjectName.Core/Services/IIdentityService.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\IdentityService.cs"
+      "path": "Param_ProjectName.Core/Services/IdentityService.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\IMicrosoftGraphService.cs"
+      "path": "Param_ProjectName.Core/Services/IMicrosoftGraphService.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\MicrosoftGraphService.cs"
+      "path": "Param_ProjectName.Core/Services/MicrosoftGraphService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/Prism/Service.IdentityForcedLogin.Blank/.template.config/template.json
+++ b/templates/Uwp/_comp/Prism/Service.IdentityForcedLogin.Blank/.template.config/template.json
@@ -19,13 +19,13 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\ViewModels\\LogInViewModel.cs"
+      "path": "ViewModels/LogInViewModel.cs"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml"
+      "path": "Views/LogInPage.xaml"
     },
     {
-      "path": ".\\Views\\LogInPage.xaml.cs"
+      "path": "Views/LogInPage.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/AddImageHelper._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/AddImageHelper._VB/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\ImageHelper.vb"
+      "path": "Helpers/ImageHelper.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/AddImageHelper/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/AddImageHelper/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Helpers\\ImageHelper.cs"
+      "path": "Helpers/ImageHelper.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.DeepLinking.AddLogoTextsAndAppxManifest._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.DeepLinking.AddLogoTextsAndAppxManifest._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Assets\\Logo.png"
+      "path": "Assets/Logo.png"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.DeepLinking.AddLogoTextsAndAppxManifest/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.DeepLinking.AddLogoTextsAndAppxManifest/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Assets\\Logo.png"
+      "path": "Assets/Logo.png"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.DragAndDrop._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.DragAndDrop._VB/.template.config/template.json
@@ -20,19 +20,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\DragDropCompletedData.vb"
+      "path": "Models/DragDropCompletedData.vb"
     },
     {
-      "path": ".\\Models\\DragDropData.vb"
+      "path": "Models/DragDropData.vb"
     },
     {
-      "path": ".\\Models\\DragDropStartingData.vb"
+      "path": "Models/DragDropStartingData.vb"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\DragDropService.vb"
+      "path": "Services/DragAndDrop/DragDropService.vb"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\VisualDropConfiguration.vb"
+      "path": "Services/DragAndDrop/VisualDropConfiguration.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.DragAndDrop/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.DragAndDrop/.template.config/template.json
@@ -20,19 +20,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Models\\DragDropCompletedData.cs"
+      "path": "Models/DragDropCompletedData.cs"
     },
     {
-      "path": ".\\Models\\DragDropData.cs"
+      "path": "Models/DragDropData.cs"
     },
     {
-      "path": ".\\Models\\DragDropStartingData.cs"
+      "path": "Models/DragDropStartingData.cs"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\DragDropService.cs"
+      "path": "Services/DragAndDrop/DragDropService.cs"
     },
     {
-      "path": ".\\Services\\DragAndDrop\\VisualDropConfiguration.cs"
+      "path": "Services/DragAndDrop/VisualDropConfiguration.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.ShareTarget.AddTemplateSelector._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.ShareTarget.AddTemplateSelector._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\TemplateSelectors\\SharedContentTemplateSelector.vb"
+      "path": "TemplateSelectors/SharedContentTemplateSelector.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.ShareTarget.AddTemplateSelector/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.ShareTarget.AddTemplateSelector/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\TemplateSelectors\\SharedContentTemplateSelector.cs"
+      "path": "TemplateSelectors/SharedContentTemplateSelector.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.ShareTarget._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.ShareTarget._VB/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\wts.ItemNameActivationHandler.vb"
+      "path": "Activation/wts.ItemNameActivationHandler.vb"
     },
     {
-    "path": ".\\Helpers\\ShareOperationExtensions.vb"
+    "path": "Helpers/ShareOperationExtensions.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Feat.ShareTarget/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Feat.ShareTarget/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Activation\\wts.ItemNameActivationHandler.cs"
+      "path": "Activation/wts.ItemNameActivationHandler.cs"
     },
     {
-    "path": ".\\Helpers\\ShareOperationExtensions.cs"
+    "path": "Helpers/ShareOperationExtensions.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.AddConnectedAnimationService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.AddConnectedAnimationService/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\ConnectedAnimationService.cs"
+      "path": "Services/ConnectedAnimationService.cs"
     },
     {
-      "path": ".\\Services\\IConnectedAnimationService.cs"
+      "path": "Services/IConnectedAnimationService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Camera.AddResource._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Camera.AddResource._VB/.template.config/template.json
@@ -19,16 +19,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\EventHandlers\\CameraControlEventArgs.vb"
+      "path": "EventHandlers/CameraControlEventArgs.vb"
     },
     {
-      "path": ".\\Helpers\\CameraOrientationExtensions.vb"
+      "path": "Helpers/CameraOrientationExtensions.vb"
     },
     {
-      "path": ".\\Controls\\CameraControl.xaml"
+      "path": "Controls/CameraControl.xaml"
     },
     {
-      "path": ".\\Controls\\CameraControl.xaml.vb"
+      "path": "Controls/CameraControl.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Camera.AddResource/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Camera.AddResource/.template.config/template.json
@@ -19,16 +19,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\EventHandlers\\CameraControlEventArgs.cs"
+      "path": "EventHandlers/CameraControlEventArgs.cs"
     },
     {
-      "path": ".\\Helpers\\CameraOrientationExtensions.cs"
+      "path": "Helpers/CameraOrientationExtensions.cs"
     },
     {
-      "path": ".\\Controls\\CameraControl.xaml"
+      "path": "Controls/CameraControl.xaml"
     },
     {
-      "path": ".\\Controls\\CameraControl.xaml.cs"
+      "path": "Controls/CameraControl.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Chart.SampleDataService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Chart.SampleDataService._VB/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\DataPoint.vb"
+      "path": "Param_ProjectName.Core/Models/DataPoint.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Chart.SampleDataService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Chart.SampleDataService/.template.config/template.json
@@ -20,7 +20,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\DataPoint.cs"
+      "path": "Param_ProjectName.Core/Models/DataPoint.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.ImageGallery._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.ImageGallery._VB/.template.config/template.json
@@ -20,43 +20,43 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Assets\\PlaceholderImage.png"
+      "path": "Param_ProjectName/Assets/PlaceholderImage.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto1.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto1.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto2.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto2.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto3.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto3.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto4.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto4.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto5.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto5.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto6.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto6.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto7.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto7.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto8.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto8.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto9.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto9.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto10.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto10.png"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleImage.vb"
+      "path": "Param_ProjectName.Core/Models/SampleImage.vb"
     },
     {
-      "path": ".\\Param_ProjectName\\Helpers\\ImagesNavigationHelper.vb"
+      "path": "Param_ProjectName/Helpers/ImagesNavigationHelper.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.ImageGallery/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.ImageGallery/.template.config/template.json
@@ -20,43 +20,43 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Assets\\PlaceholderImage.png"
+      "path": "Param_ProjectName/Assets/PlaceholderImage.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto1.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto1.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto2.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto2.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto3.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto3.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto4.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto4.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto5.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto5.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto6.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto6.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto7.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto7.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto8.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto8.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto9.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto9.png"
     },
     {
-      "path": ".\\Param_ProjectName\\Assets\\SampleData\\SamplePhoto10.png"
+      "path": "Param_ProjectName/Assets/SampleData/SamplePhoto10.png"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\SampleImage.cs"
+      "path": "Param_ProjectName.Core/Models/SampleImage.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Helpers\\ImagesNavigationHelper.cs"
+      "path": "Param_ProjectName/Helpers/ImagesNavigationHelper.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddBasicInkServices._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddBasicInkServices._VB/.template.config/template.json
@@ -19,25 +19,25 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\EventHandlers\\Ink\\AddStrokeEventArgs.vb"
+      "path": "EventHandlers/Ink/AddStrokeEventArgs.vb"
     },
     {
-      "path": ".\\EventHandlers\\Ink\\CopyPasteStrokesEventArgs.vb"
+      "path": "EventHandlers/Ink/CopyPasteStrokesEventArgs.vb"
     },
     {
-      "path": ".\\EventHandlers\\Ink\\MoveStrokesEventArgs.vb"
+      "path": "EventHandlers/Ink/MoveStrokesEventArgs.vb"
     },
     {
-      "path": ".\\EventHandlers\\Ink\\RemoveEventArgs.vb"
+      "path": "EventHandlers/Ink/RemoveEventArgs.vb"
     },
     {
-      "path": ".\\Services\\Ink\\InkStrokesService.vb"
+      "path": "Services/Ink/InkStrokesService.vb"
     },
     {
-      "path": ".\\Services\\Ink\\InkFileService.vb"
+      "path": "Services/Ink/InkFileService.vb"
     },
     {
-      "path": ".\\Services\\Ink\\InkPointerDeviceService.vb"
+      "path": "Services/Ink/InkPointerDeviceService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddBasicInkServices/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddBasicInkServices/.template.config/template.json
@@ -19,25 +19,25 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\EventHandlers\\Ink\\AddStrokeEventArgs.cs"
+      "path": "EventHandlers/Ink/AddStrokeEventArgs.cs"
     },
     {
-      "path": ".\\EventHandlers\\Ink\\CopyPasteStrokesEventArgs.cs"
+      "path": "EventHandlers/Ink/CopyPasteStrokesEventArgs.cs"
     },
     {
-      "path": ".\\EventHandlers\\Ink\\MoveStrokesEventArgs.cs"
+      "path": "EventHandlers/Ink/MoveStrokesEventArgs.cs"
     },
     {
-      "path": ".\\EventHandlers\\Ink\\RemoveEventArgs.cs"
+      "path": "EventHandlers/Ink/RemoveEventArgs.cs"
     },
     {
-      "path": ".\\Services\\Ink\\InkStrokesService.cs"
+      "path": "Services/Ink/InkStrokesService.cs"
     },
     {
-      "path": ".\\Services\\Ink\\InkFileService.cs"
+      "path": "Services/Ink/InkFileService.cs"
     },
     {
-      "path": ".\\Services\\Ink\\InkPointerDeviceService.cs"
+      "path": "Services/Ink/InkPointerDeviceService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddCopyPasteService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddCopyPasteService._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkCopyPasteService.vb"
+      "path": "Services/Ink/InkCopyPasteService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddCopyPasteService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddCopyPasteService/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkCopyPasteService.cs"
+      "path": "Services/Ink/InkCopyPasteService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddInkAnalyzer._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddInkAnalyzer._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkAsyncAnalyzer.vb"
+      "path": "Services/Ink/InkAsyncAnalyzer.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddInkAnalyzer/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddInkAnalyzer/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkAsyncAnalyzer.cs"
+      "path": "Services/Ink/InkAsyncAnalyzer.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddLassoSelectionService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddLassoSelectionService._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkLassoSelectionService.vb"
+      "path": "Services/Ink/InkLassoSelectionService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddLassoSelectionService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddLassoSelectionService/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkLassoSelectionService.cs"
+      "path": "Services/Ink/InkLassoSelectionService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddNodeSelectionService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddNodeSelectionService._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkNodeSelectionService.vb"
+      "path": "Services/Ink/InkNodeSelectionService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddNodeSelectionService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddNodeSelectionService/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkNodeSelectionService.cs"
+      "path": "Services/Ink/InkNodeSelectionService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddSelectionRectangleService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddSelectionRectangleService._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkSelectionRectangleService.vb"
+      "path": "Services/Ink/InkSelectionRectangleService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddSelectionRectangleService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddSelectionRectangleService/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkSelectionRectangleService.cs"
+      "path": "Services/Ink/InkSelectionRectangleService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddTransformService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddTransformService._VB/.template.config/template.json
@@ -19,16 +19,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkTransformService.vb"
+      "path": "Services/Ink/InkTransformService.vb"
     },
     {
-      "path": ".\\Services\\Ink\\InkTransformResult.vb"
+      "path": "Services/Ink/InkTransformResult.vb"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\TransformUndoRedoOperation.vb"
+      "path": "Services/Ink/UndoRedo/TransformUndoRedoOperation.vb"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\ClearStrokesAndShapesUndoRedoOperation.vb"
+      "path": "Services/Ink/UndoRedo/ClearStrokesAndShapesUndoRedoOperation.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddTransformService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddTransformService/.template.config/template.json
@@ -19,16 +19,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkTransformService.cs"
+      "path": "Services/Ink/InkTransformService.cs"
     },
     {
-      "path": ".\\Services\\Ink\\InkTransformResult.cs"
+      "path": "Services/Ink/InkTransformResult.cs"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\TransformUndoRedoOperation.cs"
+      "path": "Services/Ink/UndoRedo/TransformUndoRedoOperation.cs"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\ClearStrokesAndShapesUndoRedoOperation.cs"
+      "path": "Services/Ink/UndoRedo/ClearStrokesAndShapesUndoRedoOperation.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddUndoRedoService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddUndoRedoService._VB/.template.config/template.json
@@ -19,19 +19,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkUndoRedoService.vb"
+      "path": "Services/Ink/InkUndoRedoService.vb"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\AddStrokeUndoRedoOperation.vb"
+      "path": "Services/Ink/UndoRedo/AddStrokeUndoRedoOperation.vb"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\IUndoRedoOperation.vb"
+      "path": "Services/Ink/UndoRedo/IUndoRedoOperation.vb"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\MoveStrokesUndoRedoOperation.vb"
+      "path": "Services/Ink/UndoRedo/MoveStrokesUndoRedoOperation.vb"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\RemoveStrokeUndoRedoOperation.vb"
+      "path": "Services/Ink/UndoRedo/RemoveStrokeUndoRedoOperation.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddUndoRedoService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddUndoRedoService/.template.config/template.json
@@ -19,19 +19,19 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkUndoRedoService.cs"
+      "path": "Services/Ink/InkUndoRedoService.cs"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\AddStrokeUndoRedoOperation.cs"
+      "path": "Services/Ink/UndoRedo/AddStrokeUndoRedoOperation.cs"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\IUndoRedoOperation.cs"
+      "path": "Services/Ink/UndoRedo/IUndoRedoOperation.cs"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\MoveStrokesUndoRedoOperation.cs"
+      "path": "Services/Ink/UndoRedo/MoveStrokesUndoRedoOperation.cs"
     },
     {
-      "path": ".\\Services\\Ink\\UndoRedo\\RemoveStrokeUndoRedoOperation.cs"
+      "path": "Services/Ink/UndoRedo/RemoveStrokeUndoRedoOperation.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddZoomService._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddZoomService._VB/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkZoomService.vb"
+      "path": "Services/Ink/InkZoomService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.Ink.AddZoomService/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.Ink.AddZoomService/.template.config/template.json
@@ -19,7 +19,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Services\\Ink\\InkZoomService.cs"
+      "path": "Services/Ink/InkZoomService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.MasterDetail._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.MasterDetail._VB/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\wts.ItemNameDetailControl.xaml"
+      "path": "Views/wts.ItemNameDetailControl.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNameDetailControl.xaml.vb"
+      "path": "Views/wts.ItemNameDetailControl.xaml.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Page.MasterDetail/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Page.MasterDetail/.template.config/template.json
@@ -19,10 +19,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Views\\wts.ItemNameDetailControl.xaml"
+      "path": "Views/wts.ItemNameDetailControl.xaml"
     },
     {
-      "path": ".\\Views\\wts.ItemNameDetailControl.xaml.cs"
+      "path": "Views/wts.ItemNameDetailControl.xaml.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Project.AddCoreProject._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Project.AddCoreProject._VB/.template.config/template.json
@@ -17,7 +17,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core\\Param_ProjectName.Core.vbproj" }
+    { "path": "Param_ProjectName.Core/Param_ProjectName.Core.vbproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/_comp/_shared/Project.AddCoreProject/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Project.AddCoreProject/.template.config/template.json
@@ -17,7 +17,7 @@
   "sourceName": "wts.projectName",
   "preferNameDirectory": true,
   "PrimaryOutputs": [
-    { "path": ".\\Param_ProjectName.Core\\Param_ProjectName.Core.csproj" }
+    { "path": "Param_ProjectName.Core/Param_ProjectName.Core.csproj" }
   ],
   "symbols": {
     "wts.projectName": {

--- a/templates/Uwp/_comp/_shared/Project.SplitView.AddNavigationViewHeaderBehavior._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Project.SplitView.AddNavigationViewHeaderBehavior._VB/.template.config/template.json
@@ -20,10 +20,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Behaviors\\NavigationViewHeaderBehavior.vb"
+      "path": "Behaviors/NavigationViewHeaderBehavior.vb"
     },
     {
-      "path": ".\\Behaviors\\NavigationViewHeaderMode.vb"
+      "path": "Behaviors/NavigationViewHeaderMode.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Project.SplitView.AddNavigationViewHeaderBehavior/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Project.SplitView.AddNavigationViewHeaderBehavior/.template.config/template.json
@@ -20,10 +20,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Behaviors\\NavigationViewHeaderBehavior.cs"
+      "path": "Behaviors/NavigationViewHeaderBehavior.cs"
     },
     {
-      "path": ".\\Behaviors\\NavigationViewHeaderMode.cs"
+      "path": "Behaviors/NavigationViewHeaderMode.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Service.IdentityCommon._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Service.IdentityCommon._VB/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Assets\\DefaultIcon.png"
+      "path": "Param_ProjectName/Assets/DefaultIcon.png"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\StreamExtensions.vb"
+      "path": "Param_ProjectName.Core/Helpers/StreamExtensions.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\LoginResultType.vb"
+      "path": "Param_ProjectName.Core/Helpers/LoginResultType.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\User.vb"
+      "path": "Param_ProjectName.Core/Models/User.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Service.IdentityCommon/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Service.IdentityCommon/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Assets\\DefaultIcon.png"
+      "path": "Param_ProjectName/Assets/DefaultIcon.png"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\StreamExtensions.cs"
+      "path": "Param_ProjectName.Core/Helpers/StreamExtensions.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Helpers\\LoginResultType.cs"
+      "path": "Param_ProjectName.Core/Helpers/LoginResultType.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Models\\User.cs"
+      "path": "Param_ProjectName.Core/Models/User.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Service.IdentityForcedLogin._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Service.IdentityForcedLogin._VB/.template.config/template.json
@@ -20,10 +20,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\IdentityService.vb"
+      "path": "Param_ProjectName.Core/Services/IdentityService.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\MicrosoftGraphService.vb"
+      "path": "Param_ProjectName.Core/Services/MicrosoftGraphService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Service.IdentityForcedLogin/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Service.IdentityForcedLogin/.template.config/template.json
@@ -20,10 +20,10 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\IdentityService.cs"
+      "path": "Param_ProjectName.Core/Services/IdentityService.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\MicrosoftGraphService.cs"
+      "path": "Param_ProjectName.Core/Services/MicrosoftGraphService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Service.IdentityOptionalLogin._VB/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Service.IdentityOptionalLogin._VB/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Helpers\\AuthenticationHelper.vb"
+      "path": "Param_ProjectName/Helpers/AuthenticationHelper.vb"
     },
     {
-      "path": ".\\Param_ProjectName\\Helpers\\Restricted.vb"
+      "path": "Param_ProjectName/Helpers/Restricted.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\IdentityService.vb"
+      "path": "Param_ProjectName.Core/Services/IdentityService.vb"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\MicrosoftGraphService.vb"
+      "path": "Param_ProjectName.Core/Services/MicrosoftGraphService.vb"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Service.IdentityOptionalLogin/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Service.IdentityOptionalLogin/.template.config/template.json
@@ -21,16 +21,16 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName\\Helpers\\AuthenticationHelper.cs"
+      "path": "Param_ProjectName/Helpers/AuthenticationHelper.cs"
     },
     {
-      "path": ".\\Param_ProjectName\\Helpers\\Restricted.cs"
+      "path": "Param_ProjectName/Helpers/Restricted.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\IdentityService.cs"
+      "path": "Param_ProjectName.Core/Services/IdentityService.cs"
     },
     {
-      "path": ".\\Param_ProjectName.Core\\Services\\MicrosoftGraphService.cs"
+      "path": "Param_ProjectName.Core/Services/MicrosoftGraphService.cs"
     }
   ],
   "symbols": {

--- a/templates/Uwp/_comp/_shared/Services.WebApi/.template.config/template.json
+++ b/templates/Uwp/_comp/_shared/Services.WebApi/.template.config/template.json
@@ -23,7 +23,7 @@
   "preferNameDirectory": true,
   "PrimaryOutputs": [
     {
-      "path": ".\\Param_ProjectName.WebApi\\Param_ProjectName.WebApi.csproj"
+      "path": "Param_ProjectName.WebApi/Param_ProjectName.WebApi.csproj"
     }
   ],
   "symbols": {


### PR DESCRIPTION
- Quick summary of changes
Changed primary output path format to use '/' instead of '\' as sourceName is not replaced correctly in paths with '\\'
- Which issue does this PR relate to?
#3309 Generation error in VS 2019 Preview version
- Anything that requires particular review or attention?
Please adapt templates in PR to this change
- Do all automated tests pass? yes
- Have automated tests been added for new features? yes
- Have you raised issues for any needed follow-on work? no
- Have docs been updated? yes
