### PR TITLE
Fix Synchronize-Files-Used-By-VisualBasic-Templates.ps1 script

### DIFF
--- a/_utils/Synchronize-Files-Used-By-VisualBasic-Templates.ps1
+++ b/_utils/Synchronize-Files-Used-By-VisualBasic-Templates.ps1
@@ -3,10 +3,10 @@
 # This is necessary because the way template folders are copied and filtered means that, for example, the VB templates can't point to files in the C# folders.
 
 # This script finds all interested files in VB folders and then copies the equivalent file from the CS version
-Get-ChildItem ..\templates\* -Recurse -include *.xaml, *.resw, *.md, *.png, Package.appxmanifest | where { $_.FullName -Match "._VB\\" -and ($_.FullName -notmatch "\\templates\\Uwp\\test\\") } | % { $cs = $_.FullName -replace "._VB\\", "\\"; Copy-Item $cs $_.FullName }
+Get-ChildItem ..\templates\* -Recurse -include *.xaml, *.resw, *.md, *.png, Package.appxmanifest | where { $_.FullName -Match "._VB\\" -and ($_.FullName -notmatch "\\templates\\Uwp\\SC\\") } | % { $cs = $_.FullName -replace "._VB\\", "\\"; Copy-Item $cs $_.FullName }
 
 # This script handles project file postactions that add 3rd party references
-Get-ChildItem ..\templates\* -Recurse -include _postaction.vbproj | where { $_.FullName -notmatch "\\templates\\Uwp\\test\\" } | % { $cs = $_.FullName -replace "._VB\\", "\\"; $cs = $cs -replace ".vbproj", ".csproj"; Copy-Item $cs $_.FullName }
+Get-ChildItem ..\templates\* -Recurse -include _postaction.vbproj | where { $_.FullName -notmatch "\\templates\\Uwp\\SC\\" } | % { $cs = $_.FullName -replace "._VB\\", "\\"; $cs = $cs -replace ".vbproj", ".csproj"; Copy-Item $cs $_.FullName }
 
 # Formats JSON in a nicer format than the built-in ConvertTo-Json does.
 # This is based on code from https://github.com/PowerShell/PowerShell/issues/2736 and will be built into PS6.0
@@ -31,7 +31,7 @@ function Format-Json([Parameter(Mandatory, ValueFromPipeline)][String] $json) {
 
 # This script updates all the localized string values in VB template files from their C# equivalents.
 # This is needed as the files can't just be copied as they have VB specific content.
-Get-ChildItem ..\templates\* -Recurse -include *template.json | where { $_.FullName -Match "VB\\" -and ($_.FullName -notmatch "\\templates\\Uwp\\test\\") } |  % { 
+Get-ChildItem ..\templates\* -Recurse -include *template.json | where { $_.FullName -Match "VB\\" -and ($_.FullName -notmatch "\\templates\\Uwp\\SC\\") } |  % { 
 
     $vbFile = $_.FullName;
     $csFile = $_.FullName -replace "._VB\\", "\\"; 
@@ -56,7 +56,7 @@ Get-ChildItem ..\templates\* -Recurse -include *template.json | where { $_.FullN
         # Not every template contains "name" or "description" properties so only look at those that do.
         if (($vbJson.PSobject.Properties.name -match "name") -and ($csJson.PSobject.Properties.name -match "name"))
         {
-            if ($vbJson.name -ne $csJson.name)
+            if ($vbJson.name -ne $csJson.name -and $vbJson.tags.'wts.type' -ne "composition")
             {
                 $vbJson.name = $csJson.name
                 $somethingWasChanged = $true;

--- a/templates/Uwp/_comp/_shared/Page.TabView.Blank._VB/App_postaction.xaml
+++ b/templates/Uwp/_comp/_shared/Page.TabView.Blank._VB/App_postaction.xaml
@@ -1,9 +1,5 @@
-﻿    <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
+﻿            <ResourceDictionary.MergedDictionaries>
 <!--{[{-->
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls" />
 <!--}]}-->
             </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Application.Resources>


### PR DESCRIPTION
I've fixed the folder comparison to update the templates and remove the name equivalency on composition templates.

Synchronize-Files-Used-By-VisualBasic-Templates.ps1 script changes more files than it should #3440