### PR TITLE
Add comment on how to navigate to settings page in NavView

### DIFF
--- a/templates/Uwp/_comp/CaliburnMicro/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
+++ b/templates/Uwp/_comp/CaliburnMicro/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
@@ -7,14 +7,15 @@ namespace Param_RootNamespace.ViewModels
     {
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            //{[{
             if (args.IsSettingsInvoked)
             {
+//{--{
+                // Navigate to the settings page - implement as appropriate if needed
+//}--}
+                //{[{
                 _navigationService.Navigate(typeof(wts.ItemNamePage));
-                return;
+                //}]}
             }
-
-            //}]}
         }
 
         private void NavigationService_Navigated(object sender, NavigationEventArgs e)

--- a/templates/Uwp/_comp/CaliburnMicro/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
+++ b/templates/Uwp/_comp/CaliburnMicro/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
@@ -73,7 +73,11 @@ namespace Param_RootNamespace.ViewModels
 
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
+            if (args.IsSettingsInvoked)
+            {
+                // Navigate to the settings page - implement as appropriate if needed
+            }
+            else if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
             {
                 var pageType = selectedItem.GetValue(NavHelper.NavigateToProperty) as Type;
                 var viewModelType = ViewModelLocator.LocateTypeForViewType(pageType, false);

--- a/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav.Page.Settings._VB/Views/ShellPage_postaction.xaml.vb
+++ b/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav.Page.Settings._VB/Views/ShellPage_postaction.xaml.vb
@@ -19,13 +19,14 @@ Namespace Views
         End Sub
 
         Private Sub OnItemInvoked(sender As WinUI.NavigationView, args As WinUI.NavigationViewItemInvokedEventArgs)
-'{[{
             If args.IsSettingsInvoked Then
+'{--{
+                ' Navigate to the settings page - implement as appropriate if needed
+'}--}
+                '{[{
                 NavigationService.Navigate(GetType(wts.ItemNamePage), Nothing, args.RecommendedNavigationTransitionInfo)
-                Return
+                '}]}
             End If
-
-'}]}
         End Sub
     End Class
 End Namespace

--- a/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav.Page.Settings/Views/ShellPage_postaction.xaml.cs
+++ b/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav.Page.Settings/Views/ShellPage_postaction.xaml.cs
@@ -20,14 +20,15 @@ namespace Param_RootNamespace.Views
 
         private void OnItemInvoked(WinUI.NavigationView sender, WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            //{[{
             if (args.IsSettingsInvoked)
             {
+//{--{
+                // Navigate to the settings page - implement as appropriate if needed
+//}--}
+                //{[{
                 NavigationService.Navigate(typeof(wts.ItemNamePage), null, args.RecommendedNavigationTransitionInfo);
-                return;
+                //}]}
             }
-
-            //}]}
         }
     }
 }

--- a/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav._VB/Views/ShellPage.xaml.vb
+++ b/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav._VB/Views/ShellPage.xaml.vb
@@ -97,9 +97,13 @@ Namespace Views
         End Function
 
         Private Sub OnItemInvoked(sender As WinUI.NavigationView, args As WinUI.NavigationViewItemInvokedEventArgs)
-            Dim selectedItem As WinUI.NavigationViewItem = TryCast(args.InvokedItemContainer, WinUI.NavigationViewItem)
-            Dim pageType = TryCast(selectedItem.GetValue(NavHelper.NavigateToProperty), Type)
-            NavigationService.Navigate(pageType, Nothing, args.RecommendedNavigationTransitionInfo)
+            If args.IsSettingsInvoked Then
+                ' Navigate to the settings page - implement as appropriate if needed
+            Else
+                Dim selectedItem As WinUI.NavigationViewItem = TryCast(args.InvokedItemContainer, WinUI.NavigationViewItem)
+                Dim pageType = TryCast(selectedItem.GetValue(NavHelper.NavigateToProperty), Type)
+                NavigationService.Navigate(pageType, Nothing, args.RecommendedNavigationTransitionInfo)
+            End If
         End Sub
 
         Private Function BuildKeyboardAccelerator(key As VirtualKey, Optional modifiers As VirtualKeyModifiers? = Nothing) As KeyboardAccelerator

