### PR TITLE
Remove magic strings from test code

### DIFF
--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -65,15 +65,11 @@ namespace Microsoft.Templates.Test
                     return "B";
                 case ProjectTypes.SplitView:
                     return "SV";
-                case "SplitViewWpf":
-                    return "SVWpf";
                 case ProjectTypes.TabbedNav:
                     return "TN";
                 case ProjectTypes.MenuBar:
                     return "MB";
-                case "MenuBarWpf":
-                    return "MBWpf";
-                case "Ribbon":
+                case ProjectTypes.Ribbon:
                     return "RB";
                 default:
                     return projectType;

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -61,15 +61,15 @@ namespace Microsoft.Templates.Test
         {
             switch (projectType)
             {
-                case "Blank":
+                case ProjectTypes.Blank:
                     return "B";
-                case "SplitView":
+                case ProjectTypes.SplitView:
                     return "SV";
                 case "SplitViewWpf":
                     return "SVWpf";
-                case "TabbedNav":
+                case ProjectTypes.TabbedNav:
                     return "TN";
-                case "MenuBar":
+                case ProjectTypes.MenuBar:
                     return "MB";
                 case "MenuBarWpf":
                     return "MBWpf";
@@ -481,7 +481,7 @@ namespace Microsoft.Templates.Test
                 // Useful if creating a blank project type and want to change the start page
                 userSelection.HomeName = userSelection.Pages.Last().Name;
 
-                if (projectType == "TabbedNav")
+                if (projectType == ProjectTypes.TabbedNav)
                 {
                     userSelection.Pages.Reverse();
                 }
@@ -500,29 +500,21 @@ namespace Microsoft.Templates.Test
             return result;
         }
 
-        private const string NavigationPanel = "SplitView";
-        private const string Blank = "Blank";
-        private const string TabbedNav = "TabbedNav";
-        private const string MenuBar = "MenuBar";
-        private const string MvvmBasic = "MVVMBasic";
-        private const string MvvmLight = "MVVMLight";
-        private const string CodeBehind = "CodeBehind";
-
         // This returns a list of project types and frameworks supported by BOTH C# and VB
         public static IEnumerable<object[]> GetMultiLanguageProjectsAndFrameworks()
         {
-            yield return new object[] { NavigationPanel, CodeBehind };
-            yield return new object[] { NavigationPanel, MvvmBasic };
-            yield return new object[] { NavigationPanel, MvvmLight };
-            yield return new object[] { Blank, CodeBehind };
-            yield return new object[] { Blank, MvvmBasic };
-            yield return new object[] { Blank, MvvmLight };
-            yield return new object[] { TabbedNav, CodeBehind };
-            yield return new object[] { TabbedNav, MvvmBasic };
-            yield return new object[] { TabbedNav, MvvmLight };
-            yield return new object[] { MenuBar, CodeBehind };
-            yield return new object[] { MenuBar, MvvmBasic };
-            yield return new object[] { MenuBar, MvvmLight };
+            yield return new object[] { ProjectTypes.SplitView, Frameworks.CodeBehind };
+            yield return new object[] { ProjectTypes.SplitView, Frameworks.MVVMBasic };
+            yield return new object[] { ProjectTypes.SplitView, Frameworks.MVVMLight };
+            yield return new object[] { ProjectTypes.Blank, Frameworks.CodeBehind };
+            yield return new object[] { ProjectTypes.Blank, Frameworks.MVVMBasic };
+            yield return new object[] { ProjectTypes.Blank, Frameworks.MVVMLight };
+            yield return new object[] { ProjectTypes.TabbedNav, Frameworks.CodeBehind };
+            yield return new object[] { ProjectTypes.TabbedNav, Frameworks.MVVMBasic };
+            yield return new object[] { ProjectTypes.TabbedNav, Frameworks.MVVMLight };
+            yield return new object[] { ProjectTypes.MenuBar, Frameworks.CodeBehind };
+            yield return new object[] { ProjectTypes.MenuBar, Frameworks.MVVMBasic };
+            yield return new object[] { ProjectTypes.MenuBar, Frameworks.MVVMLight };
         }
 
         // Gets a list of partial identities for page and feature templates supported by C# and VB
@@ -543,19 +535,19 @@ namespace Microsoft.Templates.Test
 
             switch (framework)
             {
-                case "CodeBehind":
+                case Frameworks.CodeBehind:
                     result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
                     break;
 
-                case "MVVMBasic":
+                case Frameworks.MVVMBasic:
                     result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
                     break;
 
-                case "MVVMLight":
+                case Frameworks.MVVMLight:
                     result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
                     break;
 
-                case "CaliburnMicro":
+                case Frameworks.CaliburnMicro:
                     result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
                     break;
 
@@ -570,7 +562,7 @@ namespace Microsoft.Templates.Test
                     }
                     break;
 
-                case "Prism":
+                case Frameworks.Prism:
                     result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
                     break;
 
@@ -587,23 +579,23 @@ namespace Microsoft.Templates.Test
 
             switch (framework)
             {
-                case "CodeBehind":
+                case Frameworks.CodeBehind:
                     result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework, language, platform, excludedItem);
                     break;
 
-                case "MVVMBasic":
+                case Frameworks.MVVMBasic:
                     result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework, language, platform, excludedItem);
                     break;
 
