### PR TITLE
Issue3780 Add Template Tests for WPF

### DIFF
--- a/code/test/Templates.Test/TemplateJsonValidationTests.cs
+++ b/code/test/Templates.Test/TemplateJsonValidationTests.cs
@@ -27,14 +27,19 @@ namespace Microsoft.Templates.Test
             const string templatesRoot = "../../../../../Templates";
 
             // The following excludes the catalog and project folders, but they only contain a single template file each
-            var foldersOfInterest = new[] { "Uwp/_comp", "Uwp/Features", "Uwp/Pages", "Uwp/Services", "Uwp/Testing" };
+            var foldersOfInterest = new[] { "Uwp/_comp", "Uwp/Features", "Uwp/Pages", "Uwp/Services", "Uwp/Testing",
+                                            "Wpf/_comp", "Wpf/Features", "Wpf/Pages", "Wpf/Services", "Wpf/Testing"};
 
             foreach (var folder in foldersOfInterest)
             {
-                foreach (var file in new DirectoryInfo(Path.Combine(templatesRoot, folder)).GetFiles("template.json", SearchOption.AllDirectories))
+                var folderPath = Path.Combine(templatesRoot, folder);
+                if (Directory.Exists(folderPath))
                 {
-                    yield return new object[] { file.FullName };
-                }
+                    foreach (var file in new DirectoryInfo(folderPath).GetFiles("template.json", SearchOption.AllDirectories))
+                    {
+                        yield return new object[] { file.FullName };
+                    }
+                }     
             }
         }
 

--- a/code/tools/TemplateValidator/TemplateJsonVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateJsonVerifier.cs
@@ -116,7 +116,7 @@ namespace TemplateValidator
 
                 VerifySymbols(template, results);
 
-                VerifyLicensesAndProjPostactions(template, templateRoot, results);
+                VerifyLicensesAndProjPostactions(template, results);
 
                 VerifyPostactionsPath(template, results);
             }
@@ -132,6 +132,11 @@ namespace TemplateValidator
 
         private static void VerifySymbols(ValidationTemplateInfo template, List<string> results)
         {
+            if (template.Symbols == null)
+            {
+                return;
+            }
+
             var type = typeof(GenParams);
             var paramValues = type.GetFields(BindingFlags.Static | BindingFlags.Public)
                                   .Where(f => f.IsLiteral)
@@ -141,7 +146,18 @@ namespace TemplateValidator
             // The explicit values here are the ones that are currently in use.
             // In theory any string could be exported and used as a symbol but currently it's only these
             // If lots of templates start exporting new symbols it might be necessary to change how symbol keys are verified
-            var allValidSymbolKeys = new List<string>(paramValues) { "baseclass", "setter", "wts.Page.Settings", "wts.Page.Settings.CodeBehind", "wts.Page.Settings.Prism", "wts.Page.Settings.CaliburnMicro", "wts.Page.Settings.VB", "wts.Page.Settings.CodeBehind.VB", "copyrightYear", "wts.safeprojectName" };
+            var allValidSymbolKeys = new List<string>(paramValues)
+            {
+                "baseclass", "setter",
+                "wts.Page.Settings", "wts.Page.Settings.CodeBehind", "wts.Page.Settings.Prism", "wts.Page.Settings.CaliburnMicro", "wts.Page.Settings.VB", "wts.Page.Settings.CodeBehind.VB",
+                "copyrightYear",
+                "wts.safeprojectName",
+                "commandclass",
+                "onNavigatedToParams", "onNavigatedFromParams",
+                "configtype", "configvalue",
+                "pagetype",
+                "canExecuteChangedMethodName",
+            };
 
             foreach (var symbol in template.Symbols)
             {
@@ -169,7 +185,7 @@ namespace TemplateValidator
                         VerifyWtsTypeFeatureMultipleInstancesRule(tag, template, results);
                         break;
                     case "wts.order":
-                        VerifyWtsOrderTagValue(tag, results);
+                        VerifyWtsOrderTagValue(results);
                         break;
                     case "wts.displayOrder":
                         VerifyWtsDisplayOrderTagValue(tag, results);
@@ -220,12 +236,6 @@ namespace TemplateValidator
                     case "wts.defaultInstance":
                         VerifyWtsDefaultinstanceTagValue(tag, results);
                         break;
-                    case "wts.export.baseclass":
-                        VerifyWtsExportBaseclassTagValue(tag, results);
-                        break;
-                    case "wts.export.setter":
-                        VerifyWtsExportSetterTagValue(tag, results);
-                        break;
                     case "wts.isHidden":
                         VerifyWtsIshiddenTagValue(tag, results);
                         break;
@@ -239,10 +249,40 @@ namespace TemplateValidator
                         VerifyWtsOutputToParentTagValue(tag, results);
                         break;
                     case "wts.requiredVsWorkload":
-                        // No validation done here as we don't know all workload IDs.
+                        VerifyRequiredVsWorkloadTagValue(tag, results);
+                        break;
+                    case "wts.requiredSdks":
+                        VerifyRequiredSdkTagValue(tag, results);
+                        break;
+                    case "wts.export.baseclass":
+                        VerifyWtsExportBaseclassTagValue(tag, results);
+                        break;
+                    case "wts.export.setter":
+                        VerifyWtsExportSetterTagValue(tag, results);
+                        break;
+                    case "wts.export.configtype":
+                        VerifyWtsExportConfigTypeTagValue(tag, results);
+                        break;
+                    case "wts.export.configvalue":
+                        VerifyWtsExportConfigValueTagValue(tag, results);
+                        break;
+                    case "wts.export.commandclass":
+                        VerifyWtsExportCommandClassTagValue(tag, results);
+                        break;
+                    case "wts.export.pagetype":
+                        VerifyWtsExportPageTypeTagValue(tag, results);
+                        break;
+                    case "wts.export.canExecuteChangedMethodName":
+                        VerifyWtsExportCanExecuteChangedMethodNameTagValue(tag, results);
+                        break;
+                    case "wts.export.onNavigatedToParams":
+                        VerifyWtsExportOnNavigatedToParamsTagValue(tag, results);
+                        break;
+                    case "wts.export.onNavigatedFromParams":
+                        VerifyWtsExportOnNavigatedFromParamsTagValue(tag, results);
                         break;
                     default:
-                        results.Add($"Unknown tag '{tag.Value}' specified in the file.");
+                        results.Add($"Unknown tag '{tag.Key}' specified in the file.");
                         break;
                 }
             }
