### PR TITLE
Set CanReorderFalse in UWP TreeView Page Template

### DIFF
--- a/templates/Uwp/Pages/TreeView.CodeBehind._VB/Views/wts.ItemNamePage.xaml
+++ b/templates/Uwp/Pages/TreeView.CodeBehind._VB/Views/wts.ItemNamePage.xaml
@@ -305,6 +305,7 @@
                 x:Name="treeView"
                 Grid.Row="1"
                 SelectionMode="Single"
+                CanReorderItems="False"
                 ItemsSource="{x:Bind SampleItems}"
                 ItemInvoked="OnItemInvoked"
                 ItemTemplateSelector="{StaticResource TreeViewTemplateSelector}" />

--- a/templates/Uwp/Pages/TreeView.CodeBehind/Views/wts.ItemNamePage.xaml
+++ b/templates/Uwp/Pages/TreeView.CodeBehind/Views/wts.ItemNamePage.xaml
@@ -305,6 +305,7 @@
                 x:Name="treeView"
                 Grid.Row="1"
                 SelectionMode="Single"
+                CanReorderItems="False"
                 ItemsSource="{x:Bind SampleItems}"
                 ItemInvoked="OnItemInvoked"
                 ItemTemplateSelector="{StaticResource TreeViewTemplateSelector}" />

--- a/templates/Uwp/Pages/TreeView.Prism/Param_ProjectName/Views/wts.ItemNamePage.xaml
+++ b/templates/Uwp/Pages/TreeView.Prism/Param_ProjectName/Views/wts.ItemNamePage.xaml
@@ -308,6 +308,7 @@
                 x:Name="treeView"
                 Grid.Row="1"
                 SelectionMode="Single"
+                CanReorderItems="False"
                 ItemsSource="{x:Bind ViewModel.SampleItems}"
                 ItemTemplateSelector="{StaticResource TreeViewTemplateSelector}">
                 <i:Interaction.Behaviors>

--- a/templates/Uwp/Pages/TreeView._VB/Views/wts.ItemNamePage.xaml
+++ b/templates/Uwp/Pages/TreeView._VB/Views/wts.ItemNamePage.xaml
@@ -308,6 +308,7 @@
                 x:Name="treeView"
                 Grid.Row="1"
                 SelectionMode="Single"
+                CanReorderItems="False"
                 ItemsSource="{x:Bind ViewModel.SampleItems}"
                 ItemTemplateSelector="{StaticResource TreeViewTemplateSelector}">
                 <i:Interaction.Behaviors>

--- a/templates/Uwp/Pages/TreeView/Views/wts.ItemNamePage.xaml
+++ b/templates/Uwp/Pages/TreeView/Views/wts.ItemNamePage.xaml
@@ -308,6 +308,7 @@
                 x:Name="treeView"
                 Grid.Row="1"
                 SelectionMode="Single"
+                CanReorderItems="False"
                 ItemsSource="{x:Bind ViewModel.SampleItems}"
                 ItemTemplateSelector="{StaticResource TreeViewTemplateSelector}">
                 <i:Interaction.Behaviors>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Set CanReorderFalse in UWP TreeView Page Template

**Which issue does this PR relate to?**
TreeViewPage Exception on Drop TreeViewItem #4056

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| Yes | No | No |