-                case "MVVMLight":
+                case Frameworks.MVVMLight:
                     result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework, language, platform, excludedItem);
                     break;
 
-                case "CaliburnMicro":
+                case Frameworks.CaliburnMicro:
                     result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework, language, platform, excludedItem);
                     break;
 
-                case "Prism":
+                case Frameworks.Prism:
                     result = BuildTemplatesTestFixture.GetPageAndFeatureTemplatesForBuild(framework, language, platform, excludedItem);
                     break;
             }

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildTemplatesTestFixture.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildTemplatesTestFixture.cs
@@ -116,15 +116,15 @@ namespace Microsoft.Templates.Test
         {
             switch (framework)
             {
-                case "CaliburnMicro":
+                case Frameworks.CaliburnMicro:
                     return "CM";
-                case "Prism":
+                case Frameworks.Prism:
                     return "P";
-                case "CodeBehind":
+                case Frameworks.CodeBehind:
                     return "CB";
-                case "MVVMLight":
+                case Frameworks.MVVMLight:
                     return "ML";
-                case "MVVMBasic":
+                case Frameworks.MVVMBasic:
                     return "MB";
                 default:
                     return framework;

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCaliburnMicroProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCaliburnMicroProjectTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Templates.Test.Build.Uwp
     public class BuildCaliburnMicroProjectTests : BaseGenAndBuildTests
     {
         public BuildCaliburnMicroProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "CaliburnMicro")
+            : base(fixture, null, Frameworks.CaliburnMicro)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -59,7 +59,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -81,7 +81,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
@@ -104,7 +104,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "MinimumCaliburnMicro")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -128,7 +128,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCaliburnMicro")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildRightClick")]
@@ -142,7 +142,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOneCaliburnMicro")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneCaliburnMicro")]

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCodeBehindProjectTests.cs
@@ -166,7 +166,5 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             AssertBuildProject(ProjectPath, ProjecName, platform);
         }
-
-       
     }
 }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildCodeBehindProjectTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Templates.Test.Build.Uwp
     public class BuildCodeBehindProjectTests : BaseGenAndBuildTests
     {
         public BuildCodeBehindProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "CodeBehind")
+            : base(fixture, null, Frameworks.CodeBehind)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -60,7 +60,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -83,7 +83,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "MinimumCodeBehind")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -107,7 +107,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
@@ -130,7 +130,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "CodeBehind", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildCodeBehind")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildRightClick")]
@@ -144,7 +144,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "CodeBehind", ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOneCodeBehind")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneCodeBehind")]
@@ -156,7 +156,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "CodeBehind", ProgrammingLanguages.VisualBasic, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.VisualBasic, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOneCodeBehind")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneCodeBehind")]

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMBasicProjectTests.cs
@@ -165,7 +165,5 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             AssertBuildProject(ProjectPath, ProjecName, platform);
         }
-
- 
     }
 }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMBasicProjectTests.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Templates.Test.Build.Uwp
     public class BuildMVVMBasicProjectTests : BaseGenAndBuildTests
     {
         public BuildMVVMBasicProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "MVVMBasic")
+            : base(fixture, null, Frameworks.MVVMBasic)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -36,7 +36,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -59,7 +59,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -82,7 +82,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "MinimumMVVMBasic")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -106,7 +106,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
@@ -129,7 +129,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMBasic")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildRightClick")]
@@ -143,7 +143,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOneMVVMBasic")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneMVVMBasic")]
@@ -155,7 +155,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.VisualBasic, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.VisualBasic, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOneMVVMBasic")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneMVVMBasic")]

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMLightProjectTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Templates.Test.Build.Uwp
     public class BuildMVVMLightProjectTests : BaseGenAndBuildTests
     {
         public BuildMVVMLightProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "MVVMLight")
