### PR TITLE
Markdown Documentation files missing in Dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ After selecting the items wanted in your app, you can extend the generated code 
 - [Using WinTS to build WPF apps](./docs/WPF/getting-started-endusers.md)
 - [Working on WinTS](./docs/getting-started-developers.md)
 
+Note. When reading the documentation, some markdown files have not been copied to the dev branch, if you find a link is 404'ing change to the 'master' branch.
+
 ## Known issues
 
 - You can't have side-by-side versions (nightly/pre-release/release) of Windows Template Studio VSPackage into a single instance of Visual Studio.


### PR DESCRIPTION
Some Markdown files are missing from the dev branch
https://github.com/microsoft/WindowsTemplateStudio/tree/dev/docs/services
compared to
https://github.com/microsoft/WindowsTemplateStudio/tree/master/docs/services

# PR checklist

Quick summary of changes

- Which issue does this PR relate to?
- Anything that requires particular review or attention?
- Do all automated tests pass?
- Have automated tests been added for new features?
- If you've changed the UI:
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).
- If you've included a new template:
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/WindowsTemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/WPF/getting-started-endusers.md) getting started doc.
- Have you raised issues for any needed follow-on work?
- Have docs been updated?
- If breaking changes or different ways of doing things have been introduced, have they been communicated widely?
