### PR TITLE
WinUI 3 Desktop Mockup adaptions

### DIFF
--- a/mockup/WinUI3/WinUIDesktopApp (Package)/WinUIDesktopApp (Package).wapproj
+++ b/mockup/WinUI3/WinUIDesktopApp (Package)/WinUIDesktopApp (Package).wapproj
@@ -67,11 +67,6 @@
       <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <SDKReference Include="Microsoft.VCLibs.Desktop, Version=14.0" />
-    <!-- Needed for ucrtbased.dll when running a debug build. -->
-    <SDKReference Include="Microsoft.VCLibs, Version=14.0" Condition="'$(Configuration)' == 'Debug'" />
-  </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <Import Project="$(AppxTargetsLocation)Microsoft.WinUI.AppX.targets" />
 </Project>

--- a/mockup/WinUI3/WinUIDesktopApp/App.xaml.cs
+++ b/mockup/WinUI3/WinUIDesktopApp/App.xaml.cs
@@ -4,9 +4,9 @@ using Microsoft.UI.Xaml;
 
 using WinUIDesktopApp.Activation;
 using WinUIDesktopApp.Contracts.Services;
-using WinUIDesktopApp.Contracts.Views;
 using WinUIDesktopApp.Core.Contracts.Services;
 using WinUIDesktopApp.Core.Services;
+using WinUIDesktopApp.Helpers;
 using WinUIDesktopApp.Services;
 using WinUIDesktopApp.ViewModels;
 using WinUIDesktopApp.Views;
