### PR TITLE
Issue101 refactornaming

### DIFF
--- a/code/src/UI/Extensions/ValidationResultExtensions.cs
+++ b/code/src/UI/Extensions/ValidationResultExtensions.cs
@@ -12,23 +12,23 @@ namespace Microsoft.Templates.UI.Extensions
 {
     public static class ValidationResultExtensions
     {
-        public static Notification GetNotification(this ValidationResult validationResult)
+        public static Notification GetNotification(this ValidationError validationError)
         {
-            switch (validationResult.ErrorType)
+            switch (validationError.ErrorType)
             {
                 case ValidationErrorType.EmptyName:
                     return Notification.Error(StringRes.NotificationValidationError_Empty, ErrorCategory.NamingValidation, CategoriesToOverride);
                 case ValidationErrorType.AlreadyExists:
                     return Notification.Error(StringRes.NotificationValidationError_AlreadyExists, ErrorCategory.NamingValidation, CategoriesToOverride);
                 case ValidationErrorType.Regex:
-                    switch (validationResult.ValidatorName)
+                    switch (validationError.ValidatorName)
                     {
                         case "badFormat":
                             return Notification.Error(StringRes.NotificationValidationError_BadFormat, ErrorCategory.NamingValidation, CategoriesToOverride);
                         case "itemEndsWithPage":
                             return Notification.Error(string.Format(StringRes.NotificationValidationError_PageSuffix, Configuration.Current.GitHubDocsUrl), ErrorCategory.NamingValidation, CategoriesToOverride);
                         default:
-                            return Notification.Error(string.Format(StringRes.NotificationValidationError_Regex, validationResult.ValidatorName));
+                            return Notification.Error(string.Format(StringRes.NotificationValidationError_Regex, validationError.ValidatorName));
                     }
 
                 case ValidationErrorType.ReservedName:

--- a/code/src/UI/Launcher/WizardLauncher.cs
+++ b/code/src/UI/Launcher/WizardLauncher.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Templates.UI.Launcher
             else
             {
                 var message = string.Empty;
-                switch (projectNameValidation.ErrorType)
+                switch (projectNameValidation.Errors.FirstOrDefault()?.ErrorType)
                 {
                     case ValidationErrorType.ReservedName:
                         message = string.Format(StringRes.ErrorProjectReservedName, projectName);

--- a/code/src/UI/ViewModels/Common/DataItems/SavedTemplateViewModel.cs
+++ b/code/src/UI/ViewModels/Common/DataItems/SavedTemplateViewModel.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Templates.UI.ViewModels.Common
                 }
                 else
                 {
-                    NotificationsControl.AddNotificationAsync(validationResult.GetNotification()).FireAndForget();
+                   NotificationsControl.AddNotificationAsync(validationResult.Errors.FirstOrDefault()?.GetNotification()).FireAndForget();
                 }
             }
 

--- a/code/src/UI/ViewModels/NewItem/TemplateSelectionViewModel.cs
+++ b/code/src/UI/ViewModels/NewItem/TemplateSelectionViewModel.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
                 }
                 else
                 {
-                    NotificationsControl.AddNotificationAsync(validationResult.GetNotification()).FireAndForget();
+                    NotificationsControl.AddNotificationAsync(validationResult.Errors.FirstOrDefault()?.GetNotification()).FireAndForget();
                 }
             }
 


### PR DESCRIPTION
Quick summary of changes
- Adapt wizard to changes in naming services (naming services return all validation errors now)
As the wizard validates names with each keystroke we decided to keep showing only the first error message.

Which issue does this PR relate to?
- https://github.com/microsoft/CoreTemplateStudio/issues/101 Refactor naming 

