### PR TITLE
Put the SampleDataService Symbol comments against the correct properties

### DIFF
--- a/templates/Uwp/Services/SampleData.Prism/Param_ProjectName.Core/Services/SampleDataService.cs
+++ b/templates/Uwp/Services/SampleData.Prism/Param_ProjectName.Core/Services/SampleDataService.cs
@@ -37,7 +37,7 @@ namespace Param_RootNamespace.Core.Services
                     {
                         new SampleOrder()
                         {
-                            OrderID = 10643, // Symbol Globe
+                            OrderID = 10643,
                             OrderDate = new DateTime(1997, 8, 25),
                             RequiredDate = new DateTime(1997, 9, 22),
                             ShippedDate = new DateTime(1997, 9, 22),
@@ -48,7 +48,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             OrderTotal = 814.50,
                             Status = "Shipped",
-                            SymbolCode = 57643,
+                            SymbolCode = 57643, // Symbol Globe
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -91,7 +91,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10835, // Symbol Music
+                            OrderID = 10835,
                             OrderDate = new DateTime(1998, 1, 15),
                             RequiredDate = new DateTime(1998, 2, 12),
                             ShippedDate = new DateTime(1998, 1, 21),
@@ -102,7 +102,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             OrderTotal = 845.80,
                             Status = "Closed",
-                            SymbolCode = 57737,
+                            SymbolCode = 57737, // Symbol Audio
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -133,7 +133,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10952, // Symbol Calendar
+                            OrderID = 10952,
                             OrderDate = new DateTime(1998, 3, 16),
                             RequiredDate = new DateTime(1998, 4, 27),
                             ShippedDate = new DateTime(1998, 3, 24),
@@ -144,7 +144,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             OrderTotal = 471.20,
                             Status = "Closed",
-                            SymbolCode = 57699,
+                            SymbolCode = 57699, // Symbol Calendar
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -191,7 +191,7 @@ namespace Param_RootNamespace.Core.Services
                     {
                         new SampleOrder()
                         {
-                            OrderID = 10625, // Symbol Camera
+                            OrderID = 10625,
                             OrderDate = new DateTime(1997, 8, 8),
                             RequiredDate = new DateTime(1997, 9, 5),
                             ShippedDate = new DateTime(1997, 8, 14),
@@ -202,7 +202,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company F, Avda. de la Constitución 2222, 05021, México D.F., Mexico",
                             OrderTotal = 469.75,
                             Status = "Shipped",
-                            SymbolCode = 57620,
+                            SymbolCode = 57620, // Symbol Camera
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -245,7 +245,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10926, // Symbol Clock
+                            OrderID = 10926,
                             OrderDate = new DateTime(1998, 3, 4),
                             RequiredDate = new DateTime(1998, 4, 1),
                             ShippedDate = new DateTime(1998, 3, 11),
@@ -256,7 +256,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company F, Avda. de la Constitución 2222, 05021, México D.F., Mexico",
                             OrderTotal = 507.20,
                             Status = "Shipped",
-                            SymbolCode = 57633,
+                            SymbolCode = 57633, // Symbol Clock
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -327,7 +327,7 @@ namespace Param_RootNamespace.Core.Services
                     {
                         new SampleOrder()
                         {
-                            OrderID = 10507, // Symbol Contact
+                            OrderID = 10507,
                             OrderDate = new DateTime(1997, 4, 15),
                             RequiredDate = new DateTime(1997, 5, 13),
                             ShippedDate = new DateTime(1997, 4, 22),
@@ -338,7 +338,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             OrderTotal = 978.50,
                             Status = "Closed",
-                            SymbolCode = 57661,
+                            SymbolCode = 57661, // Symbol Contact
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -369,7 +369,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10573, // Symbol Star
+                            OrderID = 10573,
                             OrderDate = new DateTime(1997, 6, 19),
                             RequiredDate = new DateTime(1997, 7, 17),
                             ShippedDate = new DateTime(1997, 6, 20),
@@ -380,7 +380,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             OrderTotal = 2082.00,
                             Status = "Closed",
-                            SymbolCode = 57619,
+                            SymbolCode = 57619, // Symbol Star
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -423,7 +423,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10682, // Symbol Home
+                            OrderID = 10682,
                             OrderDate = new DateTime(1997, 9, 25),
                             RequiredDate = new DateTime(1997, 10, 23),
                             ShippedDate = new DateTime(1997, 10, 1),
@@ -434,7 +434,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             OrderTotal = 375.50,
                             Status = "Closed",
-                            SymbolCode = 57615,
+                            SymbolCode = 57615, // Symbol Home
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()

--- a/templates/Uwp/Services/SampleData._VB/Param_ProjectName.Core/Services/SampleDataService.vb
+++ b/templates/Uwp/Services/SampleData._VB/Param_ProjectName.Core/Services/SampleDataService.vb
@@ -26,7 +26,7 @@ Namespace Services
                     .Fax = "030-0076545",
                     .Orders = New List(Of SampleOrder)() From {
                         New SampleOrder() With {
-                            .OrderID = 10643, ' Symbol-Globe
+                            .OrderID = 10643,
                             .OrderDate = New DateTime(1997, 8, 25),
                             .RequiredDate = New DateTime(1997, 9, 22),
                             .ShippedDate = New DateTime(1997, 9, 22),
@@ -37,7 +37,7 @@ Namespace Services
                             .ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             .OrderTotal = 814.5,
                             .Status = "Shipped",
-                            .SymbolCode = 57643,
+                            .SymbolCode = 57643, ' Symbol-Globe
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 28,
@@ -75,7 +75,7 @@ Namespace Services
                             }
                         },
                         New SampleOrder() With {
-                            .OrderID = 10835, ' Symbol-Music
+                            .OrderID = 10835,
                             .OrderDate = New DateTime(1998, 1, 15),
                             .RequiredDate = New DateTime(1998, 2, 12),
                             .ShippedDate = New DateTime(1998, 1, 21),
@@ -86,7 +86,7 @@ Namespace Services
                             .ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             .OrderTotal = 845.8,
                             .Status = "Closed",
-                            .SymbolCode = 57737,
+                            .SymbolCode = 57737, ' Symbol-Audio
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 59,
@@ -113,7 +113,7 @@ Namespace Services
                             }
                         },
                         New SampleOrder() With {
-                            .OrderID = 10952, ' Symbol-Calendar
+                            .OrderID = 10952,
                             .OrderDate = New DateTime(1998, 3, 16),
                             .RequiredDate = New DateTime(1998, 4, 27),
                             .ShippedDate = New DateTime(1998, 3, 24),
@@ -124,7 +124,7 @@ Namespace Services
                             .ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             .OrderTotal = 471.2,
                             .Status = "Closed",
-                            .SymbolCode = 57699,
+                            .SymbolCode = 57699, ' Symbol-Calendar
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 6,
@@ -165,7 +165,7 @@ Namespace Services
                     .Fax = "(5) 555-3745",
                     .Orders = New List(Of SampleOrder)() From {
                         New SampleOrder() With {
-                            .OrderID = 10625, ' Symbol-Camera
+                            .OrderID = 10625,
                             .OrderDate = New DateTime(1997, 8, 8),
                             .RequiredDate = New DateTime(1997, 9, 5),
                             .ShippedDate = New DateTime(1997, 8, 14),
@@ -176,7 +176,7 @@ Namespace Services
                             .ShipTo = "Company F, Avda. de la Constitución 2222, 05021, México D.F., Mexico",
                             .OrderTotal = 469.75,
                             .Status = "Shipped",
-                            .SymbolCode = 57620,
+                            .SymbolCode = 57620, ' Symbol-Camera
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 14,
@@ -214,7 +214,7 @@ Namespace Services
                             }
                         },
                         New SampleOrder() With {
-                            .OrderID = 10926, ' Symbol-Clock
+                            .OrderID = 10926,
                             .OrderDate = New DateTime(1998, 3, 4),
                             .RequiredDate = New DateTime(1998, 4, 1),
                             .ShippedDate = New DateTime(1998, 3, 11),
@@ -225,7 +225,7 @@ Namespace Services
                             .ShipTo = "Company F, Avda. de la Constitución 2222, 05021, México D.F., Mexico",
                             .OrderTotal = 507.2,
                             .Status = "Shipped",
-                            .SymbolCode = 57633,
+                            .SymbolCode = 57633, ' Symbol-Clock
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 11,
@@ -288,7 +288,7 @@ Namespace Services
                     .Fax = String.Empty,
                     .Orders = New List(Of SampleOrder)() From {
                         New SampleOrder() With {
-                            .OrderID = 10507, ' Symbol-Contact
+                            .OrderID = 10507,
                             .OrderDate = New DateTime(1997, 4, 15),
                             .RequiredDate = New DateTime(1997, 5, 13),
                             .ShippedDate = New DateTime(1997, 4, 22),
@@ -299,7 +299,7 @@ Namespace Services
                             .ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             .OrderTotal = 978.5,
                             .Status = "Closed",
-                            .SymbolCode = 57661,
+                            .SymbolCode = 57661, ' Symbol-Contact
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 43,
@@ -326,7 +326,7 @@ Namespace Services
                             }
                         },
                         New SampleOrder() With {
-                            .OrderID = 10573, ' Symbol-Star
+                            .OrderID = 10573,
                             .OrderDate = new DateTime(1997, 6, 19),
                             .RequiredDate = new DateTime(1997, 7, 17),
                             .ShippedDate = new DateTime(1997, 6, 20),
@@ -337,7 +337,7 @@ Namespace Services
                             .ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             .OrderTotal = 2082.00,
                             .Status = "Closed",
-                            .SymbolCode = 57619,
+                            .SymbolCode = 57619, ' Symbol-Star
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 17,
@@ -375,7 +375,7 @@ Namespace Services
                             }
                         },
                         New SampleOrder() With {
-                            .OrderID = 10682, ' Symbol-Home
+                            .OrderID = 10682,
                             .OrderDate = New DateTime(1997, 9, 25),
                             .RequiredDate = New DateTime(1997, 10, 23),
                             .ShippedDate = New DateTime(1997, 10, 1),
@@ -386,7 +386,7 @@ Namespace Services
                             .ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             .OrderTotal = 375.5,
                             .Status = "Closed",
-                            .SymbolCode = 57615,
+                            .SymbolCode = 57615, ' Symbol-Home
                             .Details = New List(Of SampleOrderDetail)() From {
                                 New SampleOrderDetail() With {
                                     .ProductID = 33,

--- a/templates/Uwp/Services/SampleData/Param_ProjectName.Core/Services/SampleDataService.cs
+++ b/templates/Uwp/Services/SampleData/Param_ProjectName.Core/Services/SampleDataService.cs
@@ -37,7 +37,7 @@ namespace Param_RootNamespace.Core.Services
                     {
                         new SampleOrder()
                         {
-                            OrderID = 10643, // Symbol Globe
+                            OrderID = 10643,
                             OrderDate = new DateTime(1997, 8, 25),
                             RequiredDate = new DateTime(1997, 9, 22),
                             ShippedDate = new DateTime(1997, 9, 22),
@@ -48,7 +48,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             OrderTotal = 814.50,
                             Status = "Shipped",
-                            SymbolCode = 57643,
+                            SymbolCode = 57643, // Symbol Globe
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -91,7 +91,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10835, // Symbol Music
+                            OrderID = 10835,
                             OrderDate = new DateTime(1998, 1, 15),
                             RequiredDate = new DateTime(1998, 2, 12),
                             ShippedDate = new DateTime(1998, 1, 21),
@@ -102,7 +102,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             OrderTotal = 845.80,
                             Status = "Closed",
-                            SymbolCode = 57737,
+                            SymbolCode = 57737, // Symbol Audio
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -133,7 +133,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10952, // Symbol Calendar
+                            OrderID = 10952,
                             OrderDate = new DateTime(1998, 3, 16),
                             RequiredDate = new DateTime(1998, 4, 27),
                             ShippedDate = new DateTime(1998, 3, 24),
@@ -144,7 +144,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company A, Obere Str. 57, Berlin, 12209, Germany",
                             OrderTotal = 471.20,
                             Status = "Closed",
-                            SymbolCode = 57699,
+                            SymbolCode = 57699, // Symbol Calendar
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -191,7 +191,7 @@ namespace Param_RootNamespace.Core.Services
                     {
                         new SampleOrder()
                         {
-                            OrderID = 10625, // Symbol Camera
+                            OrderID = 10625,
                             OrderDate = new DateTime(1997, 8, 8),
                             RequiredDate = new DateTime(1997, 9, 5),
                             ShippedDate = new DateTime(1997, 8, 14),
@@ -202,7 +202,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company F, Avda. de la Constitución 2222, 05021, México D.F., Mexico",
                             OrderTotal = 469.75,
                             Status = "Shipped",
-                            SymbolCode = 57620,
+                            SymbolCode = 57620, // Symbol Camera
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -245,7 +245,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10926, // Symbol Clock
+                            OrderID = 10926,
                             OrderDate = new DateTime(1998, 3, 4),
                             RequiredDate = new DateTime(1998, 4, 1),
                             ShippedDate = new DateTime(1998, 3, 11),
@@ -256,7 +256,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company F, Avda. de la Constitución 2222, 05021, México D.F., Mexico",
                             OrderTotal = 507.20,
                             Status = "Shipped",
-                            SymbolCode = 57633,
+                            SymbolCode = 57633, // Symbol Clock
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -327,7 +327,7 @@ namespace Param_RootNamespace.Core.Services
                     {
                         new SampleOrder()
                         {
-                            OrderID = 10507, // Symbol Contact
+                            OrderID = 10507,
                             OrderDate = new DateTime(1997, 4, 15),
                             RequiredDate = new DateTime(1997, 5, 13),
                             ShippedDate = new DateTime(1997, 4, 22),
@@ -338,7 +338,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             OrderTotal = 978.50,
                             Status = "Closed",
-                            SymbolCode = 57661,
+                            SymbolCode = 57661, // Symbol Contact
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -369,7 +369,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10573, // Symbol Star
+                            OrderID = 10573,
                             OrderDate = new DateTime(1997, 6, 19),
                             RequiredDate = new DateTime(1997, 7, 17),
                             ShippedDate = new DateTime(1997, 6, 20),
@@ -380,7 +380,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             OrderTotal = 2082.00,
                             Status = "Closed",
-                            SymbolCode = 57619,
+                            SymbolCode = 57619, // Symbol Star
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()
@@ -423,7 +423,7 @@ namespace Param_RootNamespace.Core.Services
                         },
                         new SampleOrder()
                         {
-                            OrderID = 10682, // Symbol Home
+                            OrderID = 10682,
                             OrderDate = new DateTime(1997, 9, 25),
                             RequiredDate = new DateTime(1997, 10, 23),
                             ShippedDate = new DateTime(1997, 10, 1),
@@ -434,7 +434,7 @@ namespace Param_RootNamespace.Core.Services
                             ShipTo = "Company Z, Mataderos  2312, 05023, México D.F., Mexico",
                             OrderTotal = 375.50,
                             Status = "Closed",
-                            SymbolCode = 57615,
+                            SymbolCode = 57615, // Symbol Home
                             Details = new List<SampleOrderDetail>()
                             {
                                 new SampleOrderDetail()


### PR DESCRIPTION
# PR checklist

Quick summary of changes

Fix inline comments being against the wrong properties in the `SampleDataService`

- Which issue does this PR relate to? #3787 
- Anything that requires particular review or attention? - nope, it's trivial
- Do all automated tests pass? yes
- Have automated tests been added for new features? n/a
- If you've changed the UI:
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).
- If you've included a new template: 
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/WindowsTemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/WPF/getting-started-endusers.md) getting started doc.
- Have you raised issues for any needed follow-on work? n/a
- Have docs been updated? n/a
- If breaking changes or different ways of doing things have been introduced, have they been communicated widely?