+            : base(fixture, null, Frameworks.MVVMLight)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -60,7 +60,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -83,7 +83,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "MinimumMVVMLight")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -107,7 +107,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
@@ -130,7 +130,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildMVVMLight")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildRightClick")]
@@ -144,7 +144,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOneMVVMLight")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneMVVMLight")]
@@ -156,7 +156,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "MVVMLight", ProgrammingLanguages.VisualBasic, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.VisualBasic, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOneMVVMLight")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneMVVMLight")]

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildMVVMLightProjectTests.cs
@@ -166,6 +166,5 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             AssertBuildProject(ProjectPath, ProjecName, platform);
         }
-
     }
 }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildPrismProjectTests.cs
@@ -152,7 +152,5 @@ namespace Microsoft.Templates.Test.Build.Uwp
 
             AssertBuildProject(ProjectPath, ProjecName, platform);
         }
-
-     
     }
 }

--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildPrismProjectTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Templates.Test.Build.Uwp
     public class BuildPrismProjectTests : BaseGenAndBuildTests
     {
         public BuildPrismProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "Prism")
+            : base(fixture, null, Frameworks.Prism)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -37,7 +37,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -59,7 +59,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
@@ -81,7 +81,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "MinimumPrism")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -105,7 +105,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
@@ -128,7 +128,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", "", Platforms.Uwp)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, "", Platforms.Uwp)]
         [Trait("ExecutionSet", "BuildPrism")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildRightClick")]
@@ -142,7 +142,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Uwp, "")]
         [Trait("ExecutionSet", "BuildOneByOnePrism")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOnePrism")]

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMBasicProjectTests.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Templates.Test.Build.Wpf
     public class BuildMVVMBasicProjectTests : BaseGenAndBuildTests
     {
         public BuildMVVMBasicProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "MVVMBasic")
+            : base(fixture, null, Frameworks.MVVMBasic)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMBasicWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -33,7 +33,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMBasicWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeaturesWpf")]
@@ -56,7 +56,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMBasicWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeaturesWpf")]
@@ -79,7 +79,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
         [Trait("ExecutionSet", "MVVMBasicWpf")]
         [Trait("ExecutionSet", "_Full")]
@@ -103,7 +103,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
         [Trait("ExecutionSet", "MinimumMVVMBasicWpf")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -128,7 +128,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMBasicWpf")]
         [Trait("ExecutionSet", "_Full")]
         public async Task Build_AllWithMsix_G1_WpfAsync(string projectType, string framework, string platform, string language)
@@ -149,7 +149,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMBasicWpf")]
         [Trait("ExecutionSet", "_Full")]
         public async Task Build_AllWithMsix_G2_WpfAsync(string projectType, string framework, string platform, string language)
@@ -170,7 +170,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Wpf, "wts.Wpf.Feat.MSIXPackaging")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf, "wts.Wpf.Feat.MSIXPackaging")]
         [Trait("ExecutionSet", "BuildOneByOneMVVMBasicWpf")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneMVVMBasicWpf")]

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMLightProjectTests.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Templates.Test.Build.Wpf
     public class BuildMVVMLightProjectTests : BaseGenAndBuildTests
     {
         public BuildMVVMLightProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "MVVMLight")
+            : base(fixture, null, Frameworks.MVVMLight)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMLightWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -33,7 +33,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMLightWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeaturesWpf")]
@@ -56,7 +56,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMLightWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeaturesWpf")]
@@ -79,7 +79,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
         [Trait("ExecutionSet", "MVVMLightWpf")]
         [Trait("ExecutionSet", "_Full")]
@@ -103,7 +103,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
         [Trait("ExecutionSet", "MinimumMVVMLightWpf")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -128,7 +128,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMLightWpf")]
         [Trait("ExecutionSet", "_Full")]
         public async Task Build_AllWithMsix_G1_WpfAsync(string projectType, string framework, string platform, string language)
@@ -149,7 +149,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildMVVMLightWpf")]
         [Trait("ExecutionSet", "_Full")]
         public async Task Build_AllWithMsix_G2_WpfAsync(string projectType, string framework, string platform, string language)
@@ -170,7 +170,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Wpf, "wts.Wpf.Feat.MSIXPackaging")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Wpf, "wts.Wpf.Feat.MSIXPackaging")]
         [Trait("ExecutionSet", "BuildOneByOneMVVMLightWpf")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOneMVVMLightWpf")]

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Templates.Test.Build.Wpf
     public class BuildPrismProjectTests : BaseGenAndBuildTests
     {
         public BuildPrismProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, "Prism")
+            : base(fixture, null, Frameworks.Prism)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildPrismWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
@@ -33,7 +33,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildPrismWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeaturesWpf")]
@@ -56,7 +56,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", "", Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, "", Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildPrismWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeaturesWpf")]
@@ -79,7 +79,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
         [Trait("ExecutionSet", "PrismWpf")]
         [Trait("ExecutionSet", "_Full")]
