### PR TITLE
Fix detail page scroll in wizard

### DIFF
--- a/code/src/UI/Services/NavigationService.cs
+++ b/code/src/UI/Services/NavigationService.cs
@@ -28,6 +28,10 @@ namespace Microsoft.Templates.UI.Services
         {
             _secondaryFrame = secondaryFrame;
             _secondaryFrame.Content = content;
+        }
+
+        public static void SubscribeEventHandlers()
+        {
             _secondaryFrame.Navigated += SecondaryFrameNavigated;
             _secondaryFrame.Navigating += SecondaryFrameNavigating;
         }

--- a/code/src/UI/Views/NewItem/MainPage.xaml.cs
+++ b/code/src/UI/Views/NewItem/MainPage.xaml.cs
@@ -19,7 +19,12 @@ namespace Microsoft.Templates.UI.Views.NewItem
         private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
         {
             MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
-            Services.NavigationService.InitializeSecondaryFrame(stepFrame, new TemplateSelectionPage());
+            if (stepFrame.Content == null)
+            {
+                Services.NavigationService.InitializeSecondaryFrame(stepFrame, new TemplateSelectionPage());
+            }
+
+            Services.NavigationService.SubscribeEventHandlers();
         }
 
         private void OnUnloaded(object sender, System.Windows.RoutedEventArgs e)

--- a/code/src/UI/Views/NewProject/MainPage.xaml.cs
+++ b/code/src/UI/Views/NewProject/MainPage.xaml.cs
@@ -23,7 +23,12 @@ namespace Microsoft.Templates.UI.Views.NewProject
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
-            Services.NavigationService.InitializeSecondaryFrame(stepFrame, WizardNavigation.Current.CurrentStep.GetPage());
+            if (stepFrame.Content == null)
+            {
+                Services.NavigationService.InitializeSecondaryFrame(stepFrame, WizardNavigation.Current.CurrentStep.GetPage());
+            }
+
+            Services.NavigationService.SubscribeEventHandlers();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Scroll position (offset) is lost when viewing the details of an item in the wizard #3804