@@ -271,7 +311,7 @@ namespace TemplateValidator
 
         private static void VerifyPlatformTagValue(KeyValuePair<string, string> tag, List<string> results)
         {
-            if (!new[] { Platforms.Uwp }.Contains(tag.Value))
+            if (!new[] { Platforms.Uwp, Platforms.Wpf }.Contains(tag.Value))
             {
                 results.Add($"Invalid value '{tag.Value}' specified in the platform tag.");
             }
@@ -293,6 +333,14 @@ namespace TemplateValidator
             }
         }
 
+        private static void VerifyWtsExportBaseclassTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            if (!new[] { "Observable", "ViewModelBase", "INotifyPropertyChanged", "Screen", "PropertyChangedBase", "BindableBase" }.Contains(tag.Value))
+            {
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.baseclass tag.");
+            }
+        }
+
         private static void VerifyWtsExportSetterTagValue(KeyValuePair<string, string> tag, List<string> results)
         {
             if (!new[] { "Set", "SetProperty" }.Contains(tag.Value))
@@ -301,11 +349,59 @@ namespace TemplateValidator
             }
         }
 
-        private static void VerifyWtsExportBaseclassTagValue(KeyValuePair<string, string> tag, List<string> results)
+        private static void VerifyWtsExportConfigTypeTagValue(KeyValuePair<string, string> tag, List<string> results)
         {
-            if (!new[] { "Observable", "ViewModelBase", "INotifyPropertyChanged", "Screen", "PropertyChangedBase" }.Contains(tag.Value))
+            if (!new[] { "IOptions<AppConfig>", "AppConfig" }.Contains(tag.Value))
             {
-                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.baseclass tag.");
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.configtype tag.");
+            }
+        }
+
+        private static void VerifyWtsExportConfigValueTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            if (!new[] { "appConfig.Value", "appConfig" }.Contains(tag.Value))
+            {
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.configvalue tag.");
+            }
+        }
+
+        private static void VerifyWtsExportCommandClassTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            if (!new[] { "RelayCommand", "DelegateCommand" }.Contains(tag.Value))
+            {
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.commandclass tag.");
+            }
+        }
+
+        private static void VerifyWtsExportPageTypeTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            if (!new[] { "Page", "UserControl" }.Contains(tag.Value))
+            {
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.pageType tag.");
+            }
+        }
+
+        private static void VerifyWtsExportCanExecuteChangedMethodNameTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            if (!new[] { "OnCanExecuteChanged", "RaiseCanExecuteChanged" }.Contains(tag.Value))
+            {
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.canExecuteChangedMethodName tag.");
+            }
+        }
+
+        private static void VerifyWtsExportOnNavigatedToParamsTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            if (!new[] { "object parameter", "NavigationContext navigationContext" }.Contains(tag.Value))
+            {
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.onNavigatedToParams tag.");
+            }
+        }
+
+        private static void VerifyWtsExportOnNavigatedFromParamsTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            if (!new[] { "", "NavigationContext navigationContext" }.Contains(tag.Value))
+            {
+                results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.onNavigatedFromParams tag.");
             }
         }
 
