### PR TITLE
Issue3944 on navigated from

### DIFF
--- a/templates/Wpf/_comp/CodeBehind/Project/Services/NavigationService.cs
+++ b/templates/Wpf/_comp/CodeBehind/Project/Services/NavigationService.cs
@@ -38,7 +38,17 @@ namespace Param_RootNamespace.Services
         }
 
         public void GoBack()
-            => _frame.GoBack();
+        {
+            if (_frame.CanGoBack)
+            {
+                var dataContext = _frame.GetDataContext();
+                _frame.GoBack();
+                if (dataContext is INavigationAware navigationAware)
+                {
+                    navigationAware.OnNavigatedFrom();
+                }
+            }
+        }
 
         public bool NavigateTo(Type pageType, object parameter = null, bool clearNavigation = false)
         {

--- a/templates/Wpf/_comp/CodeBehind/Project/Services/NavigationService.cs
+++ b/templates/Wpf/_comp/CodeBehind/Project/Services/NavigationService.cs
@@ -41,9 +41,9 @@ namespace Param_RootNamespace.Services
         {
             if (_frame.CanGoBack)
             {
-                var dataContext = _frame.GetDataContext();
+                var pageBeforeNavigation = _frame.Content;
                 _frame.GoBack();
-                if (dataContext is INavigationAware navigationAware)
+                if (pageBeforeNavigation is INavigationAware navigationAware)
                 {
                     navigationAware.OnNavigatedFrom();
                 }

--- a/templates/Wpf/_comp/MVVMBasic/Project/Services/NavigationService.cs
+++ b/templates/Wpf/_comp/MVVMBasic/Project/Services/NavigationService.cs
@@ -37,7 +37,17 @@ namespace Param_RootNamespace.Services
         }
 
         public void GoBack()
-            => _frame.GoBack();
+        {
+            if (_frame.CanGoBack)
+            {
+                var dataContext = _frame.GetDataContext();
+                _frame.GoBack();
+                if (dataContext is INavigationAware navigationAware)
+                {
+                    navigationAware.OnNavigatedFrom();
+                }
+            }
+        }
 
         public bool NavigateTo(string pageKey, object parameter = null, bool clearNavigation = false)
         {

--- a/templates/Wpf/_comp/MVVMBasic/Project/Services/NavigationService.cs
+++ b/templates/Wpf/_comp/MVVMBasic/Project/Services/NavigationService.cs
@@ -40,9 +40,9 @@ namespace Param_RootNamespace.Services
         {
             if (_frame.CanGoBack)
             {
-                var dataContext = _frame.GetDataContext();
+                var vmBeforeNavigation = _frame.GetDataContext();
                 _frame.GoBack();
-                if (dataContext is INavigationAware navigationAware)
+                if (vmBeforeNavigation is INavigationAware navigationAware)
                 {
                     navigationAware.OnNavigatedFrom();
                 }

--- a/templates/Wpf/_comp/MVVMLight/Project/Services/NavigationService.cs
+++ b/templates/Wpf/_comp/MVVMLight/Project/Services/NavigationService.cs
@@ -52,7 +52,17 @@ namespace Param_RootNamespace.Services
         }
 
         public void GoBack()
-            => _frame.GoBack();
+        {
+            if (_frame.CanGoBack)
+            {
+                var dataContext = _frame.GetDataContext();
+                _frame.GoBack();
+                if (dataContext is INavigationAware navigationAware)
+                {
+                    navigationAware.OnNavigatedFrom();
+                }
+            }
+        }
 
         public void NavigateTo(string pageKey)
             => NavigateTo(pageKey, null, false);

--- a/templates/Wpf/_comp/MVVMLight/Project/Services/NavigationService.cs
+++ b/templates/Wpf/_comp/MVVMLight/Project/Services/NavigationService.cs
@@ -55,9 +55,9 @@ namespace Param_RootNamespace.Services
         {
             if (_frame.CanGoBack)
             {
-                var dataContext = _frame.GetDataContext();
+                var vmBeforeNavigation = _frame.GetDataContext();
                 _frame.GoBack();
-                if (dataContext is INavigationAware navigationAware)
+                if (vmBeforeNavigation is INavigationAware navigationAware)
                 {
                     navigationAware.OnNavigatedFrom();
                 }


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**

Call OnNavigatedFrom in backwards navitagion on WPF Templates

**Which issue does this PR relate to?**

OnNavigatedFrom event is not invoked when navigating backwards in WPF templates #3944

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No | Yes | No |
