### PR TITLE
Issue1976 commandlinesupport

### DIFF
--- a/code/tools/TemplateValidator/TemplateJsonVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateJsonVerifier.cs
@@ -139,7 +139,7 @@ namespace TemplateValidator
             // The explicit values here are the ones that are currently in use.
             // In theory any string could be exported and used as a symbol but currently it's only these
             // If lots of templates start exporting new symbols it might be necessary to change how symbol keys are verified
-            var allValidSymbolKeys = new List<string>(paramValues) { "baseclass", "setter", "wts.Page.Settings", "wts.Page.Settings.CodeBehind", "wts.Page.Settings.Prism", "wts.Page.Settings.CaliburnMicro", "wts.Page.Settings.VB", "wts.Page.Settings.CodeBehind.VB", "copyrightYear" };
+            var allValidSymbolKeys = new List<string>(paramValues) { "baseclass", "setter", "wts.Page.Settings", "wts.Page.Settings.CodeBehind", "wts.Page.Settings.Prism", "wts.Page.Settings.CaliburnMicro", "wts.Page.Settings.VB", "wts.Page.Settings.CodeBehind.VB", "copyrightYear", "wts.safeprojectName" };
 
             foreach (var symbol in template.Symbols)
             {

--- a/templates/Uwp/Features/CommandLine.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/CommandLine.Prism/.template.config/template.json
@@ -43,6 +43,21 @@
     "wts.rootNamespace": {
       "type": "parameter",
       "replaces": "Param_RootNamespace"
-    }
+    },
+    "wts.safeprojectName": {
+      "type": "generated",
+      "generator": "regex",
+      "dataType": "string",
+      "replaces": "SafeProjectName",
+      "parameters": {
+          "source": "wts.projectName",
+          "steps": [
+              {
+                  "regex": "([-_,@! (£)+=])",
+                  "replacement": "_"
+              }
+          ],
+          "action":"replace"
+      }
   }
 }

--- a/templates/Uwp/Features/CommandLine.Prism/.template.config/template.json
+++ b/templates/Uwp/Features/CommandLine.Prism/.template.config/template.json
@@ -59,5 +59,6 @@
           ],
           "action":"replace"
       }
+    }
   }
 }

--- a/templates/Uwp/Features/CommandLine.Prism/Package_postaction.appxmanifest
+++ b/templates/Uwp/Features/CommandLine.Prism/Package_postaction.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
 <!--{[{-->
-  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" 
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
 <!--}]}-->
   xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/windowsTemplateStudio"
   IgnorableNamespaces="uap mp genTemplate">
@@ -13,13 +13,12 @@
     <Application Id="App"
       <Extensions>
 <!--{[{-->
-      
-          <uap5:Extension 
-            Category="windows.appExecutionAlias" 
-            Executable="Param_ProjectName.exe" 
-            EntryPoint="Param_ProjectName.App">
+          <uap5:Extension
+            Category="windows.appExecutionAlias"
+            Executable="SafeProjectName.exe"
+            EntryPoint="SafeProjectName.App">
             <uap5:AppExecutionAlias>
-              <uap5:ExecutionAlias Alias="Param_ProjectName.exe" />
+              <uap5:ExecutionAlias Alias="SafeProjectName.exe" />
             </uap5:AppExecutionAlias>
           </uap5:Extension>
 <!--}]}-->

--- a/templates/Uwp/Features/CommandLine._VB/.template.config/template.json
+++ b/templates/Uwp/Features/CommandLine._VB/.template.config/template.json
@@ -46,6 +46,22 @@
     "wts.rootNamespace": {
       "type": "parameter",
       "replaces": "Param_RootNamespace"
+    },
+    "wts.safeprojectName": {
+      "type": "generated",
+      "generator": "regex",
+      "dataType": "string",
+      "replaces": "SafeProjectName",
+      "parameters": {
+          "source": "wts.projectName",
+          "steps": [
+              {
+                  "regex": "([-_,@! (£)+=])",
+                  "replacement": "_"
+              }
+          ],
+          "action":"replace"
+      }
     }
   }
 }

--- a/templates/Uwp/Features/CommandLine._VB/Package_postaction.appxmanifest
+++ b/templates/Uwp/Features/CommandLine._VB/Package_postaction.appxmanifest
@@ -13,13 +13,12 @@
     <Application Id="App"
       <Extensions>
 <!--{[{-->
-      
-          <uap5:Extension 
-            Category="windows.appExecutionAlias" 
-            Executable="Param_ProjectName.exe" 
-            EntryPoint="Param_ProjectName.App">
+          <uap5:Extension
+            Category="windows.appExecutionAlias"
+            Executable="SafeProjectName.exe"
+            EntryPoint="SafeProjectName.App">
             <uap5:AppExecutionAlias>
-              <uap5:ExecutionAlias Alias="Param_ProjectName.exe" />
+              <uap5:ExecutionAlias Alias="SafeProjectName.exe" />
             </uap5:AppExecutionAlias>
           </uap5:Extension>
 <!--}]}-->

--- a/templates/Uwp/Features/CommandLine/.template.config/template.json
+++ b/templates/Uwp/Features/CommandLine/.template.config/template.json
@@ -46,6 +46,22 @@
     "wts.rootNamespace": {
       "type": "parameter",
       "replaces": "Param_RootNamespace"
+    },
+    "wts.safeprojectName": {
+      "type": "generated",
+      "generator": "regex",
+      "dataType": "string",
+      "replaces": "SafeProjectName",
+      "parameters": {
+          "source": "wts.projectName",
+          "steps": [
+              {
+                  "regex": "([-_,@! (£)+=])",
+                  "replacement": "_"
+              }
+          ],
+          "action":"replace"
+      }
     }
   }
 }

--- a/templates/Uwp/Features/CommandLine/Package_postaction.appxmanifest
+++ b/templates/Uwp/Features/CommandLine/Package_postaction.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
 <!--{[{-->
-  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" 
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
 <!--}]}-->
   xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/windowsTemplateStudio"
   IgnorableNamespaces="uap mp genTemplate">
@@ -13,13 +13,12 @@
     <Application Id="App"
       <Extensions>
 <!--{[{-->
-      
-          <uap5:Extension 
-            Category="windows.appExecutionAlias" 
-            Executable="Param_ProjectName.exe" 
-            EntryPoint="Param_ProjectName.App">
+          <uap5:Extension
+            Category="windows.appExecutionAlias"
+            Executable="SafeProjectName.exe"
+            EntryPoint="SafeProjectName.App">
             <uap5:AppExecutionAlias>
-              <uap5:ExecutionAlias Alias="Param_ProjectName.exe" />
+              <uap5:ExecutionAlias Alias="SafeProjectName.exe" />
             </uap5:AppExecutionAlias>
           </uap5:Extension>
 <!--}]}-->


### PR DESCRIPTION
- Quick summary of changes: 
Tests for commandline with special chars in names are failing with the following error:
`Reason: The file name "SV -_.,@! (ú)+=CS.exe" declared for element […] doesn't exist in the package. `
Added a regex to transform the Projectname to a safeprojectname.

- Which issue does this PR relate to?
#1976 Commandline support