@@ -16,7 +16,7 @@ namespace WinUIDesktopApp
 {
     public partial class App : Application
     {
-        public static Window MainWindow { get; set; }
+        public static Window MainWindow { get; set; } = new Window() { Title = "AppDisplayName".GetLocalized() };
 
         public App()
         {
@@ -74,7 +74,7 @@ namespace WinUIDesktopApp
             services.AddSingleton<ISampleDataService, SampleDataService>();
 
             // Views and ViewModels
-            services.AddTransient<IShellWindow, ShellWindow>();
+            services.AddTransient<ShellPage>();
             services.AddTransient<ShellViewModel>();
 
             services.AddTransient<MainViewModel>();

--- a/mockup/WinUI3/WinUIDesktopApp/Contracts/Views/IShellWindow.cs
+++ b/mockup/WinUI3/WinUIDesktopApp/Contracts/Views/IShellWindow.cs
@@ -1,6 +1,0 @@
-﻿namespace WinUIDesktopApp.Contracts.Views
-{
-    public interface IShellWindow
-    {
-    }
-}

--- a/mockup/WinUI3/WinUIDesktopApp/Services/ActivationService.cs
+++ b/mockup/WinUI3/WinUIDesktopApp/Services/ActivationService.cs
@@ -1,25 +1,25 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
+using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.UI.Xaml;
-
+using Microsoft.UI.Xaml.Controls;
 using WinUIDesktopApp.Activation;
 using WinUIDesktopApp.Contracts.Services;
-using WinUIDesktopApp.Contracts.Views;
+using WinUIDesktopApp.Views;
 
 namespace WinUIDesktopApp.Services
 {
     public class ActivationService : IActivationService
-    {
+    {        
         private readonly ActivationHandler<LaunchActivatedEventArgs> _defaultHandler;
         private readonly IEnumerable<IActivationHandler> _activationHandlers;
         private readonly INavigationService _navigationService;
         private readonly IThemeSelectorService _themeSelectorService;
+        private UIElement _shell = null;
 
-        public ActivationService(IShellWindow shellWindow, ActivationHandler<LaunchActivatedEventArgs> defaultHandler, IEnumerable<IActivationHandler> activationHandlers, INavigationService navigationService, IThemeSelectorService themeSelectorService)
+        public ActivationService(ActivationHandler<LaunchActivatedEventArgs> defaultHandler, IEnumerable<IActivationHandler> activationHandlers, INavigationService navigationService, IThemeSelectorService themeSelectorService)
         {
-            App.MainWindow = shellWindow as Window;
             _defaultHandler = defaultHandler;
             _activationHandlers = activationHandlers;
             _navigationService = navigationService;
@@ -28,18 +28,31 @@ namespace WinUIDesktopApp.Services
 
         public async Task ActivateAsync(object activationArgs)
         {
-            // Initialize services that you need before app activation
-            // take into account that the splash screen is shown while this code runs.
-            await InitializeAsync();
+            if (IsInteractive(activationArgs))
+            {
+                // Initialize services that you need before app activation
+                // take into account that the splash screen is shown while this code runs.
+                await InitializeAsync();
 
-            App.MainWindow.Activate();
+                if (App.MainWindow.Content == null)
+                {
+                    _shell = Ioc.Default.GetService<ShellPage>();
+                    App.MainWindow.Content = _shell ?? new Frame();
+                }
+            }
 
             // Depending on activationArgs one of ActivationHandlers or DefaultActivationHandler
             // will navigate to the first page
             await HandleActivationAsync(activationArgs);
 
-            // Tasks after activation
-            await StartupAsync();
+            if (IsInteractive(activationArgs))
+            {
+                // Ensure the current window is active
+                App.MainWindow.Activate();
+
+                // Tasks after activation
+                await StartupAsync();
+            }
         }
 
         private async Task HandleActivationAsync(object activationArgs)
@@ -68,6 +81,11 @@ namespace WinUIDesktopApp.Services
         {
             await _themeSelectorService.SetRequestedThemeAsync();
             await Task.CompletedTask;
+        }
+
+        private bool IsInteractive(object args)
+        {
+            return true;
         }
     }
 }

--- a/mockup/WinUI3/WinUIDesktopApp/Services/NavigationService.cs
+++ b/mockup/WinUI3/WinUIDesktopApp/Services/NavigationService.cs
@@ -23,7 +23,7 @@ namespace WinUIDesktopApp.Services
             {
                 if (_frame == null)
                 {
-                    _frame = Window.Current.Content as Frame;
+                    _frame = App.MainWindow.Content as Frame;
                     RegisterFrameEvents();
                 }
 

--- a/mockup/WinUI3/WinUIDesktopApp/Views/ShellPage.xaml
+++ b/mockup/WinUI3/WinUIDesktopApp/Views/ShellPage.xaml
@@ -1,5 +1,5 @@
-﻿<Window
-    x:Class="WinUIDesktopApp.Views.ShellWindow"
+﻿<Page
+    x:Class="WinUIDesktopApp.Views.ShellPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -62,4 +62,4 @@
             <Frame x:Name="shellFrame" />
         </Grid>
     </NavigationView>
-</Window>
+</Page>

--- a/mockup/WinUI3/WinUIDesktopApp/Views/ShellPage.xaml.cs
+++ b/mockup/WinUI3/WinUIDesktopApp/Views/ShellPage.xaml.cs
@@ -1,19 +1,15 @@
-﻿using Microsoft.UI.Xaml;
-
-using WinUIDesktopApp.Contracts.Views;
-using WinUIDesktopApp.Helpers;
+﻿using Microsoft.UI.Xaml.Controls;
 using WinUIDesktopApp.ViewModels;
 
 namespace WinUIDesktopApp.Views
 {
     // TODO WTS: Change the icons and titles for all NavigationViewItems in ShellWindow.xaml.
-    public sealed partial class ShellWindow : Window, IShellWindow
+    public sealed partial class ShellPage : Page
     {
         public ShellViewModel ViewModel { get; }
 
-        public ShellWindow(ShellViewModel viewModel)
+        public ShellPage(ShellViewModel viewModel)
         {
-            Title = "AppDisplayName".GetLocalized();
             ViewModel = viewModel;
             InitializeComponent();
             ViewModel.NavigationService.Frame = shellFrame;


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Adapt WinUI 3 Desktop Mockup for sharing code between different app models (Desktop and UWP)
 - Use ShellPage instead of  ShellWindow to host the navigation view (Creating a new Window with this ShellPage as Content).
 - Add `IsInteractive` check to ActivationService to support non-interactive activations (i.e. BackgroundTask).
 - Prepare ActivationService and NavigationService for Blank projects support.

**Which issue does this PR relate to?**
Proposal: C# Templates for WinUI 3 #3810
WinUI 3 Desktop App NavigationService should not use Window.Currrent #4032

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No | No | Yes |