### PR TITLE
Issue3479 fixtemplatetests

### DIFF
--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -565,8 +565,7 @@ namespace Microsoft.Templates.Test
                     break;
 
                 default:
-                    result = BuildFixture.GetProjectTemplates();
-                    break;
+                    throw new ArgumentOutOfRangeException(nameof(framework));
             }
 
             return result;

--- a/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
+++ b/code/test/Templates.Test/BuildRightClickWithLegacy/BuildRightClickWithLegacyTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Templates.Test
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "LegacyFrameworks")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "LegacyFrameworks", "", Platforms.Uwp)]
         [Trait("ExecutionSet", "ManualOnly")]
         ////This test sets up projects for further manual tests. It generates legacy projects with all pages and features.
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Templates.Test.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMPrism", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildPrismWpf")]
         [Trait("ExecutionSet", "_Full")]
         public async Task Build_AllWithMsix_Wpf(string projectType, string framework, string platform, string language)


### PR DESCRIPTION
Quick summary of changes
- Correct Test setup 
- Remove possibility to get all projecttypes over all platforms and frameworks (there is no test with such a broad configuration)

Which issue does this PR relate to?
- #3479 Build_AllWithMsix_Wp tests fail due to invalid test theory declaration for Prism
