### PR TITLE
Accessibility - Wizard - Pages section is not in logical order

### DIFF
--- a/code/src/UI/Views/NewProject/MainPage.xaml
+++ b/code/src/UI/Views/NewProject/MainPage.xaml
@@ -86,6 +86,7 @@
                             AutomationProperties.Name="{x:Static strings:StringRes.ProjectDetailsFrameworkSectionTitle}"
                             PreviewKeyDown="ComboBox_PreviewKeyDown" />
                         <ItemsControl
+                            Focusable="False"
                             ItemsSource="{Binding UserSelection.Groups}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Disable item focus to solve screen reader logical order.

**Which issue does this PR relate to?**
#3893