@@ -327,7 +423,7 @@ namespace TemplateValidator
 
         private static void VerifyWtsGroupTagValue(KeyValuePair<string, string> tag, List<string> results)
         {
-            if (!new[] { "Analytics", "BackgroundWork", "UserInteraction", "ApplicationLifecycle", "ApplicationLaunching", "ConnectedExperiences", "Identity", "Testing", "Data", "Tools" }.Contains(tag.Value))
+            if (!new[] { "Analytics", "BackgroundWork", "UserInteraction", "ApplicationLifecycle", "ApplicationLaunching", "ConnectedExperiences", "Identity", "Testing", "Data", "Tools", "Packaging" }.Contains(tag.Value))
             {
                 results.Add($"Invalid value '{tag.Value}' specified in the wts.group tag.");
             }
@@ -420,11 +516,14 @@ namespace TemplateValidator
         private static void VerifyWtsFrameworkTagValue(KeyValuePair<string, string> tag, List<string> results)
         {
             // This tag may contain a single value or multiple ones separated by the pipe character
-            foreach (var frameworkValue in tag.Value.Split('|'))
+            if (tag.Value != "all")
             {
-                if (!AllFrameworks.Contains(frameworkValue))
+                foreach (var frameworkValue in tag.Value.Split('|'))
                 {
-                    results.Add($"Invalid value '{tag.Value}' specified in the wts.framework tag.");
+                    if (!AllFrameworks.Contains(frameworkValue))
+                    {
+                        results.Add($"Invalid value '{tag.Value}' specified in the wts.framework tag.");
+                    }
                 }
             }
         }
@@ -436,9 +535,12 @@ namespace TemplateValidator
             {
                 if (language == ProgrammingLanguages.CSharp)
                 {
-                    if (!CsFrameworks.Contains(frameworkValue))
+                    if (frameworkValue != "all")
                     {
-                        results.Add($"Invalid framework '{frameworkValue}' is not supported in templates for C# projects.");
+                        if (!CsFrameworks.Contains(frameworkValue))
+                        {
+                            results.Add($"Invalid framework '{frameworkValue}' is not supported in templates for C# projects.");
+                        }
                     }
                 }
                 else if (language == ProgrammingLanguages.VisualBasic)
@@ -451,7 +553,7 @@ namespace TemplateValidator
             }
         }
 
-        private static void VerifyWtsOrderTagValue(KeyValuePair<string, string> tag, List<string> results)
+        private static void VerifyWtsOrderTagValue(List<string> results)
         {
             results.Add($"The wts.order tag is no longer supported. Please use the wts.displayOrder or the wts.compositionOrder tag.");
         }
@@ -514,6 +616,32 @@ namespace TemplateValidator
             }
         }
 
+        private static void VerifyRequiredVsWorkloadTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            string[] allRequiredWorkloads = new[] { "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging", "Microsoft.VisualStudio.Workload.NetWeb" };
+
+            foreach (var requiredWorkload in tag.Value.Split('|'))
+            {
+                if (!allRequiredWorkloads.Contains(requiredWorkload))
+                {
+                    results.Add($"Invalid value '{requiredWorkload}' specified in the wts.requiredVsWorkload tag.");
+                }
+            }
+        }
+
+        private static void VerifyRequiredSdkTagValue(KeyValuePair<string, string> tag, List<string> results)
+        {
+            string[] allSdks = new[] { "UAP, Version=10.0.19041.0" };
+
+            foreach (var sdk in tag.Value.Split('|'))
+            {
+                if (!allSdks.Contains(sdk))
+                {
+                    results.Add($"Invalid value '{sdk}' specified in the wts.requiredSdks tag.");
+                }
+            }
+        }
+
         private static void EnsureAllDefinedGuidsAreUsed(ValidationTemplateInfo template, string templateRoot, List<string> results)
         {
             if (template.Guids != null)
@@ -548,7 +676,7 @@ namespace TemplateValidator
             }
         }
 
-        private static void VerifyLicensesAndProjPostactions(ValidationTemplateInfo template, string templateRoot, List<string> results)
+        private static void VerifyLicensesAndProjPostactions(ValidationTemplateInfo template, List<string> results)
         {
             if (template.TemplateTags.ContainsKey("wts.licenses") && !string.IsNullOrEmpty(template.TemplateTags["wts.licenses"]))
             {

--- a/code/tools/TemplateValidator/TemplateJsonVerifier.cs
+++ b/code/tools/TemplateValidator/TemplateJsonVerifier.cs
@@ -399,7 +399,7 @@ namespace TemplateValidator
 
         private static void VerifyWtsExportOnNavigatedFromParamsTagValue(KeyValuePair<string, string> tag, List<string> results)
         {
-            if (!new[] { "", "NavigationContext navigationContext" }.Contains(tag.Value))
+            if (!new[] { string.Empty, "NavigationContext navigationContext" }.Contains(tag.Value))
             {
                 results.Add($"Unexpected value '{tag.Value}' specified in the wts.export.onNavigatedFromParams tag.");
             }

--- a/code/tools/TemplateValidator/ValidationTemplateInfo.cs
+++ b/code/tools/TemplateValidator/ValidationTemplateInfo.cs
@@ -63,7 +63,7 @@ namespace TemplateValidator
 
         // We just use strings for tags. The template engine uses a converter but this is fine for testing purposes
         [ApiAnalysisMandatoryKeys("language", "type", "wts.type", "wts.platform")]
-        [ApiAnalysisOptionalKeys("wts.displayOrder", "wts.compositionOrder", "wts.frontendframework", "wts.backendframework", "wts.projecttype", "wts.version", "wts.genGroup", "wts.rightClickEnabled", "wts.compositionFilter", "wts.licenses", "wts.group", "wts.multipleInstance", "wts.dependencies", "wts.requirements", "wts.exclusions", "wts.defaultInstance", "wts.export.baseclass", "wts.export.setter", "wts.isHidden", "wts.telemName", "wts.outputToParent", "wts.isGroupExclusiveSelection", "wts.requiredVsWorkload")]
+        [ApiAnalysisOptionalKeys("wts.displayOrder", "wts.compositionOrder", "wts.frontendframework", "wts.backendframework", "wts.projecttype", "wts.version", "wts.genGroup", "wts.rightClickEnabled", "wts.compositionFilter", "wts.licenses", "wts.group", "wts.multipleInstance", "wts.dependencies", "wts.requirements", "wts.exclusions", "wts.defaultInstance", "wts.export.baseclass", "wts.export.setter", "wts.isHidden", "wts.telemName", "wts.outputToParent", "wts.isGroupExclusiveSelection", "wts.requiredVsWorkload", "wts.requiredSdks", "wts.export.configtype", "wts.export.configvalue", "wts.export.commandclass", "wts.export.pagetype", "wts.export.canExecuteChangedMethodName", "wts.export.onNavigatedToParams", "wts.export.onNavigatedFromParams")]
         [JsonProperty("tags")]
         public IReadOnlyDictionary<string, string> TemplateTags { get; set; }
 


### PR DESCRIPTION


- Quick summary of changes
Add template tests for WPF

- Which issue does this PR relate to?
#3780 Add template verification tests for WPF templates

- Applies to the following platforms:
  - [ ] UWP
  - [x] WPF

- Anything that requires particular review or attention?
no
- Do all automated tests pass?
yes

- Have you raised issues for any needed follow-on work?
Raised #3820 to make test maintenance easier and enable using TemplateJsonVerifier for WebTS
