### PR TITLE
Remove services from WPF right click options

### DIFF
--- a/code/src/UI/VisualStudio/RightClickActions.cs
+++ b/code/src/UI/VisualStudio/RightClickActions.cs
@@ -139,7 +139,11 @@ namespace Microsoft.Templates.UI.VisualStudio
         public bool Visible(TemplateType templateType)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            return _shell.GetActiveProjectIsWts() && EnsureGenContextInitialized() && GenContext.ToolBox.Repo.GetAll().Any(t => t.GetTemplateType() == templateType);
+            return _shell.GetActiveProjectIsWts() && EnsureGenContextInitialized() &&
+                GenContext.ToolBox.Repo.GetAll().Any(
+                    t => t.GetTemplateType() == templateType &&
+                    t.GetRightClickEnabled() == true &&
+                    t.GetIsHidden() == false);
         }
 
         public bool Visible()


### PR DESCRIPTION
Quick summary of changes
- Exclude hidden templates and templates that are not available for right click when evaluating visibility for right click options

Which issue does this PR relate to?
- #3691 Dev-nightly: WPF projects should not show Add Services option
