### PR TITLE
Add link to docs for secured web api

### DIFF
--- a/templates/Uwp/_comp/_shared/Services.SecuredWebApi/Param_ProjectName.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/templates/Uwp/_comp/_shared/Services.SecuredWebApi/Param_ProjectName.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     // Read more about Microsoft Identity Platform at https://docs.microsoft.com/azure/active-directory/develop/v2-overview
     // You can find detailed info on protecting Web API's on https://docs.microsoft.com/azure/active-directory/develop/scenario-protected-web-api-overview
+    // For more info about this class and the Secured Web Api Feature configuration steps see https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/services/secured-web-api.md
     public static class ServiceCollectionExtensions
     {
         public static IServiceCollection ProtectWebApiWithJwtBearer(this IServiceCollection services, IConfiguration configuration)


### PR DESCRIPTION
Quick summary of changes
- Add link to docs for secured web api
Which issue does this PR relate to?
- #3603  Docs for secured web api is not linked on template