--- a/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav/Views/ShellPage.xaml.cs
+++ b/templates/Uwp/_comp/CodeBehind/Project.SplitView.TabbedNav/Views/ShellPage.xaml.cs
@@ -102,7 +102,11 @@ namespace Param_RootNamespace.Views
 
         private void OnItemInvoked(WinUI.NavigationView sender, WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
+            if (args.IsSettingsInvoked)
+            {
+                // Navigate to the settings page - implement as appropriate if needed
+            }
+            else if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
             {
                 var pageType = selectedItem.GetValue(NavHelper.NavigateToProperty) as Type;
                 NavigationService.Navigate(pageType, null, args.RecommendedNavigationTransitionInfo);

--- a/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav.Page.Settings._VB/ViewModels/ShellViewModel_postaction.vb
+++ b/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav.Page.Settings._VB/ViewModels/ShellViewModel_postaction.vb
@@ -10,13 +10,14 @@ Namespace ViewModels
         Inherits Observable
 
         Private Sub OnItemInvoked(args As WinUI.NavigationViewItemInvokedEventArgs)
-            '{[{
             If args.IsSettingsInvoked Then
+'{--{
+                ' Navigate to the settings page - implement as appropriate if needed
+'}--}
+                '{[{
                 NavigationService.Navigate(GetType(wts.ItemNamePage), Nothing, args.RecommendedNavigationTransitionInfo)
-                Return
+                '}]}
             End If
-
-            '}]}
         End Sub
 
         Public Sub Frame_Navigated(sender As Object, e As NavigationEventArgs)

--- a/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
+++ b/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
@@ -11,14 +11,15 @@ namespace Param_RootNamespace.ViewModels
     {
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            //{[{
             if (args.IsSettingsInvoked)
             {
+//{--{
+                // Navigate to the settings page - implement as appropriate if needed
+//}--}
+                //{[{
                 NavigationService.Navigate(typeof(wts.ItemNamePage), null, args.RecommendedNavigationTransitionInfo);
-                return;
+                //}]}
             }
-
-            //}]}
         }
 
         private void Frame_Navigated(object sender, NavigationEventArgs e)

--- a/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav._VB/ViewModels/ShellViewModel.vb
+++ b/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav._VB/ViewModels/ShellViewModel.vb
@@ -87,9 +87,13 @@ Namespace ViewModels
         End Sub
 
         Private Sub OnItemInvoked(args As WinUI.NavigationViewItemInvokedEventArgs)
-            Dim selectedItem As WinUI.NavigationViewItem = TryCast(args.InvokedItemContainer, WinUI.NavigationViewItem)
-            Dim pageType = TryCast(selectedItem.GetValue(NavHelper.NavigateToProperty), Type)
-            NavigationService.Navigate(pageType, Nothing, args.RecommendedNavigationTransitionInfo)
+            If args.IsSettingsInvoked Then
+                ' Navigate to the settings page - implement as appropriate if needed
+            Else
+                Dim selectedItem As WinUI.NavigationViewItem = TryCast(args.InvokedItemContainer, WinUI.NavigationViewItem)
+                Dim pageType = TryCast(selectedItem.GetValue(NavHelper.NavigateToProperty), Type)
+                NavigationService.Navigate(pageType, Nothing, args.RecommendedNavigationTransitionInfo)
+            End If
         End Sub
 
         Private Sub Frame_NavigationFailed(sender As Object, e As NavigationFailedEventArgs)

--- a/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
+++ b/templates/Uwp/_comp/MVVMBasic/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
@@ -66,7 +66,11 @@ namespace Param_RootNamespace.ViewModels
 
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
+            if (args.IsSettingsInvoked)
+            {
+                // Navigate to the settings page - implement as appropriate if needed
+            }
+            else if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
             {
                 var pageType = selectedItem.GetValue(NavHelper.NavigateToProperty) as Type;
                 NavigationService.Navigate(pageType, null, args.RecommendedNavigationTransitionInfo);

--- a/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav.Page.Settings._VB/ViewModels/ShellViewModel_postaction.vb
+++ b/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav.Page.Settings._VB/ViewModels/ShellViewModel_postaction.vb
@@ -11,13 +11,14 @@ Namespace ViewModels
         Inherits ViewModelBase
 
         Private Sub OnItemInvoked(args As WinUI.NavigationViewItemInvokedEventArgs)
-            '{[{
             If args.IsSettingsInvoked Then
+'{--{
+                ' Navigate to the settings page - implement as appropriate if needed
+'}--}
+                '{[{
                 NavigationService.Navigate(GetType(wts.ItemNameViewModel).FullName, Nothing, args.RecommendedNavigationTransitionInfo)
-                Return
+                '}]}
             End If
-
-            '}]}
         End Sub
 
         Public Sub Frame_Navigated(sender As Object, e As NavigationEventArgs)

--- a/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
+++ b/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
@@ -10,14 +10,15 @@ namespace Param_RootNamespace.ViewModels
     {
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            //{[{
             if (args.IsSettingsInvoked)
             {
+//{--{
+                // Navigate to the settings page - implement as appropriate if needed
+//}--}
+                //{[{
                 NavigationService.Navigate(typeof(wts.ItemNameViewModel).FullName, null, args.RecommendedNavigationTransitionInfo);
-                return;
+                //}]}
             }
-
-            //}]}
         }
 
         private void Frame_Navigated(object sender, NavigationEventArgs e)

--- a/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav._VB/ViewModels/ShellViewModel.vb
+++ b/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav._VB/ViewModels/ShellViewModel.vb
@@ -92,9 +92,13 @@ Namespace ViewModels
         End Sub
 
         Private Sub OnItemInvoked(args As WinUI.NavigationViewItemInvokedEventArgs)
-            Dim selectedItem As WinUI.NavigationViewItem = TryCast(args.InvokedItemContainer, WinUI.NavigationViewItem)
-            Dim pageKey = TryCast(selectedItem.GetValue(NavHelper.NavigateToProperty), String)
-            NavigationService.Navigate(pageKey, Nothing, args.RecommendedNavigationTransitionInfo)
+            If args.IsSettingsInvoked Then
+                ' Navigate to the settings page - implement as appropriate if needed
+            Else
+                Dim selectedItem As WinUI.NavigationViewItem = TryCast(args.InvokedItemContainer, WinUI.NavigationViewItem)
+                Dim pageKey = TryCast(selectedItem.GetValue(NavHelper.NavigateToProperty), String)
+                NavigationService.Navigate(pageKey, Nothing, args.RecommendedNavigationTransitionInfo)
+            End If
         End Sub
 
         Private Sub Frame_NavigationFailed(sender As Object, e As NavigationFailedEventArgs)

--- a/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
+++ b/templates/Uwp/_comp/MVVMLight/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
@@ -72,7 +72,11 @@ namespace Param_RootNamespace.ViewModels
 
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
+            if (args.IsSettingsInvoked)
+            {
+                // Navigate to the settings page - implement as appropriate if needed
+            }
+            else if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
             {
                 var pageKey = selectedItem.GetValue(NavHelper.NavigateToProperty) as string;
                 NavigationService.Navigate(pageKey, null, args.RecommendedNavigationTransitionInfo);

--- a/templates/Uwp/_comp/Prism/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
+++ b/templates/Uwp/_comp/Prism/Project.SplitView.TabbedNav.Page.Settings/ViewModels/ShellViewModel_postaction.cs
@@ -10,14 +10,15 @@ namespace Param_RootNamespace.ViewModels
     {
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            //{[{
             if (args.IsSettingsInvoked)
             {
+//{--{
+                // Navigate to the settings page - implement as appropriate if needed
+//}--}
+                //{[{
                 _navigationService.Navigate("wts.ItemName", null);
-                return;
+                //}]}
             }
-
-            //}]}
         }
 
         private void Frame_Navigated(object sender, NavigationEventArgs e)

--- a/templates/Uwp/_comp/Prism/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
+++ b/templates/Uwp/_comp/Prism/Project.SplitView.TabbedNav/ViewModels/ShellViewModel.cs
@@ -56,7 +56,11 @@ namespace Param_RootNamespace.ViewModels
 
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)
         {
-            if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
+            if (args.IsSettingsInvoked)
+            {
+                // Navigate to the settings page - implement as appropriate if needed
+            }
+            else if (args.InvokedItemContainer is WinUI.NavigationViewItem selectedItem)
             {
                 var pageKey = selectedItem.GetValue(NavHelper.NavigateToProperty) as string;
                 _navigationService.Navigate(pageKey, null);


### PR DESCRIPTION
# PR checklist

Quick summary of changes
- Add comment on how to navigate to settings page in NavView

Which issue does this PR relate to?
- #3784 Clicking on NavigationView's Settings item throws NullReferenceException

Applies to the following platforms:
  - [x] UWP
  - [ ] WPF
