### PR TITLE
Fix error handling for WinUI3 templates in VS Preview

### DIFF
--- a/code/src/UI/Services/GenerationService.cs
+++ b/code/src/UI/Services/GenerationService.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Templates.UI.Services
             }
             catch (Exception ex)
             {
-                GenContext.ToolBox.Shell.CloseSolution();
                 _dialogService.ShowError(ex, userSelection.ToString());
+                GenContext.ToolBox.Shell.CloseSolution();
                 GenContext.ToolBox.Shell.CancelWizard(false);
             }
         }


### PR DESCRIPTION
**Quick summary of changes**
Show error message before closing the solution. 

Trying to create a WinUI3 solution in VS 16.8 fails, but the error message is not shown correctly in WTS.
Closing the solution after showing the error message fixes the problem. 

