### PR TITLE
Move Microsoft.NET.Test.Sdk packages to csproj/vbproj file

### DIFF
--- a/templates/Uwp/Testing/UnitTests.App.MSTest._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.MSTest._VB/.template.config/template.json
@@ -118,17 +118,6 @@
         "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.vbproj"
       },
       "continueOnError": true
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.8.0",
-        "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.vbproj"
-      },
-      "continueOnError": true
     }
   ]
 }

--- a/templates/Uwp/Testing/UnitTests.App.MSTest._VB/Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.vbproj
+++ b/templates/Uwp/Testing/UnitTests.App.MSTest._VB/Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.vbproj
@@ -104,6 +104,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>16.8.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />

--- a/templates/Uwp/Testing/UnitTests.App.MSTest/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.MSTest/.template.config/template.json
@@ -118,17 +118,6 @@
         "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj"
       },
       "continueOnError": true
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.8.0",
-        "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj"
-      },
-      "continueOnError": true
     }
   ]
 }

--- a/templates/Uwp/Testing/UnitTests.App.MSTest/Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.csproj
+++ b/templates/Uwp/Testing/UnitTests.App.MSTest/Param_ProjectName.Tests.MSTest/Param_ProjectName.Tests.MSTest.csproj
@@ -101,6 +101,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>16.8.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />

--- a/templates/Uwp/Testing/UnitTests.App.xUnit._VB/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.xUnit._VB/.template.config/template.json
@@ -118,17 +118,6 @@
         "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.vbproj"
       },
       "continueOnError": true
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.8.0",
-        "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.vbproj"
-      },
-      "continueOnError": true
     }
   ]
 }

--- a/templates/Uwp/Testing/UnitTests.App.xUnit._VB/Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.vbproj
+++ b/templates/Uwp/Testing/UnitTests.App.xUnit._VB/Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.vbproj
@@ -104,6 +104,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>16.8.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />

--- a/templates/Uwp/Testing/UnitTests.App.xUnit/.template.config/template.json
+++ b/templates/Uwp/Testing/UnitTests.App.xUnit/.template.config/template.json
@@ -118,17 +118,6 @@
         "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.csproj"
       },
       "continueOnError": true
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.8.0",
-        "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.csproj"
-      },
-      "continueOnError": true
     }
   ]
 }

--- a/templates/Uwp/Testing/UnitTests.App.xUnit/Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.csproj
+++ b/templates/Uwp/Testing/UnitTests.App.xUnit/Param_ProjectName.Tests.xUnit/Param_ProjectName.Tests.xUnit.csproj
@@ -101,6 +101,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>16.8.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />


### PR DESCRIPTION
**Quick summary of changes**
Move Microsoft.NET.Test.Sdk packages to csproj/vbproj file.

**Which issue does this PR relate to?**
#3940 Test App with xUnit NuGet Package Microsoft.NET.Test.Sdk Upgrade Issue 

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| Yes | No |No |

