### PR TITLE
Update test templates to .NET Core 3.1

### DIFF
--- a/code/test/Templates.Test/BaseGenAndBuildFixture.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildFixture.cs
@@ -253,9 +253,9 @@ namespace Microsoft.Templates.Test
             const string batFile = "bat\\Uwp\\RunTests.bat";
 
             // Just run the tests against code in the core library. Can't run UI related/dependent code from the cmd line / on the server
-            var mstestPath = $"\"{outputPath}\\{projectName}.Core.Tests.MSTest\\bin\\Debug\\netcoreapp2.1\\{projectName}.Core.Tests.MSTest.dll\" ";
-            var nunitPath = $"\"{outputPath}\\{projectName}.Core.Tests.NUnit\\bin\\Debug\\netcoreapp2.1\\{projectName}.Core.Tests.NUnit.dll\" ";
-            var xunitPath = $"\"{outputPath}\\{projectName}.Core.Tests.xUnit\\bin\\Debug\\netcoreapp2.1\\{projectName}.Core.Tests.xUnit.dll\" ";
+            var mstestPath = $"\"{outputPath}\\{projectName}.Core.Tests.MSTest\\bin\\Debug\\netcoreapp3.1\\{projectName}.Core.Tests.MSTest.dll\" ";
+            var nunitPath = $"\"{outputPath}\\{projectName}.Core.Tests.NUnit\\bin\\Debug\\netcoreapp3.1\\{projectName}.Core.Tests.NUnit.dll\" ";
+            var xunitPath = $"\"{outputPath}\\{projectName}.Core.Tests.xUnit\\bin\\Debug\\netcoreapp3.1\\{projectName}.Core.Tests.xUnit.dll\" ";
 
             var batPath = Path.GetDirectoryName(GetPath(batFile));
 

--- a/templates/Uwp/SC/_comp/T.SC.C.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest_searchreplace.vbproj
+++ b/templates/Uwp/SC/_comp/T.SC.C.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest_searchreplace.vbproj
@@ -1,6 +1,6 @@
-﻿    <TargetFramework>netcoreapp2.1</TargetFramework>
+﻿    <TargetFramework>netcoreapp3.1</TargetFramework>
 ^^^-searchabove-replacebelow-vvv
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>VBSAC002</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>WTSVBRules.ruleset</CodeAnalysisRuleSet>

--- a/templates/Uwp/SC/_comp/T.SC.C.MSTest/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest_searchreplace.csproj
+++ b/templates/Uwp/SC/_comp/T.SC.C.MSTest/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest_searchreplace.csproj
@@ -1,4 +1,4 @@
-﻿    <TargetFramework>netcoreapp2.1</TargetFramework>
+﻿    <TargetFramework>netcoreapp3.1</TargetFramework>
 ^^^-searchabove-replacebelow-vvv
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/templates/Uwp/SC/_comp/T.SC.C.NUnit._VB/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit_searchreplace.vbproj
+++ b/templates/Uwp/SC/_comp/T.SC.C.NUnit._VB/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit_searchreplace.vbproj
@@ -1,6 +1,6 @@
-﻿    <TargetFramework>netcoreapp2.1</TargetFramework>
+﻿    <TargetFramework>netcoreapp3.1</TargetFramework>
 ^^^-searchabove-replacebelow-vvv
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>VBSAC002</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>WTSVBRules.ruleset</CodeAnalysisRuleSet>

--- a/templates/Uwp/SC/_comp/T.SC.C.NUnit/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit_searchreplace.csproj
+++ b/templates/Uwp/SC/_comp/T.SC.C.NUnit/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit_searchreplace.csproj
@@ -1,4 +1,4 @@
-﻿    <TargetFramework>netcoreapp2.1</TargetFramework>
+﻿    <TargetFramework>netcoreapp3.1</TargetFramework>
 ^^^-searchabove-replacebelow-vvv
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/templates/Uwp/SC/_comp/T.SC.C.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit_searchreplace.vbproj
+++ b/templates/Uwp/SC/_comp/T.SC.C.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit_searchreplace.vbproj
@@ -1,6 +1,6 @@
-﻿    <TargetFramework>netcoreapp2.1</TargetFramework>
+﻿    <TargetFramework>netcoreapp3.1</TargetFramework>
 ^^^-searchabove-replacebelow-vvv
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>VBSAC002</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>WTSVBRules.ruleset</CodeAnalysisRuleSet>

