### PR TITLE
Mark line await Task.CompletedTask; as optional context

### DIFF
--- a/templates/Uwp/Features/BackgroundTask.Prism/Param_ProjectName/App_postaction.xaml.cs
+++ b/templates/Uwp/Features/BackgroundTask.Prism/Param_ProjectName/App_postaction.xaml.cs
@@ -23,7 +23,9 @@ namespace Param_RootNamespace
 
         protected override async Task OnActivateApplicationAsync(IActivatedEventArgs args)
         {
+//{??{
             await Task.CompletedTask;
+//}??}
         }
 
 //{[{

--- a/templates/Uwp/Features/CommandLine.Prism/App_postaction.xaml.cs
+++ b/templates/Uwp/Features/CommandLine.Prism/App_postaction.xaml.cs
@@ -52,7 +52,9 @@ namespace Param_RootNamespace
             }
 //}]}
 
+//{??{
             await Task.CompletedTask;
+//}??}
         }
     }
 }


### PR DESCRIPTION
Quick summary of changes
- Mark line "await Task.CompletedTask;" as optional context

Which issue does this PR relate to?
#3437 Dev-nightly: Generation fails when adding all features on a Prism app
