### PR TITLE
Issue3793 Update Platform info in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,9 @@ If applicable, add screenshots to help explain your problem.
 Add any other context about the problem here.
 
 Applies to the following platforms:
-- [ ] UWP
-- [ ] WPF
+| UWP              | WPF              |
+| :--------------- | :--------------- |
+| <!-- Yes/No? --> | <!-- Yes/No? --> |
 
 **System**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,5 +20,6 @@ A clear and concise description of any alternative solutions or features you've 
 Add any other context or screenshots about the feature request here.
 
 Applies to the following platforms:
-- [ ] UWP
-- [ ] WPF
+| UWP              | WPF              |
+| :--------------- | :--------------- |
+| <!-- Yes/No? --> | <!-- Yes/No? --> |

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,31 @@
 # PR checklist
 
-Quick summary of changes
+**Quick summary of changes**
 
-- Which issue does this PR relate to?
-- Applies to the following platforms:
-  - [ ] UWP
-  - [ ] WPF
-- Anything that requires particular review or attention?
-- Do all automated tests pass?
-- Have automated tests been added for new features?
-- If you've changed the UI:
+**Which issue does this PR relate to?**
+
+**Applies to the following platforms:**
+
+| UWP              | WPF              |
+| :--------------- | :--------------- |
+| <!-- Yes/No? --> | <!-- Yes/No? --> |
+
+**Anything that requires particular review or attention?**
+
+**Do all automated tests pass?**
+
+**Have automated tests been added for new features?**
+
+**If you've changed the UI:**
   - Be sure you are including screenshots to show the changes.
   - Be sure you have reviewed the [accessibility checklist](accessibility.md).
-- If you've included a new template:
+
+**If you've included a new template:**
   - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/WindowsTemplateStudio/wiki/Checklist:-Template-Verification).
   - Be sure it's included in the list on this [UWP](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/WPF/getting-started-endusers.md) getting started doc.
-- Have you raised issues for any needed follow-on work?
-- Have docs been updated?
-- If breaking changes or different ways of doing things have been introduced, have they been communicated widely?
+
+**Have you raised issues for any needed follow-on work?**
+
+**Have docs been updated?**
+
+**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**


### PR DESCRIPTION
Quick summary of changes
- Changed platform info in github templates from checkable bullet points to table 
- Also changed PR template format a bit as you cannot show a table in a bulleted list

Which issue does this PR relate to?
- #3793 issue and PR templates to include indication of related platform(s) 

Applies to the following platforms:
  - [x] UWP
  - [x] WPF