@@ -103,7 +103,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
         [Trait("ExecutionSet", "MinimumPrismWpf")]
         [Trait("ExecutionSet", "_CIBuild")]
@@ -128,7 +128,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildPrismWpf")]
         [Trait("ExecutionSet", "_Full")]
         public async Task Build_AllWithMsix_G1_WpfAsync(string projectType, string framework, string platform, string language)
@@ -149,7 +149,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "BuildPrismWpf")]
         [Trait("ExecutionSet", "_Full")]
         public async Task Build_AllWithMsix_G2_WpfAsync(string projectType, string framework, string platform, string language)
@@ -170,7 +170,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Wpf, "wts.Wpf.Feat.MSIXPackaging")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Wpf, "wts.Wpf.Feat.MSIXPackaging")]
         [Trait("ExecutionSet", "BuildOneByOnePrismWpf")]
         [Trait("ExecutionSet", "_OneByOne")]
         [Trait("Type", "BuildOneByOnePrismWpf")]

--- a/code/test/Templates.Test/Frameworks.cs
+++ b/code/test/Templates.Test/Frameworks.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Templates.Test
+{
+    public static class Frameworks
+    {
+        public const string CaliburnMicro = "CaliburnMicro";
+
+        public const string CodeBehind = "CodeBehind";
+
+        public const string MVVMBasic = "MVVMBasic";
+
+        public const string MVVMLight = "MVVMLight";
+
+        public const string Prism = "Prism";
+    }
+}

--- a/code/test/Templates.Test/ProjectTypes.cs
+++ b/code/test/Templates.Test/ProjectTypes.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Templates.Test
         public const string SplitView = "SplitView";
 
         public const string TabbedNav = "TabbedNav";
+
+        public const string Ribbon = "Ribbon";
     }
 }

--- a/code/test/Templates.Test/ProjectTypes.cs
+++ b/code/test/Templates.Test/ProjectTypes.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Templates.Test
+{
+    public static class ProjectTypes
+    {
+        public const string Blank = "Blank";
+
+        public const string MenuBar = "MenuBar";
+
+        public const string SplitView = "SplitView";
+
+        public const string TabbedNav = "TabbedNav";
+    }
+}

--- a/code/test/Templates.Test/Templates.Test.csproj
+++ b/code/test/Templates.Test/Templates.Test.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
@@ -87,6 +87,8 @@
     <Compile Include="BuildTemplatesTests\Wpf\BuildPrismProjectTests.cs" />
     <Compile Include="BuildTemplatesTests\Wpf\BuildMVVMLightProjectTests.cs" />
     <Compile Include="BuildTemplatesTests\Wpf\BuildMVVMBasicProjectTests.cs" />
+    <Compile Include="Frameworks.cs" />
+    <Compile Include="ProjectTypes.cs" />
     <Compile Include="VBCodeAnalysis\VBStyleProjectGenerationTests.cs" />
     <Compile Include="VBCodeAnalysis\VBStyleGenerationTestsFixture.cs" />
     <Compile Include="VBCodeAnalysis\VBStyleCollection.cs" />

--- a/code/test/Templates.Test/VisualTests/AccessibilityTests.cs
+++ b/code/test/Templates.Test/VisualTests/AccessibilityTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Templates.Test
             var rootFolder = $"{Path.GetPathRoot(Environment.CurrentDirectory)}UIT\\ALLY\\{DateTime.Now:dd_HHmmss}\\";
             var reportFolder = Path.Combine(rootFolder, "Reports");
 
-            var pageIdentities = AllTestablePages("CodeBehind");
+            var pageIdentities = AllTestablePages(Frameworks.CodeBehind);
 
             VisualComparisonTestDetails appDetails = null;
 
