### PR TITLE
Remove AnyCPU from packaging project and WPF project

### DIFF
--- a/templates/Wpf/Features/MSIXPackaging/Param_ProjectName.Packaging/Param_ProjectName.Packaging.wapproj
+++ b/templates/Wpf/Features/MSIXPackaging/Param_ProjectName.Packaging/Param_ProjectName.Packaging.wapproj
@@ -37,14 +37,6 @@
       <Configuration>Release</Configuration>
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|AnyCPU">
-      <Configuration>Debug</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|AnyCPU">
-      <Configuration>Release</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup>
     <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>

--- a/templates/Wpf/Features/MSIXPackaging/Param_ProjectName/Param_ProjectName_postaction.csproj
+++ b/templates/Wpf/Features/MSIXPackaging/Param_ProjectName/Param_ProjectName_postaction.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>Param_RootNamespace</RootNamespace>
     <UseWPF>true</UseWPF>
 <!--{[{-->
-    <Platforms>AnyCPU;x64;x86</Platforms>
+    <Platforms>x64;x86</Platforms>
 <!--}]}-->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Quick summary of changes
- Remove AnyCPU from packaging project and WPF project

Which issue does this PR relate to?
- #3741 Dev-nightly: Msix template should not add AnyCPU configuration to the WPF project