### PR TITLE
Fix wack tests and add wack tests for CodeBehind

### DIFF
--- a/code/test/Templates.Test/WACK/Wpf/WindowsAppCertKitTests.cs
+++ b/code/test/Templates.Test/WACK/Wpf/WindowsAppCertKitTests.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Templates.Test.Wack.Wpf
         {
         }
 
+        [Theory]
+        [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.Wpf)]
+        public async Task WackTests_CodeBehind_All_WPFAsync(string projectType, string framework, string platform, string language)
+        {
+            await RunWackOnProjectWithAllPagesAndFeaturesAsync(projectType, framework, platform, language);
+        }
 
         [Theory]
         [MemberData(nameof(GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf)]
@@ -58,7 +64,7 @@ namespace Microsoft.Templates.Test.Wack.Wpf
         {
             bool templateSelector(ITemplateInfo t) => t.GetTemplateType().IsItemTemplate()
                 && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
-                && t.GetFrontEndFrameworkList().Contains(framework) || t.GetFrontEndFrameworkList().Contains(All)
+                && (t.GetFrontEndFrameworkList().Contains(framework) || t.GetFrontEndFrameworkList().Contains(All))
                 && !t.GroupIdentity.StartsWith("wts.Wpf.Service.Identity")
                 && t.GetPlatform() == platform
                 && !t.GetIsHidden();


### PR DESCRIPTION
**Quick summary of changes**
- Fix wack tests 
- Add wack tests for CodeBehind

**Which issue does this PR relate to?**
#3774 Add codebehind as a framework option for WPF

**Applies to the following platforms:**

| UWP              | WPF              |
| :--------------- | :--------------- |
| No | Yes |

