### PR TITLE
UWP Pre-req Win10 Fall Creators Update

### DIFF
--- a/docs/UWP/getting-started-endusers.md
+++ b/docs/UWP/getting-started-endusers.md
@@ -152,6 +152,10 @@ Windows Template Studio approaches UWP app creation using the following attribut
 
 ---
 
+## Pre-requisies
+
+The minimum support Windows 10 version that your visual studio needs to be installed on is the Fall Creators Update. As the Microsoft.Toolkit.Uwp.UI.Controls 5.1.1 (https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI.Controls/) support is for UAP 10.0.16299, this limits how far back you can support Windows 10 OSs for your app.
+
 ## Learn more
 
 - [Handling app activation](./activation.md)

--- a/docs/UWP/getting-started-endusers.md
+++ b/docs/UWP/getting-started-endusers.md
@@ -154,7 +154,7 @@ Windows Template Studio approaches UWP app creation using the following attribut
 
 ## Pre-requisies
 
-The minimum support Windows 10 version that your visual studio needs to be installed on is the Fall Creators Update. As the Microsoft.Toolkit.Uwp.UI.Controls 5.1.1 (https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI.Controls/) support is for UAP 10.0.16299, this limits how far back you can support Windows 10 OSs for your app.
+The minimum supported Windows 10 version and which SDKs should be pre-installed are detailed in the [WinTS Principles](../../../README.md#principles).
 
 ## Learn more
 


### PR DESCRIPTION
Minimum Windows 10 version is the Fall Creators Update because (at least) UWP.UI.Controls require >= 10.0.16299

# PR checklist

Quick summary of changes

- Which issue does this PR relate to?
- Anything that requires particular review or attention?
- Do all automated tests pass?
- Have automated tests been added for new features?
- If you've changed the UI:
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).
- If you've included a new template:
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/WindowsTemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/WPF/getting-started-endusers.md) getting started doc.
- Have you raised issues for any needed follow-on work?
- Have docs been updated?
- If breaking changes or different ways of doing things have been introduced, have they been communicated widely?