@@ -107,7 +107,7 @@ namespace Microsoft.Templates.Test
 
             try
             {
-                appDetails = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, "SplitView", "CodeBehind", pageIdentities);
+                appDetails = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, ProjectTypes.SplitView, Frameworks.CodeBehind, pageIdentities);
 
                 using (var appSession = WinAppDriverHelper.LaunchAppx(appDetails.PackageFamilyName))
                 {

--- a/code/test/Templates.Test/VisualTests/VisualComparisonTests.cs
+++ b/code/test/Templates.Test/VisualTests/VisualComparisonTests.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Templates.Test
     [Collection("GenerationCollection")]
     public class VisualComparisonTests : BaseGenAndBuildTests
     {
-        const string MenuBar = "MenuBar";
-
         public VisualComparisonTests(GenerationFixture fixture)
             : base(fixture)
         {
@@ -34,7 +32,7 @@ namespace Microsoft.Templates.Test
         {
             var result = new List<string>();
 
-            if (framework == "CaliburnMicro" || framework == "Prism")
+            if (framework == Frameworks.CaliburnMicro || framework == Frameworks.Prism)
             {
                 result.AddRange(AllPagesThatSupportSimpleTestingOnAllFrameworks());
             }
@@ -151,16 +149,16 @@ namespace Microsoft.Templates.Test
         public static IEnumerable<object[]> GetAdditionalCsFrameworks(string projectType)
         {
             //TODO: Remove this once Caliburn Micro Templates are done for MenuBar
-            if (projectType == "MenuBar")
+            if (projectType == ProjectTypes.MenuBar)
             {
-                foreach (var framework in new[] { "CodeBehind", "MVVMLight", "Prism" })
+                foreach (var framework in new[] { Frameworks.CodeBehind, Frameworks.MVVMLight, Frameworks.Prism })
                 {
                     yield return new object[] { framework };
                 }
             }
             else
             {
-                foreach (var framework in new[] { "CodeBehind", "MVVMLight", "CaliburnMicro", "Prism" })
+                foreach (var framework in new[] { Frameworks.CodeBehind, Frameworks.MVVMLight, Frameworks.CaliburnMicro, Frameworks.Prism })
                 {
                     yield return new object[] { framework };
                 }
@@ -170,7 +168,7 @@ namespace Microsoft.Templates.Test
 
         public static IEnumerable<object[]> GetAllFrameworksForBothVbAndCs()
         {
-            foreach (var framework in new[] { "CodeBehind", "MVVMBasic", "MVVMLight" })
+            foreach (var framework in new[] { Frameworks.CodeBehind, Frameworks.MVVMBasic, Frameworks.MVVMLight })
             {
                 yield return new object[] { framework };
             }
@@ -178,19 +176,19 @@ namespace Microsoft.Templates.Test
 
         public static IEnumerable<object[]> GetAllFrameworksAndLanguageCombinations()
         {
-            yield return new object[] { "CodeBehind", ProgrammingLanguages.CSharp };
-            yield return new object[] { "MVVMBasic", ProgrammingLanguages.CSharp };
-            yield return new object[] { "MVVMLight", ProgrammingLanguages.CSharp };
-            yield return new object[] { "CaliburnMicro", ProgrammingLanguages.CSharp };
-            yield return new object[] { "Prism", ProgrammingLanguages.CSharp };
-            yield return new object[] { "CodeBehind", ProgrammingLanguages.VisualBasic };
-            yield return new object[] { "MVVMBasic", ProgrammingLanguages.VisualBasic };
-            yield return new object[] { "MVVMLight", ProgrammingLanguages.VisualBasic };
+            yield return new object[] { Frameworks.CodeBehind, ProgrammingLanguages.CSharp };
+            yield return new object[] { Frameworks.MVVMBasic, ProgrammingLanguages.CSharp };
+            yield return new object[] { Frameworks.MVVMLight, ProgrammingLanguages.CSharp };
+            yield return new object[] { Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp };
+            yield return new object[] { Frameworks.Prism, ProgrammingLanguages.CSharp };
+            yield return new object[] { Frameworks.CodeBehind, ProgrammingLanguages.VisualBasic };
+            yield return new object[] { Frameworks.MVVMBasic, ProgrammingLanguages.VisualBasic };
+            yield return new object[] { Frameworks.MVVMLight, ProgrammingLanguages.VisualBasic };
         }
 
         public static IEnumerable<string> GetAllProjectTypes()
         {
-            foreach (var projectType in new[] { "Blank", "SplitView", "TabbedNav", "MenuBar" })
+            foreach (var projectType in new[] { ProjectTypes.Blank, ProjectTypes.SplitView, ProjectTypes.TabbedNav, ProjectTypes.MenuBar })
             {
                 yield return projectType;
             }
@@ -205,13 +203,13 @@ namespace Microsoft.Templates.Test
                     // Exclude the area at the end of the app name and also covering the version number
                     switch (projectType)
                     {
-                        case "SplitView":
+                        case ProjectTypes.SplitView:
                             return "new[] { new ImageComparer.ExclusionArea(new Rectangle(480, 300, 450, 40), 1.25f) }";
-                        case "TabbedNav":
+                        case ProjectTypes.TabbedNav:
                             return "new[] { new ImageComparer.ExclusionArea(new Rectangle(60, 350, 450, 40), 1.25f) }";
-                        case MenuBar:
+                        case ProjectTypes.MenuBar:
                             return "new[] { new ImageComparer.ExclusionArea(new Rectangle(60, 405, 450, 40), 1.25f) }";
-                        case "Blank":
+                        case ProjectTypes.Blank:
                         default:
                             return "new[] { new ImageComparer.ExclusionArea(new Rectangle(60, 350, 450, 50), 1.25f) }";
                     }
@@ -231,7 +229,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_Blank_MvvmBasic_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("Blank", "MVVMBasic", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.Blank, Frameworks.MVVMBasic, page);
         }
 
         [Theory]
@@ -240,7 +238,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_Blank_MvvmBasic_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("Blank", "MVVMBasic", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.Blank, Frameworks.MVVMBasic, page);
         }
 
         [Theory]
@@ -249,7 +247,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_Blank_MvvmLight_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("Blank", "MVVMLight", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.Blank, Frameworks.MVVMLight, page);
         }
 
         [Theory]
@@ -258,7 +256,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_Blank_MvvmLight_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("Blank", "MVVMLight", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.Blank, Frameworks.MVVMLight, page);
         }
 
         [Theory]
@@ -267,7 +265,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_Blank_CodeBehind_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("Blank", "CodeBehind", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.Blank, Frameworks.CodeBehind, page);
         }
 
         [Theory]
@@ -276,7 +274,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_Blank_CodeBehind_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("Blank", "CodeBehind", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.Blank, Frameworks.CodeBehind, page);
         }
 
         [Theory]
@@ -285,7 +283,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_SplitView_MvvmBasic_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("SplitView", "MVVMBasic", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.SplitView, Frameworks.MVVMBasic, page);
         }
 
         [Theory]
@@ -294,7 +292,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_SplitView_MvvmBasic_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("SplitView", "MVVMBasic", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.SplitView, Frameworks.MVVMBasic, page);
         }
 
         [Theory]
