### PR TITLE
Add multiple instances of every multiinstance template to StyleCop tests

### DIFF
--- a/code/test/Templates.Test/BaseGenAndBuildFixture.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildFixture.cs
@@ -60,11 +60,16 @@ namespace Microsoft.Templates.Test
             return userSelection;
         }
 
-        public void AddItems(UserSelection userSelection, IEnumerable<TemplateInfo> templates, Func<TemplateInfo, string> getName)
+        public void AddItems(UserSelection userSelection, IEnumerable<TemplateInfo> templates, Func<TemplateInfo, string> getName, bool includeMultipleInstances = false)
         {
             foreach (var template in templates)
             {
                 AddItem(userSelection, template, getName);
+                // Add multiple pages if supported to check these are handled the same
+                if (includeMultipleInstances && template.MultipleInstance)
+                {
+                    AddItem(userSelection, template, getName);
+                }
             }
         }
 

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Templates.Test
         protected const string All = "all";
 
         protected List<string> excludedTemplates_Uwp_Group1 = new List<string>() { "wts.Service.IdentityOptionalLogin", "wts.Feat.MultiInstanceAdvanced", "wts.Feat.MultiInstance" };
-        protected List<string> excludedTemplates_Uwp_Group2 = new List<string>() { "wts.Service.IdentityForcedLogin", "wts.Feat.BackgroundTask" };
+        protected List<string> excludedTemplates_Uwp_Group2 = new List<string>() { "wts.Service.IdentityForcedLogin", "wts.Feat.BackgroundTask" }; // Add multiinstance templates on this group if possible
         protected List<string> excludedTemplates_Wpf_Group1 = new List<string>() { "wts.Wpf.Service.IdentityOptionalLogin" };
-        protected List<string> excludedTemplates_Wpf_Group2 = new List<string>() { "wts.Wpf.Service.IdentityForcedLogin" };
+        protected List<string> excludedTemplates_Wpf_Group2 = new List<string>() { "wts.Wpf.Service.IdentityForcedLogin" }; // Add multiinstance templates on this group if possible
         protected List<string> excludedTemplatesGroup1VB = new List<string>() { "wts.Service.IdentityOptionalLogin.VB", "wts.Feat.MultiInstanceAdvanced.VB", "wts.Feat.MultiInstance.VB" };
-        protected List<string> excludedTemplatesGroup2VB = new List<string>() { "wts.Service.IdentityForcedLogin.VB", "wts.Feat.BackgroundTask.VB" };
+        protected List<string> excludedTemplatesGroup2VB = new List<string>() { "wts.Service.IdentityForcedLogin.VB", "wts.Feat.BackgroundTask.VB" }; // Add multiinstance templates on this group if possible
 
         public BaseGenAndBuildTests(BaseGenAndBuildFixture fixture, IContextProvider contextProvider = null, string framework = "")
         {
@@ -121,7 +121,7 @@ namespace Microsoft.Templates.Test
             return (projectName, projectPath);
         }
 
-        protected async Task<string> AssertGenerateProjectAsync(string projectName, string projectType, string framework, string platform, string language, Func<ITemplateInfo, bool> itemTemplatesSelector = null, Func<TemplateInfo, string> getName = null)
+        protected async Task<string> AssertGenerateProjectAsync(string projectName, string projectType, string framework, string platform, string language, Func<ITemplateInfo, bool> itemTemplatesSelector = null, Func<TemplateInfo, string> getName = null, bool includeMultipleInstances = false)
         {
             BaseGenAndBuildFixture.SetCurrentLanguage(language);
             BaseGenAndBuildFixture.SetCurrentPlatform(platform);
@@ -141,7 +141,7 @@ namespace Microsoft.Templates.Test
             {
                 var itemTemplates = _fixture.Templates().Where(itemTemplatesSelector);
                 var itemsTemplateInfo = GenContext.ToolBox.Repo.GetTemplatesInfo(itemTemplates, platform, projectType, framework, _emptyBackendFramework);
-                _fixture.AddItems(userSelection, itemsTemplateInfo, getName);
+                _fixture.AddItems(userSelection, itemsTemplateInfo, getName, includeMultipleInstances);
             }
 
             await NewProjectGenController.Instance.UnsafeGenerateProjectAsync(userSelection);

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCaliburnMicroProjectTests.cs
@@ -96,9 +96,9 @@ namespace Microsoft.Templates.Test.Build.Uwp
                 && !excludedTemplates_Uwp_Group2.Contains(t.GroupIdentity))
                 || t.Identity == "wts.Feat.StyleCop";
 
