### PR TITLE
Fix UI tests

### DIFF
--- a/code/src/UI/ViewModels/Common/BaseMainViewModel.cs
+++ b/code/src/UI/ViewModels/Common/BaseMainViewModel.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Templates.UI.ViewModels.Common
 
         public abstract Task ProcessItemAsync(object item);
 
-        protected abstract Task OnTemplatesAvailableAsync();
+        public abstract Task OnTemplatesAvailableAsync();
 
         public virtual void UnsubscribeEventHandlers()
         {
@@ -62,7 +62,7 @@ namespace Microsoft.Templates.UI.ViewModels.Common
             StylesService.UnsubscribeEventHandlers();
         }
 
-        public virtual async Task InitializeAsync(string platform, string language)
+        public virtual void Initialize(string platform, string language)
         {
             Platform = platform;
             Language = language;
@@ -81,8 +81,13 @@ namespace Microsoft.Templates.UI.ViewModels.Common
                 }
             }
 
-            GenContext.ToolBox.Repo.Sync.SyncStatusChanged += OnSyncStatusChanged;
             SystemService.Initialize();
+        }
+
+        public virtual async Task SynchronizeAsync()
+        {
+            GenContext.ToolBox.Repo.Sync.SyncStatusChanged += OnSyncStatusChanged;
+
             try
             {
                 await GenContext.ToolBox.Repo.SynchronizeAsync();

--- a/code/src/UI/ViewModels/NewItem/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewItem/MainViewModel.cs
@@ -92,12 +92,12 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
             }
         }
 
-        public async Task InitializeAsync(TemplateType templateType, string language)
+        public void Initialize(TemplateType templateType, string language)
         {
             TemplateType = templateType;
             WizardStatus.Title = GetNewItemTitle(templateType);
             SetProjectConfigInfo();
-            await InitializeAsync(ConfigPlatform, language);
+            Initialize(ConfigPlatform, language);
         }
 
         private string GetNewItemTitle(TemplateType templateType)
@@ -202,7 +202,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
             WizardShell.Current.Result.ItemGenerationType = ChangesSummary.DoNotMerge ? ItemGenerationType.Generate : ItemGenerationType.GenerateAndMerge;
         }
 
-        protected override async Task OnTemplatesAvailableAsync()
+        public override async Task OnTemplatesAvailableAsync()
         {
             TemplateSelection.LoadData(TemplateType, ConfigPlatform, ConfigProjectType, ConfigFramework);
             WizardStatus.IsLoading = false;

--- a/code/src/UI/ViewModels/NewProject/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewProject/MainViewModel.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewProject
             WizardStatus.IsLoading = false;
         }
 
-        public async Task BuildStepViewModelAsync(TemplateType templateType)
+        private async Task BuildStepViewModelAsync(TemplateType templateType)
         {
             var hasTemplates = DataService.HasTemplatesFromType(templateType, Platform, ProjectType.Selected.Name, Framework.Selected.Name);
             var stepId = templateType.GetNewProjectStepId();

--- a/code/src/UI/ViewModels/NewProject/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewProject/MainViewModel.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewProject
             }
         }
 
-        public override async Task InitializeAsync(string platform, string language)
+        public override void Initialize(string platform, string language)
         {
             switch (platform)
             {
@@ -99,7 +99,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewProject
                     break;
             }
 
-            await base.InitializeAsync(platform, language);
+            base.Initialize(platform, language);
         }
 
         private void OnFinish(object sender, EventArgs e)
@@ -168,7 +168,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewProject
             }
         }
 
-        protected override async Task OnTemplatesAvailableAsync()
+        public override async Task OnTemplatesAvailableAsync()
         {
             ValidationService.Initialize(UserSelection.GetNames, UserSelection.GetPageNames);
             await ProjectType.LoadDataAsync(Platform);
@@ -214,7 +214,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewProject
             WizardStatus.IsLoading = false;
         }
 
