### PR TITLE
Issue3811 validate project paths on right click

### DIFF
--- a/code/src/UI/Controls/Notification.cs
+++ b/code/src/UI/Controls/Notification.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Templates.UI.Controls
     {
         None,
         NamingValidation,
+        ProjectPathValidation,
     }
 
     public enum Category

--- a/code/src/UI/Resources/StringRes.Designer.cs
+++ b/code/src/UI/Resources/StringRes.Designer.cs
@@ -1027,6 +1027,15 @@ namespace Microsoft.Templates.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The project name does not match the project folder name. Please adjust to ensure a correct generation..
+        /// </summary>
+        public static string NotificationValidationError_ProjectNameAndPathDoNotMatch {
+            get {
+                return ResourceManager.GetString("NotificationValidationError_ProjectNameAndPathDoNotMatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to RegEx validation {0} failed..
         /// </summary>
         public static string NotificationValidationError_Regex {

--- a/code/src/UI/Resources/StringRes.cs-CZ.resx
+++ b/code/src/UI/Resources/StringRes.cs-CZ.resx
@@ -901,4 +901,7 @@ Ověřte následující seznam balíčků požadovaných v kódu vašeho projek
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.de-DE.resx
+++ b/code/src/UI/Resources/StringRes.de-DE.resx
@@ -901,4 +901,7 @@
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.es-ES.resx
+++ b/code/src/UI/Resources/StringRes.es-ES.resx
@@ -901,4 +901,7 @@ Comprueba la lista siguiente de paquetes que necesitan el código del proyecto y
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.fr-FR.resx
+++ b/code/src/UI/Resources/StringRes.fr-FR.resx
@@ -901,4 +901,7 @@ Vérifiez la liste suivante reprenant les packages requis par le code de votre p
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.it-IT.resx
+++ b/code/src/UI/Resources/StringRes.it-IT.resx
@@ -901,4 +901,7 @@ Verifica il seguente elenco di pacchetti necessario al codice del progetto e agg
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.ja-JP.resx
+++ b/code/src/UI/Resources/StringRes.ja-JP.resx
@@ -901,4 +901,7 @@
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.ko-KR.resx
+++ b/code/src/UI/Resources/StringRes.ko-KR.resx
@@ -901,4 +901,7 @@
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.pl-PL.resx
+++ b/code/src/UI/Resources/StringRes.pl-PL.resx
@@ -901,4 +901,7 @@ Sprawdź następującą listę pakietów wymaganych przez kod źródłowy Twojeg
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.pt-BR.resx
+++ b/code/src/UI/Resources/StringRes.pt-BR.resx
@@ -901,4 +901,7 @@ Verifique a seguinte lista de pacotes necessários para o código de seu projeto
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.resx
+++ b/code/src/UI/Resources/StringRes.resx
@@ -901,4 +901,7 @@ Please verify the following list of packages needed by your project's code and m
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.ru-RU.resx
+++ b/code/src/UI/Resources/StringRes.ru-RU.resx
@@ -901,4 +901,7 @@
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.tr-TR.resx
+++ b/code/src/UI/Resources/StringRes.tr-TR.resx
@@ -901,4 +901,7 @@ Lütfen projenizin kodunun gerektirdiği aşağıdaki paket listesini doğrulay�
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.zh-CN.resx
+++ b/code/src/UI/Resources/StringRes.zh-CN.resx
@@ -901,4 +901,7 @@
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/Resources/StringRes.zh-TW.resx
+++ b/code/src/UI/Resources/StringRes.zh-TW.resx
@@ -901,4 +901,7 @@
   <data name="WinUI" xml:space="preserve">
     <value>Windows UI</value>
   </data>
+  <data name="NotificationValidationError_ProjectNameAndPathDoNotMatch" xml:space="preserve">
+    <value>The project name does not match the project folder name. Please adjust to ensure a correct generation.</value>
+  </data>
 </root>

--- a/code/src/UI/ViewModels/NewItem/ChangesSummaryViewModel.cs
+++ b/code/src/UI/ViewModels/NewItem/ChangesSummaryViewModel.cs
@@ -15,12 +15,19 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
     public class ChangesSummaryViewModel : Observable
     {
         private bool _doNotMerge;
+        private bool _isDoNotMergeEnabled;
         private NewItemFileViewModel _selected;
 
         public bool DoNotMerge
         {
             get => _doNotMerge;
             set => SetProperty(ref _doNotMerge, value);
+        }
+
+        public bool IsDoNotMergeEnabled
+        {
+            get => _isDoNotMergeEnabled;
+            set => SetProperty(ref _isDoNotMergeEnabled, value);
         }
 
         public NewItemFileViewModel Selected

--- a/code/src/UI/ViewModels/NewItem/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewItem/MainViewModel.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -98,6 +99,23 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
             WizardStatus.Title = GetNewItemTitle(templateType);
             SetProjectConfigInfo();
             Initialize(ConfigPlatform, language);
+        }
+
+        public void ValidateProjectPaths()
+        {
+            var projectFolderName = new DirectoryInfo(GenContext.Current.DestinationPath).Name;
+            if (GenContext.Current.ProjectName != projectFolderName)
+            {
+                var notification = Notification.Error(StringRes.NotificationValidationError_ProjectNameAndPathDoNotMatch, ErrorCategory.ProjectPathValidation);
+                NotificationsControl.AddNotificationAsync(notification).FireAndForget();
+                ChangesSummary.DoNotMerge = true;
+                ChangesSummary.IsDoNotMergeEnabled = false;
+            }
+            else
+            {
+                ChangesSummary.DoNotMerge = false;
+                ChangesSummary.IsDoNotMergeEnabled = true;
+            }
         }
 
         private string GetNewItemTitle(TemplateType templateType)

--- a/code/src/UI/ViewModels/NewItem/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewItem/MainViewModel.cs
@@ -101,23 +101,6 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
             Initialize(ConfigPlatform, language);
         }
 
-        public void ValidateProjectPaths()
-        {
-            var projectFolderName = new DirectoryInfo(GenContext.Current.DestinationPath).Name;
-            if (GenContext.Current.ProjectName != projectFolderName)
-            {
-                var notification = Notification.Error(StringRes.NotificationValidationError_ProjectNameAndPathDoNotMatch, ErrorCategory.ProjectPathValidation);
-                NotificationsControl.AddNotificationAsync(notification).FireAndForget();
-                ChangesSummary.DoNotMerge = true;
-                ChangesSummary.IsDoNotMergeEnabled = false;
-            }
-            else
-            {
-                ChangesSummary.DoNotMerge = false;
-                ChangesSummary.IsDoNotMergeEnabled = true;
-            }
-        }
-
         private string GetNewItemTitle(TemplateType templateType)
         {
             switch (templateType)
@@ -240,6 +223,8 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
 
                 await Task.CompletedTask;
             }
+
+            ValidateProjectPaths();
         }
 
         protected async Task OnRefreshTemplatesAsync()
@@ -259,6 +244,22 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
             finally
             {
                 WizardStatus.IsLoading = GenContext.ToolBox.Repo.SyncInProgress;
+            }
+        }
+
+        private void ValidateProjectPaths()
+        {
+            if (GenContext.Current.ProjectName != new DirectoryInfo(GenContext.Current.DestinationPath).Name)
+            {
+                var notification = Notification.Error(StringRes.NotificationValidationError_ProjectNameAndPathDoNotMatch, ErrorCategory.ProjectPathValidation);
+                NotificationsControl.AddNotificationAsync(notification).FireAndForget();
+                ChangesSummary.DoNotMerge = true;
+                ChangesSummary.IsDoNotMergeEnabled = false;
+            }
+            else
+            {
+                ChangesSummary.DoNotMerge = false;
+                ChangesSummary.IsDoNotMergeEnabled = true;
             }
         }
 

--- a/code/src/UI/Views/NewItem/MainPage.xaml
+++ b/code/src/UI/Views/NewItem/MainPage.xaml
@@ -55,6 +55,7 @@
                 Content="{x:Static res:StringRes.ChangesSummaryCheckBoxText}"
                 Style="{StaticResource WtsCheckBoxStyle}"
                 Margin="{StaticResource Margin_M_LeftRight}"
+                IsEnabled="{Binding ChangesSummary.IsDoNotMergeEnabled, Mode=TwoWay}"
                 IsChecked="{Binding ChangesSummary.DoNotMerge, Mode=TwoWay}"
                 Visibility="{Binding Navigation.CurrentStep, Converter={StaticResource StepVisibilityConverter}, ConverterParameter=2}" />
             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,26,0">

--- a/code/src/UI/Views/NewItem/MainPage.xaml
+++ b/code/src/UI/Views/NewItem/MainPage.xaml
@@ -55,7 +55,7 @@
                 Content="{x:Static res:StringRes.ChangesSummaryCheckBoxText}"
                 Style="{StaticResource WtsCheckBoxStyle}"
                 Margin="{StaticResource Margin_M_LeftRight}"
-                IsEnabled="{Binding ChangesSummary.IsDoNotMergeEnabled, Mode=TwoWay}"
+                IsEnabled="{Binding ChangesSummary.IsDoNotMergeEnabled, Mode=OneWay}"
                 IsChecked="{Binding ChangesSummary.DoNotMerge, Mode=TwoWay}"
                 Visibility="{Binding Navigation.CurrentStep, Converter={StaticResource StepVisibilityConverter}, ConverterParameter=2}" />
             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,26,0">

--- a/code/src/UI/Views/NewItem/WizardShell.xaml.cs
+++ b/code/src/UI/Views/NewItem/WizardShell.xaml.cs
@@ -62,7 +62,6 @@ namespace Microsoft.Templates.UI.Views.NewItem
         {
             MainViewModel.Instance.Initialize(_templateType, _language);
             await MainViewModel.Instance.SynchronizeAsync();
-            MainViewModel.Instance.ValidateProjectPaths();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/code/src/UI/Views/NewItem/WizardShell.xaml.cs
+++ b/code/src/UI/Views/NewItem/WizardShell.xaml.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Templates.UI.Views.NewItem
         {
             MainViewModel.Instance.Initialize(_templateType, _language);
             await MainViewModel.Instance.SynchronizeAsync();
+            MainViewModel.Instance.ValidateProjectPaths();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
**Quick summary of changes**
- Validate project path and project name match 
- Show notification in case there is a mismatch as this might cause postactions to fail
- Only allow temporary generation in case there is a mismatch

**Which issue does this PR relate to?**
#3811 Can't create new files using Windows Template Studio after renaming the project

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| yes | yes |yes |