-            var projectName = $"{ShortProjectType(projectType)}{ShortProjectType(framework)}AllStyleCopG2";
+            var projectName = $"{ShortProjectType(projectType)}{ShortProjectType(framework)}AllStyleCopG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }
@@ -122,7 +122,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{ShortProjectType(projectType)}{ShortProjectType(framework)}AllStyleCopG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCodeBehindProjectTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }
@@ -124,7 +124,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMBasicProjectTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }
@@ -123,7 +123,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMLightProjectTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }
@@ -124,7 +124,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildPrismProjectTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }
@@ -122,7 +122,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             var projectName = $"{projectType}{framework}AllStyleCopG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMBasicProjectTests.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Templates.Test.Build.Wpf
                 && t.Identity != "wts.Wpf.Feat.MSIXPackaging"
                 || t.Identity == "wts.Wpf.Feat.StyleCop";
 
-            var projectName = $"{projectType}{framework}All";
+            var projectName = $"{projectType}{framework}AllG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProject(projectPath, projectName, platform);
         }
@@ -120,9 +120,9 @@ namespace Microsoft.Templates.Test.Build.Wpf
                 && t.Identity != "wts.Wpf.Feat.MSIXPackaging"
                 || t.Identity == "wts.Wpf.Feat.StyleCop";
 
-            var projectName = $"{projectType}{framework}All";
+            var projectName = $"{projectType}{framework}AllG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProject(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMLightProjectTests.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Templates.Test.Build.Wpf
                 && t.Identity != "wts.Wpf.Feat.MSIXPackaging"
                 || t.Identity == "wts.Wpf.Feat.StyleCop";
 
-            var projectName = $"{projectType}{framework}All";
+            var projectName = $"{projectType}{framework}AllG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProject(projectPath, projectName, platform);
         }
@@ -120,9 +120,9 @@ namespace Microsoft.Templates.Test.Build.Wpf
                 && t.Identity != "wts.Wpf.Feat.MSIXPackaging"
                 || t.Identity == "wts.Wpf.Feat.StyleCop";
 
-            var projectName = $"{projectType}{framework}All";
+            var projectName = $"{projectType}{framework}AllG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProject(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Templates.Test.Build.Wpf
                 && t.Identity != "wts.Wpf.Feat.MSIXPackaging"
                 || t.Identity == "wts.Wpf.Feat.StyleCop";
 
-            var projectName = $"{projectType}{framework}All";
+            var projectName = $"{projectType}{framework}AllG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProject(projectPath, projectName, platform);
         }
@@ -120,9 +120,9 @@ namespace Microsoft.Templates.Test.Build.Wpf
                 && t.Identity != "wts.Wpf.Feat.MSIXPackaging"
                 || t.Identity == "wts.Wpf.Feat.StyleCop";
 
-            var projectName = $"{projectType}{framework}All";
+            var projectName = $"{projectType}{framework}AllG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, language, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProject(projectPath, projectName, platform);
         }

--- a/code/test/Templates.Test/VBCodeAnalysis/VBStyleProjectGenerationTests.cs
+++ b/code/test/Templates.Test/VBCodeAnalysis/VBStyleProjectGenerationTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{projectType}{framework}AllVBStyleG1";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName, false);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }
@@ -57,7 +57,7 @@ namespace Microsoft.Templates.Test
 
             var projectName = $"{projectType}{framework}AllVBStyleG2";
 
-            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName);
+            var projectPath = await AssertGenerateProjectAsync(projectName, projectType, framework, platform, ProgrammingLanguages.VisualBasic, templateSelector, BaseGenAndBuildFixture.GetDefaultName, true);
 
             AssertBuildProjectThenRunTests(projectPath, projectName, platform);
         }


### PR DESCRIPTION
Quick summary of changes
- Add multiple instances of every multiinstance template to StyleCop G2 tests

Which issue does this PR relate to?
#3742 Add two instances of each template that is multiInstance to stylecop tests
