### PR TITLE
Fix project references to use ProjectName instead of RootNamespace

### DIFF
--- a/templates/Wpf/Testing/UnitTests.App.MSTest/Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.csproj
+++ b/templates/Wpf/Testing/UnitTests.App.MSTest/Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Param_RootNamespace\Param_ProjectName.csproj" />
+    <ProjectReference Include="..\Param_ProjectName\Param_ProjectName.csproj" />
   </ItemGroup>
 
 </Project>

--- a/templates/Wpf/Testing/UnitTests.App.NUnit/Param_ProjectName.Tests.NUnit/Param_ProjectName.Tests.NUnit.csproj
+++ b/templates/Wpf/Testing/UnitTests.App.NUnit/Param_ProjectName.Tests.NUnit/Param_ProjectName.Tests.NUnit.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Param_RootNamespace\Param_ProjectName.csproj" />
+    <ProjectReference Include="..\Param_ProjectName\Param_ProjectName.csproj" />
   </ItemGroup>
 
 </Project>

--- a/templates/Wpf/Testing/UnitTests.App.xUnit/Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.csproj
+++ b/templates/Wpf/Testing/UnitTests.App.xUnit/Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Param_RootNamespace\Param_RootNamespace.csproj" />
+    <ProjectReference Include="..\Param_ProjectName\Param_ProjectName.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Quick summary of changes**
Fix project references to use ProjectName instead of RootNamespace
Detected by full test pipeline https://winappstudio.visualstudio.com/WTS/_build/results?buildId=35473&view=results

**Which issue does this PR relate to?**
#3613 WPF Testing Templates

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No | Yes|No |