@@ -303,7 +301,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_SplitView_MvvmLight_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("SplitView", "MVVMLight", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.SplitView, Frameworks.MVVMLight, page);
         }
 
         [Theory]
@@ -312,7 +310,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_SplitView_MvvmLight_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("SplitView", "MVVMLight", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.SplitView, Frameworks.MVVMLight, page);
         }
 
         [Theory]
@@ -321,7 +319,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_SplitView_CodeBehind_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("SplitView", "CodeBehind", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.SplitView, Frameworks.CodeBehind, page);
         }
 
         [Theory]
@@ -330,7 +328,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_SplitView_CodeBehind_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("SplitView", "CodeBehind", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.SplitView, Frameworks.CodeBehind, page);
         }
 
         [Theory]
@@ -339,7 +337,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_TabbedNav_MvvmBasic_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("TabbedNav", "MVVMBasic", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.TabbedNav, Frameworks.MVVMBasic, page);
         }
 
         [Theory]
@@ -348,7 +346,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_TabbedNav_MvvmBasic_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("TabbedNav", "MVVMBasic", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.TabbedNav, Frameworks.MVVMBasic, page);
         }
 
         [Theory]
@@ -357,7 +355,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_TabbedNav_MvvmLight_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("TabbedNav", "MVVMLight", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.TabbedNav, Frameworks.MVVMLight, page);
         }
 
         [Theory]
@@ -366,7 +364,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_TabbedNav_MvvmLight_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("TabbedNav", "MVVMLight", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.TabbedNav, Frameworks.MVVMLight, page);
         }
 
         [Theory]
@@ -375,7 +373,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_TabbedNav_CodeBehind_Simple_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("TabbedNav", "CodeBehind", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.TabbedNav, Frameworks.CodeBehind, page);
         }
 
         [Theory]
@@ -384,7 +382,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLaunchPageVisualAreTheSameInVbAndCs_TabbedNav_CodeBehind_ExtraLogic_Async(string page)
         {
-            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync("TabbedNav", "CodeBehind", page);
+            await EnsureLanguageLaunchPageVisualsAreEquivalentAsync(ProjectTypes.TabbedNav, Frameworks.CodeBehind, page);
         }
 
         // There are tests with hardcoded projectType and framework values to make rerunning/debugging only some of the tests easier
@@ -469,7 +467,7 @@ namespace Microsoft.Templates.Test
             WinAppDriverHelper.CheckIsInstalled();
 
             // MVVMBasic is considered the reference version. Compare generated apps with equivalent in other frameworks