-        private async Task BuildStepViewModelAsync(TemplateType templateType)
+        public async Task BuildStepViewModelAsync(TemplateType templateType)
         {
             var hasTemplates = DataService.HasTemplatesFromType(templateType, Platform, ProjectType.Selected.Name, Framework.Selected.Name);
             var stepId = templateType.GetNewProjectStepId();

--- a/code/src/UI/Views/NewItem/WizardShell.xaml.cs
+++ b/code/src/UI/Views/NewItem/WizardShell.xaml.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Templates.UI.Views.NewItem
 
         private async void OnLoaded(object sender, RoutedEventArgs e)
         {
-            await MainViewModel.Instance.InitializeAsync(_templateType, _language);
+            MainViewModel.Instance.Initialize(_templateType, _language);
+            await MainViewModel.Instance.SynchronizeAsync();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/code/src/UI/Views/NewProject/WizardShell.xaml.cs
+++ b/code/src/UI/Views/NewProject/WizardShell.xaml.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Templates.UI.Views.NewProject
 
         private async void OnLoaded(object sender, RoutedEventArgs e)
         {
-            await MainViewModel.Instance.InitializeAsync(_platform, _language);
+            MainViewModel.Instance.Initialize(_platform, _language);
+            await MainViewModel.Instance.SynchronizeAsync();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/code/test/UI.Test/NewProjectTest.cs
+++ b/code/test/UI.Test/NewProjectTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Templates.Core;
 using Microsoft.Templates.Core.Gen;
 using Microsoft.Templates.UI.Controls;
+using Microsoft.Templates.UI.Services;
 using Microsoft.Templates.UI.ViewModels.Common;
 using Microsoft.Templates.UI.ViewModels.NewProject;
 using Microsoft.Templates.UI.Views.NewProject;
@@ -56,7 +57,8 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
 
             var pages = viewModel.UserSelection.Groups.First(p => p.TemplateType == TemplateType.Page);
             var features = viewModel.UserSelection.Groups.First(p => p.TemplateType == TemplateType.Feature);
@@ -78,7 +80,8 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
 
             var userSelection = viewModel.UserSelection.GetUserSelection();
             Assert.True(userSelection.ProjectType == SplitView);
@@ -100,7 +103,9 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             var settingsTemplate = GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageSettingsCodeBehind);
             var numOfDependencies = settingsTemplate.Dependencies?.Count();
             await AddTemplateAsync(viewModel, settingsTemplate);
@@ -118,7 +123,9 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             var userSelection = viewModel.UserSelection.GetUserSelection();
             Assert.True(userSelection.Pages.Count == 1);
             Assert.True(userSelection.Features.Count == 0);
@@ -140,7 +147,9 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             await AddTemplateAsync(viewModel, GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageBlankCodeBehind));
             var userSelection = viewModel.UserSelection.GetUserSelection();
             Assert.True(userSelection.Pages.Count == 2);
@@ -158,7 +167,9 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             await AddTemplateAsync(viewModel, GetTemplate(viewModel.StepsViewModels[TemplateType.Service].Groups, ServiceWebApi));
             var userSelection = viewModel.UserSelection.GetUserSelection();
             Assert.True(userSelection.Services.Count == 3);
@@ -175,7 +186,10 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+
+            await viewModel.OnTemplatesAvailableAsync();
+
             DeleteTemplate(TemplateType.Page, viewModel.UserSelection, 0);
             var userSelection = viewModel.UserSelection.GetUserSelection();
             viewModel.UnsubscribeEventHandlers();
@@ -190,7 +204,9 @@ namespace Microsoft.UI.Test
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
             viewModel.UserSelection.ResetUserSelection();
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             var settingsTemplate = GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageSettingsCodeBehind);
             var numOfDependencies = settingsTemplate.Dependencies?.Count();
             await AddTemplateAsync(viewModel, settingsTemplate);
@@ -209,7 +225,9 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             var chartTemplate = GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageChartCodeBehind);
             var gridTemplate = GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageGridCodeBehind);
             var numOfDependencies = chartTemplate.Dependencies?.Count();
@@ -239,7 +257,9 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             await AddTemplateAsync(viewModel, GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageBlankCodeBehind));
             await AddTemplateAsync(viewModel, GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageBlankCodeBehind));
             await AddTemplateAsync(viewModel, GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageBlankCodeBehind));
@@ -274,7 +294,9 @@ namespace Microsoft.UI.Test
             // Default configuration: SplitView, CodeBehind, Blank page
             var stylesProviders = new UITestStyleValuesProvider();
             var viewModel = new MainViewModel(null, stylesProviders);
-            await viewModel.InitializeAsync(Platforms.Uwp, GenContext.CurrentLanguage);
+            viewModel.Initialize(Platforms.Uwp, GenContext.CurrentLanguage);
+            await viewModel.OnTemplatesAvailableAsync();
+
             await AddTemplateAsync(viewModel, GetTemplate(viewModel.StepsViewModels[TemplateType.Page].Groups, PageBlankCodeBehind));
             var userSelection = viewModel.UserSelection.GetUserSelection();
             Assert.True(userSelection.Pages[0].Name == "Main");


### PR DESCRIPTION
UI Tests are failing on build machines inconsistently. I could reproduce locally and think the underlying issue is that sync is executed as part of the viewmodel initialization in tests and tests block each other mutually as they use the same template source. 