--- a/templates/Uwp/SC/_comp/T.SC.C.xUnit/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit_searchreplace.csproj
+++ b/templates/Uwp/SC/_comp/T.SC.C.xUnit/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit_searchreplace.csproj
@@ -1,4 +1,4 @@
-﻿    <TargetFramework>netcoreapp2.1</TargetFramework>
+﻿    <TargetFramework>netcoreapp3.1</TargetFramework>
 ^^^-searchabove-replacebelow-vvv
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/templates/Uwp/Testing/UnitTests.Core.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest.vbproj
+++ b/templates/Uwp/Testing/UnitTests.Core.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <RootNamespace>Param_RootNamespace.Core.Tests.MSTest</RootNamespace>

--- a/templates/Uwp/Testing/UnitTests.Core.MSTest/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest.csproj
+++ b/templates/Uwp/Testing/UnitTests.Core.MSTest/Param_ProjectName.Core.Tests.MSTest/Param_ProjectName.Core.Tests.MSTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <RootNamespace>Param_RootNamespace.Core.Tests.MSTest</RootNamespace>

--- a/templates/Uwp/Testing/UnitTests.Core.NUnit._VB/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit.vbproj
+++ b/templates/Uwp/Testing/UnitTests.Core.NUnit._VB/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <RootNamespace>Param_RootNamespace.Core.Tests.NUnit</RootNamespace>

--- a/templates/Uwp/Testing/UnitTests.Core.NUnit/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit.csproj
+++ b/templates/Uwp/Testing/UnitTests.Core.NUnit/Param_ProjectName.Core.Tests.NUnit/Param_ProjectName.Core.Tests.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <RootNamespace>Param_RootNamespace.Core.Tests.NUnit</RootNamespace>

--- a/templates/Uwp/Testing/UnitTests.Core.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit.vbproj
+++ b/templates/Uwp/Testing/UnitTests.Core.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <RootNamespace>Param_RootNamespace.Core.Tests.xUnit</RootNamespace>

--- a/templates/Uwp/Testing/UnitTests.Core.xUnit/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit.csproj
+++ b/templates/Uwp/Testing/UnitTests.Core.xUnit/Param_ProjectName.Core.Tests.xUnit/Param_ProjectName.Core.Tests.xUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <RootNamespace>Param_RootNamespace.Core.Tests.xUnit</RootNamespace>

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Chart.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Chart.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -12,7 +12,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsChartDataAsync()
+        public async Task EnsureSampleDataServiceReturnsChartDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetChartDataAsync();

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Chart.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Chart.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -12,7 +12,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsChartDataAsync()
+        public async Task EnsureSampleDataServiceReturnsChartDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetChartDataAsync();

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ContentGrid.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ContentGrid.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsContentGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsContentGridDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetContentGridDataAsync();

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ContentGrid.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ContentGrid.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsContentGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsContentGridDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetContentGridDataAsync();

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Grids.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Grids.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsGridDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetGridDataAsync();

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Grids.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.Grids.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsGridDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetGridDataAsync();

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ImageGallery.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ImageGallery.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -12,7 +12,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsImageGalleryDataAsync()
+        public async Task EnsureSampleDataServiceReturnsImageGalleryDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetImageGalleryDataAsync("ms-appx:///Assets");

