### PR TITLE
Fix UI Tests

### DIFF
--- a/code/test/UI.Test/TemplatesFixture.cs
+++ b/code/test/UI.Test/TemplatesFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.UI.Test
         public void InitializeFixture(string platform, string language)
         {
             var path = $"{Path.GetPathRoot(Environment.CurrentDirectory)}\\UIT\\UI\\";
-            var source = new LocalTemplatesSource(null);
+            var source = new LocalTemplatesSource(null, "UITest");
             GenContext.Bootstrap(source, new FakeGenShell(platform, language), Platforms.Uwp, language);
             GenContext.Current = new FakeContextProvider
             {

--- a/code/test/VsEmulator/CoreTemplateStudio.config.json
+++ b/code/test/VsEmulator/CoreTemplateStudio.config.json
@@ -1,5 +1,5 @@
 {
-  "Environment": "LocalEnv",
+  "Environment": "LocalEnvWinTS",
   "CdnUrl": "",
   "RemoteTelemetryKey": "VSIX Key",
   "LogFileFolderPath": "WinTS\\Logs",

--- a/code/test/VsEmulator/Main/MainViewModel.cs
+++ b/code/test/VsEmulator/Main/MainViewModel.cs
@@ -515,7 +515,7 @@ namespace Microsoft.Templates.VsEmulator.Main
 
         private string GetTemplatesFolder()
         {
-            return Path.Combine(SpecialFolder.LocalApplicationData.ToString(), @"\WinTS\Templates\LocalEnv");
+            return Path.Combine(SpecialFolder.LocalApplicationData.ToString(), @"\WinTS\Templates\LocalEnvWinTS");
         }
     }
 }

--- a/code/test/VsEmulator/TemplatesContent/TemplatesContentViewModel.cs
+++ b/code/test/VsEmulator/TemplatesContent/TemplatesContentViewModel.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Templates.VsEmulator.TemplatesContent
 
         private string GetTemplatesFolder()
         {
-            return @"C:\ProgramData\WindowsTemplateStudio\Templates\LocalEnv";
+            return @"C:\ProgramData\WindowsTemplateStudio\Templates\LocalEnvWinTS";
         }
     }
 }


### PR DESCRIPTION
Quick summary of changes
- Set UI Test Template Source Name 
- Set default version to 0.0.0.0 on CoreTS assemblies

Which issue does this PR relate to?
- #3424 Build dev.templates.tests.full_20191106.1 failed

Also changing the LocalEnv to LocalEnvWinTS as this conflicts with WebTS LocalEnv on our machines