### PR TITLE
Combine template tests

### DIFF
--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Templates.Test
             Assert.Contains(expectedPfText, content, StringComparison.OrdinalIgnoreCase);
         }
 
-        protected void AssertBuildProjectAsync(string projectPath, string projectName, string platform)
+        protected void AssertBuildProjectAsync(string projectPath, string projectName, string platform, bool deleteAfterBuild = true)
         {
             // Build solution
             var result = _fixture.BuildSolution(projectName, projectPath, platform);
@@ -208,7 +208,10 @@ namespace Microsoft.Templates.Test
             Assert.True(result.exitCode.Equals(0), $"Solution {projectName} was not built successfully. {Environment.NewLine}Errors found: {_fixture.GetErrorLines(result.outputFile)}.{Environment.NewLine}Please see {Path.GetFullPath(result.outputFile)} for more details.");
 
             // Clean
-            Fs.SafeDeleteDirectory(projectPath);
+            if (deleteAfterBuild)
+            {
+                Fs.SafeDeleteDirectory(projectPath);
+            }
         }
 
         protected void AssertBuildProjectThenRunTestsAsync(string projectPath, string projectName, string platform)

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -77,7 +78,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G1{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -87,6 +88,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG2Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -99,7 +101,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G2{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -147,30 +149,6 @@ namespace Microsoft.Templates.Test
             var projectName = $"{ShortProjectType(projectType)}{ShortProjectType(framework)}AllStyleCopG2";
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro")]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "MinimumCaliburnMicro")]
-        [Trait("ExecutionSet", "_CIBuild")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
-        {
-            var projectName = $"{ShortProjectType(projectType)}AllRandom";
-
-            Func<ITemplateInfo, bool> templateSelector =
-                t => t.GetTemplateType().IsItemTemplate()
-                && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
-                && t.GetFrontEndFrameworkList().Contains(framework)
-                && t.GetPlatform() == platform
-                && t.GetItemNameEditable()
-                && !t.GetIsHidden();
-
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro")]
-        [Trait("ExecutionSet", "BuildCaliburnMicro")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
@@ -100,7 +88,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopG1Async(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithOptionalLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -115,7 +103,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]
@@ -123,7 +111,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopG2Async(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithForcedLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -138,7 +126,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro")]
-        [Trait("ExecutionSet", "BuildCaliburnMicro")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCaliburnMicroProjectTests.cs
@@ -26,22 +26,12 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
-        public async Task BuildEmptyProjectAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro")]
-        [Trait("ExecutionSet", "BuildCaliburnMicro")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildProjects")]
         public async Task BuildEmptyProjectAndInferConfigAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-            _fixture.BuildSolution(projectName, projectPath, platform);
+
+            // Don't delete after build test as used in inference test, which will then delete.
+            AssertBuildProjectAsync(projectPath, projectName, platform, deleteAfterBuild: false);
 
             EnsureCanInferConfigInfo(projectType, framework, platform, projectPath);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -78,7 +79,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{(projectType)}{CharactersThatMayCauseProjectNameIssues()}G1{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -88,6 +89,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG2Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -101,7 +103,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G2{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -176,46 +178,6 @@ namespace Microsoft.Templates.Test
             var projectName = $"{projectType}{framework}AllStyleCopO";
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.CSharp, Platforms.Uwp)]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "BuildCodeBehind")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesCSAsync(string projectType, string framework, string platform, string language)
-        {
-            await BuildAllPagesAndFeaturesRandomNamesAsync(projectType, framework, platform, language);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "BuildMinimumVB")]
-        [Trait("ExecutionSet", "BuildCodeBehind")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesVBAsync(string projectType, string framework, string platform, string language)
-        {
-            await BuildAllPagesAndFeaturesRandomNamesAsync(projectType, framework, platform, language);
-        }
-
-        private async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
-        {
-            var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";
-
-            Func<ITemplateInfo, bool> templateSelector =
-                    t => t.GetTemplateType().IsItemTemplate()
-                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
-                    && t.GetFrontEndFrameworkList().Contains(framework)
-                    && t.GetPlatform() == platform
-                    && t.GetItemNameEditable()
-                    && !t.GetIsHidden();
-
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
@@ -26,21 +26,12 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
-        public async Task BuildEmptyProjectAsync(string projectType, string framework, string platform, string language)
+        public async Task BuildEmptyProjectAndInferConfigAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind")]
-        [Trait("ExecutionSet", "BuildCodeBehind")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildProjects")]
-        public async Task InferConfigEmptyProjectAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
+            // Don't delete after build test as used in inference test, which will then delete.
+            AssertBuildProjectAsync(projectPath, projectName, platform, deleteAfterBuild: false);
 
             EnsureCanInferConfigInfo(projectType, framework, platform, projectPath);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind")]
-        [Trait("ExecutionSet", "BuildCodeBehind")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
@@ -103,7 +91,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopAsyncWithForcedLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithForcedLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -118,7 +106,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]
@@ -128,7 +116,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateMinimumAndCheckWithStyleCopAsyncWithOptionalLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithOptionalLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -143,7 +131,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind")]
-        [Trait("ExecutionSet", "BuildCodeBehind")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
@@ -25,22 +25,12 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
-        public async Task BuildEmptyProjectAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic")]
-        [Trait("ExecutionSet", "BuildMVVMBasic")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildProjects")]
         public async Task BuildEmptyProjectAndInferConfigAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-            _fixture.BuildSolution(projectName, projectPath, platform);
+
+            // Don't delete after build test as used in inference test, which will then delete.
+            AssertBuildProjectAsync(projectPath, projectName, platform, deleteAfterBuild: false);
 
             EnsureCanInferConfigInfo(projectType, framework, platform, projectPath);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
@@ -40,18 +40,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic")]
-        [Trait("ExecutionSet", "BuildMVVMBasic")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
@@ -40,18 +40,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic")]
-        [Trait("ExecutionSet", "BuildMVVMBasic")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
@@ -104,7 +92,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopAsyncWithForcedLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithForcedLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -119,7 +107,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]
@@ -129,7 +117,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateMinimumAndCheckWithStyleCopAsyncWithOptionalLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithOptionalLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -144,7 +132,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -78,7 +79,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G1{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -88,6 +89,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG2Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -102,7 +104,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G2{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -177,46 +179,6 @@ namespace Microsoft.Templates.Test
             var projectName = $"{projectType}{framework}AllStyleCopO";
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp)]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "BuildMVVMBasic")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesCSAsync(string projectType, string framework, string platform, string language)
-        {
-            await BuildAllPagesAndFeaturesRandomNamesAsync(projectType, framework, platform, language);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "BuildMinimumVB")]
-        [Trait("ExecutionSet", "BuildMVVMBasic")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesVBAsync(string projectType, string framework, string platform, string language)
-        {
-            await BuildAllPagesAndFeaturesRandomNamesAsync(projectType, framework, platform, language);
-        }
-
-        private async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
-        {
-            var projectName = $"{ShortProjectType(projectType)}AllRandomG2{ShortLanguageName(language)}";
-
-            Func<ITemplateInfo, bool> templateSelector =
-                t => t.GetTemplateType().IsItemTemplate()
-                && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
-                && t.GetFrontEndFrameworkList().Contains(framework)
-                && t.GetPlatform() == platform
-                && t.GetItemNameEditable()
-                && !t.GetIsHidden();
-
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight")]
-        [Trait("ExecutionSet", "BuildMVVMLight")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -78,7 +79,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G1{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -88,6 +89,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG2Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -101,7 +103,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G2{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -176,47 +178,6 @@ namespace Microsoft.Templates.Test
             var projectName = $"{projectType}{framework}AllStyleCopO";
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp)]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "BuildMVVMLight")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesCSAsync(string projectType, string framework, string platform, string language)
-        {
-            await BuildAllPagesAndFeaturesRandomNamesAsync(projectType, framework, platform, language);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "BuildMinimumVB")]
-        [Trait("ExecutionSet", "BuildMVVMLight")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesVBAsync(string projectType, string framework, string platform, string language)
-        {
-            await BuildAllPagesAndFeaturesRandomNamesAsync(projectType, framework, platform, language);
-        }
-
-        private async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
-        {
-            var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";
-
-            Func<ITemplateInfo, bool> templateSelector =
-                    t => t.GetTemplateType().IsItemTemplate()
-                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
-                    && t.GetFrontEndFrameworkList().Contains(framework)
-                    && t.GetPlatform() == platform
-                    && t.GetItemNameEditable()
-                    && !t.GetIsHidden();
-
-
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
@@ -26,22 +26,12 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
-        public async Task BuildEmptyProjectAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight")]
-        [Trait("ExecutionSet", "BuildMVVMLight")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildProjects")]
         public async Task BuildEmptyProjectAndInferConfigAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-            _fixture.BuildSolution(projectName, projectPath, platform);
+
+            // Don't delete after build test as used in inference test, which will then delete.
+            AssertBuildProjectAsync(projectPath, projectName, platform, deleteAfterBuild: false);
 
             EnsureCanInferConfigInfo(projectType, framework, platform, projectPath);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight")]
-        [Trait("ExecutionSet", "BuildMVVMLight")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
@@ -103,7 +91,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopAsyncWithForcedLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithForcedLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -118,7 +106,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]
@@ -128,7 +116,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateMinimumAndCheckWithStyleCopAsyncWithOptionalLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithOptionalLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -143,7 +131,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -77,7 +78,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G1{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -87,6 +88,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
+        [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG2Async(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
@@ -99,7 +101,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}G2{ShortLanguageName(language)}";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }
@@ -174,29 +176,6 @@ namespace Microsoft.Templates.Test
             var projectName = $"{projectType}{framework}AllStyleCopO";
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism")]
-        [Trait("Type", "BuildRandomNames")]
-        [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "BuildPrism")]
-        [Trait("ExecutionSet", "_Full")]
-        public async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
-        {
-            var projectName = $"{ShortProjectType(projectType)}AllRandom";
-
-            Func<ITemplateInfo, bool> templateSelector =
-                t => t.GetTemplateType().IsItemTemplate()
-                && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
-                && t.GetFrontEndFrameworkList().Contains(framework)
-                && t.GetPlatform() == platform
-                && t.GetItemNameEditable()
-                && !t.GetIsHidden();
-
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, GenerationFixture.GetRandomName);
 
             AssertBuildProjectAsync(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism")]
-        [Trait("ExecutionSet", "BuildPrism")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
-        public async Task BuildAllPagesAndFeaturesThenRunTestsAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateAllPagesAndFeaturesAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism")]
-        [Trait("ExecutionSet", "BuildPrism")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildAllPagesAndFeatures")]
         [Trait("Type", "BuildRandomNames")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationG1Async(string projectType, string framework, string platform, string language)
         {
@@ -101,7 +89,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopAsyncWithForcedLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithForcedLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -116,7 +104,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]
@@ -126,7 +114,7 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateMinimumAndCheckWithStyleCopAsyncWithOptionalLogin(string projectType, string framework, string platform, string language)
+        public async Task GenerateAllWithOptionalLoginRunTestsAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string language)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -141,7 +129,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
@@ -26,22 +26,12 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
-        public async Task BuildEmptyProjectAsync(string projectType, string framework, string platform, string language)
-        {
-            var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-
-            AssertBuildProjectAsync(projectPath, projectName, platform);
-        }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism")]
-        [Trait("ExecutionSet", "BuildPrism")]
-        [Trait("ExecutionSet", "_Full")]
-        [Trait("Type", "BuildProjects")]
         public async Task BuildEmptyProjectAndInferConfigAsync(string projectType, string framework, string platform, string language)
         {
             var (projectName, projectPath) = await GenerateEmptyProjectAsync(projectType, framework, platform, language);
-            _fixture.BuildSolution(projectName, projectPath, platform);
+
+            // Don't delete after build test as used in inference test, which will then delete.
+            AssertBuildProjectAsync(projectPath, projectName, platform, deleteAfterBuild: false);
 
             EnsureCanInferConfigInfo(projectType, framework, platform, projectPath);
         }

--- a/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
+++ b/code/test/Templates.Test/CodeAnalysis/VBStyleProjectGenerationTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Templates.Test
         [Theory]
         [MemberData(nameof(GetProjectTemplatesForVBStyle))]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesG1AndCheckWithVBStyleAsync(string projectType, string framework, string platform)
+        public async Task GenerateAllWithOptionalLoginRunTestsAndCheckWithVBStyleAsync(string projectType, string framework, string platform)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -40,13 +40,13 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         [Theory]
         [MemberData(nameof(GetProjectTemplatesForVBStyle))]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesG2AndCheckWithVBStyleAsync(string projectType, string framework, string platform)
+        public async Task GenerateAllWithForcedLoginRunTestsAndCheckWithVBStyleAsync(string projectType, string framework, string platform)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => t.GetTemplateType().IsItemTemplate()
@@ -61,7 +61,7 @@ namespace Microsoft.Templates.Test
 
             var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
 
-            AssertBuildProjectAsync(projectPath, projectName, platform);
+            AssertBuildProjectThenRunTestsAsync(projectPath, projectName, platform);
         }
 
         public static IEnumerable<object[]> GetProjectTemplatesForVBStyle()

--- a/templates/Uwp/_comp/Prism/Service.IdentityOptionalLogin.MenuBar/ViewModels/ShellViewModel_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Service.IdentityOptionalLogin.MenuBar/ViewModels/ShellViewModel_postaction.cs
@@ -31,7 +31,7 @@ namespace Param_RootNamespace.ViewModels
         }
 //}]}
 
-        public ICommand MenuViewsMainCommand { get; }
+        public ICommand MenuViewsParam_HomeNameCommand { get; }
 
         public ShellViewModel(IMenuNavigationService menuNavigationService)
         {
@@ -98,7 +98,7 @@ namespace Param_RootNamespace.ViewModels
                 }
                 else
                 {
-                    _menuNavigationService.UpdateView(PageTokens.MainPage);
+                    _menuNavigationService.UpdateView(PageTokens.Param_HomeNamePage);
                 }
             }
         }


### PR DESCRIPTION
For #3347 

Combines some of the tests which have a large amount of overlap. While separate tests is better in a number of scenarios, these tests are hardly ever run separately and so the benefit of being able to have narrowly scoped tests loses out to having a test suite that takes less time to run.

Refactoring tests also found a bug where OptionalLogin on Prism didn't cope with the main page being renamed. There is a fix for this as part of this PR.

The old test should have caught this before but at least we know this is passing now.


Once this is merged, will need a full (overnight) build to verify everything still behaves as before.
