### PR TITLE
Exclude testing projects from WPF WACK tests

### DIFF
--- a/code/test/Templates.Test/WACK/Wpf/WindowsAppCertKitTests.cs
+++ b/code/test/Templates.Test/WACK/Wpf/WindowsAppCertKitTests.cs
@@ -72,6 +72,8 @@ namespace Microsoft.Templates.Test.Wack.Wpf
                 && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                 && (t.GetFrontEndFrameworkList().Contains(framework) || t.GetFrontEndFrameworkList().Contains(All))
                 && !t.GroupIdentity.StartsWith("wts.Wpf.Service.Identity")
+                && !t.GroupIdentity.Contains("Test")
+                && !t.GroupIdentity.Contains("WinAppDriver")
                 && t.GetPlatform() == platform
                 && !t.GetIsHidden();
 


### PR DESCRIPTION
**Quick summary of changes**
Exclude testing projects from WPF WACK tests

**Which issue does this PR relate to?**
#3613 WPF Testing Templates