-            var refAppDetails = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, projectType, "MVVMBasic", genIdentities, lastPageIsHome: true, createForScreenshots: true);
+            var refAppDetails = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, projectType, Frameworks.MVVMBasic, genIdentities, lastPageIsHome: true, createForScreenshots: true);
 
             var otherProjDetails = new VisualComparisonTestDetails[frameworks.Length];
 
@@ -529,7 +527,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLanguagesProduceIdenticalOutputForEachPageInNavViewAsync(string framework)
         {
-            await EnsureLanguagesProduceIdenticalOutputForEachPageAsync(framework, "SplitView");
+            await EnsureLanguagesProduceIdenticalOutputForEachPageAsync(framework, ProjectTypes.SplitView);
         }
 
         // Note. Visual Studio MUST be running as Admin to run this test.
@@ -540,7 +538,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureLanguagesProduceIdenticalOutputForEachPageInMenuBarAsync(string framework)
         {
-            await EnsureLanguagesProduceIdenticalOutputForEachPageAsync(framework, MenuBar);
+            await EnsureLanguagesProduceIdenticalOutputForEachPageAsync(framework, ProjectTypes.MenuBar);
         }
 
         private async Task EnsureLanguagesProduceIdenticalOutputForEachPageAsync(string framework, string projectType)
@@ -560,7 +558,7 @@ namespace Microsoft.Templates.Test
 
             switch (projectType)
             {
-                case MenuBar:
+                case ProjectTypes.MenuBar:
                     testProjectDetails = SetUpTestProjectForAllMenuBarPagesComparison(app1Details, app2Details, pageExclusions);
                     break;
                 default:
@@ -611,13 +609,13 @@ namespace Microsoft.Templates.Test
             ExecutionEnvironment.CheckRunningAsAdmin();
             WinAppDriverHelper.CheckIsInstalled();
 
-            var app1Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, "SplitView", "MVVMBasic", genIdentities);
+            var app1Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, ProjectTypes.SplitView, Frameworks.MVVMBasic, genIdentities);
 
             var errors = new List<string>();
 
-            foreach (var framework in GetAdditionalCsFrameworks("SplitView"))
+            foreach (var framework in GetAdditionalCsFrameworks(ProjectTypes.SplitView))
             {
-                var app2Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, "SplitView", framework[0].ToString(), genIdentities);
+                var app2Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, ProjectTypes.SplitView, framework[0].ToString(), genIdentities);
 
                 var pageExclusions = new Dictionary<string, string>();
                 pageExclusions.Add("Settings", "new ImageComparer.ExclusionArea(new Rectangle(480, 360, 450, 40), 1.25f)");
@@ -673,13 +671,13 @@ namespace Microsoft.Templates.Test
             ExecutionEnvironment.CheckRunningAsAdmin();
             WinAppDriverHelper.CheckIsInstalled();
 
-            var app1Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, MenuBar, "MVVMBasic", genIdentities);
+            var app1Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, ProjectTypes.MenuBar, Frameworks.MVVMBasic, genIdentities);
 
             var errors = new List<string>();
 
-            foreach (var framework in GetAdditionalCsFrameworks(MenuBar))
+            foreach (var framework in GetAdditionalCsFrameworks(ProjectTypes.MenuBar))
             {
-                var app2Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, MenuBar, framework[0].ToString(), genIdentities);
+                var app2Details = await SetUpProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, ProjectTypes.MenuBar, framework[0].ToString(), genIdentities);
 
                 var pageExclusions = new Dictionary<string, string>();
                 pageExclusions.Add("Settings", "new ImageComparer.ExclusionArea(new Rectangle(480, 360, 450, 40), 1.25f)");
@@ -729,7 +727,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureCanNavigateToEveryPageInNavViewWithoutErrorAsync(string framework, string language)
         {
-            await EnsureCanNavigateToEveryPageWithoutErrorAsync(framework, language, "SplitView");
+            await EnsureCanNavigateToEveryPageWithoutErrorAsync(framework, language, ProjectTypes.SplitView);
         }
 
         [Theory]
@@ -738,7 +736,7 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureCanNavigateToEveryPageInTabbedNavWithoutErrorAsync(string framework, string language)
         {
-            await EnsureCanNavigateToEveryPageWithoutErrorAsync(framework, language, "TabbedNav");
+            await EnsureCanNavigateToEveryPageWithoutErrorAsync(framework, language, ProjectTypes.TabbedNav);
         }
 
         [Theory]
