### PR TITLE
Accessibility - Wizard - Add border when item is selected and focused

### DIFF
--- a/code/src/UI/Styles/ListView.xaml
+++ b/code/src/UI/Styles/ListView.xaml
@@ -269,8 +269,15 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListViewItem}">
-                    <Grid>
-                        <Grid x:Name="bd" MinHeight="35"  Background="{TemplateBinding Background}">
+                    <Grid MinHeight="35">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Grid x:Name="bd" Grid.Column="0" Grid.Row="0" Background="{TemplateBinding Background}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
@@ -290,13 +297,37 @@
                                 Foreground="{TemplateBinding Foreground}"
                                 Visibility="{Binding Completed, Converter={StaticResource BoolToVisibilityConverter}}" />
                         </Grid>
+                        <Border Grid.Column="0" Grid.Row="0"
+                                x:Name="itemBorder"
+                                BorderThickness="{StaticResource SequentialFlowBorderThickness}"/>
                     </Grid>
+
                     <ControlTemplate.Triggers>
                         <DataTrigger Binding="{Binding IsSelected}" Value="true">
                             <Setter Property="Background" TargetName="bd" Value="{Binding SelectedItemActive, Source={x:Static services:UIStylesService.Instance}}" />
                             <Setter Property="Foreground" TargetName="text" Value="{Binding SelectedItemActiveText, Source={x:Static services:UIStylesService.Instance}}" />
                             <Setter Property="Foreground" TargetName="checkMark" Value="{Binding SelectedItemActiveText, Source={x:Static services:UIStylesService.Instance}}" />
                         </DataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsSelected}" Value="true" />
+                                <Condition Binding="{Binding IsFocused, RelativeSource={RelativeSource Self}}" Value="true" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="BorderBrush" TargetName="itemBorder" Value="{Binding SelectedItemActive, Source={x:Static services:UIStylesService.Instance}}" />
+                            <Setter Property="Background" TargetName="bd" Value="{Binding ListItemMouseOver, Source={x:Static services:UIStylesService.Instance}}" />
+                            <Setter Property="Foreground" TargetName="text" Value="{Binding ListItemMouseOverText, Source={x:Static services:UIStylesService.Instance}}" />
+                            <Setter Property="Foreground" TargetName="checkMark" Value="{Binding ListItemMouseOverText, Source={x:Static services:UIStylesService.Instance}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsSelected}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="BorderBrush" TargetName="itemBorder" Value="{Binding SelectedItemActive, Source={x:Static services:UIStylesService.Instance}}" />
+                            <Setter Property="Background" TargetName="bd" Value="{Binding ListItemMouseOver, Source={x:Static services:UIStylesService.Instance}}" />
+                            <Setter Property="Foreground" TargetName="text" Value="{Binding ListItemMouseOverText, Source={x:Static services:UIStylesService.Instance}}" />
+                            <Setter Property="Foreground" TargetName="checkMark" Value="{Binding ListItemMouseOverText, Source={x:Static services:UIStylesService.Instance}}" />
+                        </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsSelected}" Value="false" />

--- a/code/src/UI/Styles/_Thickness.xaml
+++ b/code/src/UI/Styles/_Thickness.xaml
@@ -52,5 +52,6 @@
     <Thickness x:Key="Margin_L_LeftRight_M2_Top">24,16,24,0</Thickness>
 
     <Thickness x:Key="CardBorderThickness">1.5,1.5,1.5,1.5</Thickness>
+    <Thickness x:Key="SequentialFlowBorderThickness">1.5,1.5,1.5,1.5</Thickness>
 
 </ResourceDictionary>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Proposal: add border when item is selected and focused

**Which issue does this PR relate to?**
#3900

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No| No |<No |

**Anything that requires particular review or attention?**

**Do all automated tests pass?**

**Have automated tests been added for new features?**

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

**Screenshots (light theme):**

Item selected, focused and not selecteds (no changes):
![imagen](https://user-images.githubusercontent.com/25466105/97004311-2e5d8000-153d-11eb-81ca-b00dfa6d27ff.png)

Item selected and focused (proposal):
![imagen](https://user-images.githubusercontent.com/25466105/97004524-78defc80-153d-11eb-9766-2ee945fd5e81.png)

**Screenshots (dark theme):**

Item selected, focused and not selecteds (no changes):
![imagen](https://user-images.githubusercontent.com/25466105/97004767-d115fe80-153d-11eb-945c-d9fe5e346cfb.png)

Item selected and focused (proposal):
![imagen](https://user-images.githubusercontent.com/25466105/97004934-06bae780-153e-11eb-887e-b4ad4aa57c8b.png)

