### PR TITLE
Remove outdated references for device family SDKs

### DIFF
--- a/docs/UWP/platform-specific-recommendations.md
+++ b/docs/UWP/platform-specific-recommendations.md
@@ -1,6 +1,6 @@
 # Platform Specific Recommendations
 
-The Universal Windows Platform (UWP) lets you build apps for any Windows device (PCs, phones, Xbox One, HoloLens, Surface Hub, IoT and more).
+The Universal Windows Platform (UWP) lets you build apps for any Windows device (PCs, Xbox One, HoloLens, Surface Hub, IoT and more).
 Here is a compilation of useful links to the documentation that will help you to adapt your WinTS generated application to add some platform-specific features.
 
 ## General
@@ -17,33 +17,15 @@ Here is a compilation of useful links to the documentation that will help you to
 
 ## Desktop Recommendations
 
-### API Extensions
-
-- [UWP API Desktop Extensions](https://docs.microsoft.com/uwp/extension-sdks/windows-desktop-extension-sdk)
-
 ### More Information
 
 - [Device Portal for Desktop](https://docs.microsoft.com/windows/uwp/debug-test-perf/device-portal-desktop)
-
-## Mobile Recommendations
-
-### API Extensions
-
-- [UWP API Windows Mobile Extensions](https://docs.microsoft.com/uwp/extension-sdks/windows-mobile-extension-sdk)
-
-### More Information
-
-- [Device Portal for Mobile](https://docs.microsoft.com/windows/uwp/debug-test-perf/device-portal-mobile)
 
 ## Xbox Recommendations
 
 ### Overview
 
 - [Xbox UWP development doc](https://docs.microsoft.com/windows/uwp/xbox-apps)
-
-### API Extensions
-
-- [UWP API Xbox Live Extensions](https://docs.microsoft.com/uwp/extension-sdks/xbox-live-extensions)
 
 ### More Information
 
@@ -72,10 +54,6 @@ Here is a compilation of useful links to the documentation that will help you to
 ### Overview
 
 - [Windows 10 IoT doc](https://docs.microsoft.com/windows/iot-core/)
-
-### API Extensions
-
-- [UWP API IoT Extensions](https://docs.microsoft.com/uwp/extension-sdks/windows-iot-extension-sdk)
 
 ## Surface Hub devices Recommendations
 


### PR DESCRIPTION


# PR checklist

**Quick summary of changes**
Remove links to Windows Mobile specific information & platform specific SDK docs that have been removed from docs.

**Which issue does this PR relate to?**
For #3857

**Applies to the following platforms:**

| UWP              | WPF              |
| :--------------- | :--------------- |
|  Yes | No |

**Anything that requires particular review or attention?**
Nope. Just a docs change.

**Do all automated tests pass?**

yes.

**Have automated tests been added for new features?**

n/a

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/WindowsTemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/WPF/getting-started-endusers.md) getting started doc.

**Have you raised issues for any needed follow-on work?**

n/a

**Have docs been updated?**

yes

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
n/a