@@ -747,14 +745,14 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "WinAppDriver")]
         public async Task EnsureCanNavigateToEveryPageWithMenuBarWithoutErrorAsync(string framework, string language)
         {
-            if (framework == "CaliburnMicro")
+            if (framework == Frameworks.CaliburnMicro)
             {
                 // Caliburn does not yet support MenuBar projects
                 // TODO: remove this when implement #3000
                 return;
             }
 
-            await EnsureCanNavigateToEveryPageWithoutErrorAsync(framework, language, "MenuBar");
+            await EnsureCanNavigateToEveryPageWithoutErrorAsync(framework, language, ProjectTypes.MenuBar);
         }
 
         private async Task EnsureCanNavigateToEveryPageWithoutErrorAsync(string framework, string language, string projectType)
@@ -815,7 +813,7 @@ namespace Microsoft.Templates.Test
 
                     await Task.Delay(TimeSpan.FromSeconds(2));
 
-                    if (projectType == "MenuBar")
+                    if (projectType == ProjectTypes.MenuBar)
                     {
                         var menuItems = appSession.FindElementsByClassName("Microsoft.UI.Xaml.Controls.MenuBarItem");
 

--- a/code/test/Templates.Test/VisualTests/WPF/AccessibilityTests.cs
+++ b/code/test/Templates.Test/VisualTests/WPF/AccessibilityTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Templates.Test.WPf
                     "wts.Wpf.Page.WebView",
                 };
 
-                var appDetails = await SetUpWpfProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, "SplitView", "MVVMLight", wpfTestPages);
+                var appDetails = await SetUpWpfProjectForUiTestComparisonAsync(ProgrammingLanguages.CSharp, ProjectTypes.SplitView, Frameworks.MVVMLight, wpfTestPages);
 
                 var exePath = Path.Combine(appDetails.ProjectPath, appDetails.ProjectName, "bin", "Release", "netcoreapp3.1", $"{appDetails.ProjectName}.exe");
 

--- a/code/test/Templates.Test/WACK/Uwp/WindowsAppCertKitTests.cs
+++ b/code/test/Templates.Test/WACK/Uwp/WindowsAppCertKitTests.cs
@@ -32,112 +32,112 @@ namespace Microsoft.Templates.Test.Uwp
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_CodeBehind_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         public async Task WackTests_CodeBehind_VBAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_MvvmBasic_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         public async Task WackTests_MvvmBasic_VBAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_MVVMLight_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         public async Task WackTests_MVVMLight_VBAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_CaliburnMicro_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_Prism_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_CodeBehind_Other_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "CodeBehind", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         public async Task WackTests_CodeBehind_Other_VBAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_MvvmBasic_Other_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         public async Task WackTests_MvvmBasic_Other_VBAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_MVVMLight_Other_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.VisualBasic, Platforms.Uwp)]
         public async Task WackTests_MVVMLight_Other_VBAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "CaliburnMicro", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.CaliburnMicro, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_CaliburnMicro_Other_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Uwp)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         public async Task WackTests_Prism_Other_CSAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithExcludedFeaturesAsync(projectType, framework, platform, language);
@@ -163,7 +163,7 @@ namespace Microsoft.Templates.Test.Uwp
         private async Task RunWackOnProjectWithExcludedFeaturesAsync(string projectType, string framework, string platform, string language)
         {
             // Skip these options as they don't present anything that isn't tested by other combinations
-            if (projectType == "Blank" || projectType == "TabbedNav")
+            if (projectType == ProjectTypes.Blank || projectType == ProjectTypes.TabbedNav)
             {
                 return;
             }

--- a/code/test/Templates.Test/WACK/Wpf/WindowsAppCertKitTests.cs
+++ b/code/test/Templates.Test/WACK/Wpf/WindowsAppCertKitTests.cs
@@ -33,21 +33,21 @@ namespace Microsoft.Templates.Test.Wack.Wpf
 
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMBasic", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         public async Task WackTests_MvvmBasic_All_WPFAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "MVVMLight", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         public async Task WackTests_MVVMLight_All_WPFAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
         }
 
         [Theory]
-        [MemberData(nameof(GetProjectTemplatesForBuild), "Prism", ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         public async Task WackTests_Prism_All_WPFAsync(string projectType, string framework, string platform, string language)
         {
             await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);


### PR DESCRIPTION
This is just some refactoring of tests to remove inconsistent use of magic strings for Frameworks and ProjectTypes

- Which issue does this PR relate to? #3799 
- Applies to the following platforms:
  - [x] UWP
  - [x] WPF

As draft as will need updates once #3800 is merged
