### PR TITLE
Screen reader announces comments

### DIFF
--- a/code/src/UI/Controls/NotificationMarkdownBlock.xaml.cs
+++ b/code/src/UI/Controls/NotificationMarkdownBlock.xaml.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Templates.UI.Controls
 
         private void RaiseAutomationEventFlowDocument()
         {
+            // Inform a screen reader to read the notification text
+            // https://devblogs.microsoft.com/dotnet/net-framework-4-7-1-accessibility-and-wpf-improvements/#uiautomation-liveregion-support
             var peer = UIElementAutomationPeer.FromElement(flowDocumentScrollViewer) ?? UIElementAutomationPeer.CreatePeerForElement(flowDocumentScrollViewer);
 
             if (peer is FlowDocumentScrollViewerAutomationPeer flowPeer)

--- a/code/src/UI/Views/Common/TemplateInfoPage.xaml.cs
+++ b/code/src/UI/Views/Common/TemplateInfoPage.xaml.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Templates.UI.Views.Common
                 {
                     accessibleHyperlink.SetValue(AutomationProperties.NameProperty, hyperlinkHelpText);
 
+                    // Inform a screen reader to read the hyperlink text
+                    // https://devblogs.microsoft.com/dotnet/net-framework-4-7-1-accessibility-and-wpf-improvements/#uiautomation-liveregion-support
                     var peer = UIElementAutomationPeer.FromElement(accessibleTextBlock) ?? UIElementAutomationPeer.CreatePeerForElement(accessibleTextBlock);
                     if (peer is TextBlockAutomationPeer textBlockPeer)
                     {


### PR DESCRIPTION
A11y_ Windows Template Studio_ MVVM Basic Details_Screenreader: Screenreader is not announcing the link “The Model-View View Model pattern”. #3897

A11y_Windows Template Studio_ Services Your project Details_Screenreader: Screenreader does not announce Alert Indication status after enter numbering in Edit field. #3894