--- a/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ImageGallery.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Test.UnitTests.Core.SampleData.ImageGallery.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -12,7 +12,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsImageGalleryDataAsync()
+        public async Task EnsureSampleDataServiceReturnsImageGalleryDataAsync()
         {
             var dataService = new SampleDataService();
             var actual = await dataService.GetImageGalleryDataAsync("ms-appx:///Assets");

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <TestMethod>
-    Public Async Sub EnsureSampleDataServiceReturnsChartDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsChartDataAsync() As Task
         Dim actual = Await SampleDataService.GetChartDataAsync()
 
         Assert.AreNotEqual(0, actual.Count)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -12,7 +12,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsChartDataAsync()
+        public async Task EnsureSampleDataServiceReturnsChartDataAsync()
         {
             var actual = await SampleDataService.GetChartDataAsync();
 

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <Fact>
-    Public Async Sub EnsureSampleDataServiceReturnsChartDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsChartDataAsync() As Task
         Dim actual = Await SampleDataService.GetChartDataAsync()
 
         Assert.NotEmpty(actual)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Chart.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -12,7 +12,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsChartDataAsync()
+        public async Task EnsureSampleDataServiceReturnsChartDataAsync()
         {
             var actual = await SampleDataService.GetChartDataAsync();
 

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <TestMethod>
-    Public Async Sub EnsureSampleDataServiceReturnsContentGridDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsContentGridDataAsync() As Task
         Dim actual = Await SampleDataService.GetContentGridDataAsync()
 
         Assert.AreNotEqual(0, actual.Count)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsContentGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsContentGridDataAsync()
         {
             var actual = await SampleDataService.GetContentGridDataAsync();
 

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <Fact>
-    Public Async Sub EnsureSampleDataServiceReturnsContentGridDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsContentGridDataAsync() As Task
         Dim actual = Await SampleDataService.GetContentGridDataAsync()
 
         Assert.NotEmpty(actual)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ContentGrid.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsContentGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsContentGridDataAsync()
         {
             var actual = await SampleDataService.GetContentGridDataAsync();
 

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <TestMethod>
-    Public Async Sub EnsureSampleDataServiceReturnsGridDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsGridDataAsync() As Task
         Dim actual = Await SampleDataService.GetGridDataAsync()
 
         Assert.AreNotEqual(0, actual.Count)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsGridDataAsync()
         {
             var actual = await SampleDataService.GetGridDataAsync();
 

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <Fact>
-    Public Async Sub EnsureSampleDataServiceReturnsGridDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsGridDataAsync() As Task
         Dim actual = Await SampleDataService.GetGridDataAsync()
 
         Assert.NotEmpty(actual)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.Grids.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsGridDataAsync()
+        public async Task EnsureSampleDataServiceReturnsGridDataAsync()
         {
             var actual = await SampleDataService.GetGridDataAsync();
 

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ImageGallery.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ImageGallery.MSTest._VB/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <TestMethod>
-    Public Async Sub EnsureSampleDataServiceReturnsImageGalleryDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsImageGalleryDataAsync() As Task
         Dim actual = Await SampleDataService.GetImageGalleryDataAsync("ms-appx:///Assets")
 
         Assert.AreNotEqual(0, actual.Count)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ImageGallery.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.ImageGallery.xUnit._VB/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.vb
@@ -9,10 +9,10 @@ Public Class Tests
     ' TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
     ' This test serves only as a demonstration of testing functionality in the Core library.
     <Fact>
-    Public Async Sub EnsureSampleDataServiceReturnsImageGalleryDataAsync()
+    Public Async Function EnsureSampleDataServiceReturnsImageGalleryDataAsync() As Task
         Dim actual = Await SampleDataService.GetImageGalleryDataAsync("ms-appx:///Assets")
 
         Assert.NotEmpty(actual)
-    End Sub
+    End Function
     '}]}
 End Class

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.TreeView.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.TreeView.MSTest/Param_ProjectName.Core.Tests.MSTest/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.MSTest
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [TestMethod]
-        public async void EnsureSampleDataServiceReturnsTreeViewDataAsync()
+        public async Task EnsureSampleDataServiceReturnsTreeViewDataAsync()
         {
             var actual = await SampleDataService.GetTreeViewDataAsync();
 

--- a/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.TreeView.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
+++ b/templates/Uwp/_comp/_shared/Test.UnitTests.Core.SampleData.TreeView.xUnit/Param_ProjectName.Core.Tests.xUnit/Tests_postaction.cs
@@ -13,7 +13,7 @@ namespace Param_RootNamespace.Core.Tests.XUnit
         // TODO WTS: Remove or update this once your app is using real data and not the SampleDataService.
         // This test serves only as a demonstration of testing functionality in the Core library.
         [Fact]
-        public async void EnsureSampleDataServiceReturnsTreeViewDataAsync()
+        public async Task EnsureSampleDataServiceReturnsTreeViewDataAsync()
         {
             var actual = await SampleDataService.GetTreeViewDataAsync();
 


### PR DESCRIPTION
Quick summary of changes
- Update test templates to .NET Core 3.1

Which issue does this PR relate to?
#3703 Update UnitTest projects to use .NET Core 3.1
