### PR TITLE
Update Win UI 3 Templates to Preview 4

### DIFF
--- a/docs/WinUI/readme.md
+++ b/docs/WinUI/readme.md
@@ -25,12 +25,9 @@ If you miss anything or find an issue that is not mentioned in the known issues 
 
 
 ### Known issues:
-- [Dark/Light Theme issue](https://github.com/microsoft/microsoft-ui-xaml/issues/3384)
 - [Windows Default theme issue](https://github.com/microsoft/microsoft-ui-xaml/issues/3385)
 - [Master/Detail Issue with WinUI](https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3433)
 - [Localized tooltips issue](https://github.com/microsoft/microsoft-ui-xaml/issues/3649)
-- [DataGrid issue](https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3585)
-- [Read Theme from settings issue](https://github.com/microsoft/microsoft-ui-xaml/issues/3730)
 
 ### Additional docs:
 - [Windows UI Library 3 Preview 4 (November 2020)](https://docs.microsoft.com/windows/apps/winui/winui3/)

--- a/docs/WinUI/readme.md
+++ b/docs/WinUI/readme.md
@@ -33,6 +33,6 @@ If you miss anything or find an issue that is not mentioned in the known issues 
 - [Read Theme from settings issue](https://github.com/microsoft/microsoft-ui-xaml/issues/3730)
 
 ### Additional docs:
-- [Windows UI Library 3 Preview 3 (November 2020)](https://docs.microsoft.com/es-es/windows/apps/winui/winui3/)
+- [Windows UI Library 3 Preview 4 (November 2020)](https://docs.microsoft.com/windows/apps/winui/winui3/)
 - [Windows UI Library on GitHub](https://github.com/Microsoft/microsoft-ui-xaml)
-- [Windows Community Toolkit 8.0.0-preview3 for WinUI 3 Preview 3](https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3295)
+- [Windows Community Toolkit 8.0.0-preview4 for WinUI 3 Preview 4](https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3295)

--- a/templates/WinUI/Features/MSIXPackaging/Param_ProjectName (Package)/Param_ProjectName (Package).wapproj
+++ b/templates/WinUI/Features/MSIXPackaging/Param_ProjectName (Package)/Param_ProjectName (Package).wapproj
@@ -68,11 +68,6 @@
       <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <SDKReference Include="Microsoft.VCLibs.Desktop, Version=14.0" />
-    <!-- Needed for ucrtbased.dll when running a debug build. -->
-    <SDKReference Include="Microsoft.VCLibs, Version=14.0" Condition="'$(Configuration)' == 'Debug'" />
-  </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <Import Project="$(AppxTargetsLocation)Microsoft.WinUI.AppX.targets" />
 </Project>

--- a/templates/WinUI/Features/MSIXPackaging/Param_ProjectName (Package)/build/Microsoft.WinUI.AppX.targets
+++ b/templates/WinUI/Features/MSIXPackaging/Param_ProjectName (Package)/build/Microsoft.WinUI.AppX.targets
@@ -207,20 +207,23 @@
   </Target>
 
   <!--
-    Add a dependency for the app against VCLibs since it doesn't come with .NET only apps. C++ apps
-    will already have this dependency, but duplicate referenes are a no-op so there's no need to
-    condition the dependency.
-   -->
-  <ItemGroup Condition="'$(OutputType)' == 'AppContainerExe'">
+    Add a dependency for the app against VCLibs.Desktop, which contains the CRT DLLs that WinUI 3 is linked against. -->
+  <ItemGroup Condition="'$(OutputType)' == 'Exe' or '$(OutputType)' == 'AppContainerExe' or '$(MSBuildProjectExtension)'=='.wapproj'">
+    <SDKReference Include="Microsoft.VCLibs.Desktop, Version=14.0" />
+    <!-- Needed for ucrtbased.dll when running a debug build. -->
+    <SDKReference Include="Microsoft.UniversalCRT.Debug, Version=$(TargetPlatformVersion)" Condition="'$(Configuration)' == 'Debug'" />
+    <!-- Needed until Microsoft.ApplicationModel.Resources.dll and Microsoft.Web.WebView2.Core.dll
+         no longer depend on the _app version of CRT DLLs. -->
     <SDKReference Include="Microsoft.VCLibs, Version=14.0" />
   </ItemGroup>
 
-  <!-- Packaged desktop apps need these framework package references -->
-  <ItemGroup Condition="'$(MSBuildProjectExtension)'=='.wapproj'">
-    <SDKReference Include="Microsoft.VCLibs.Desktop, Version=14.0" />
-    <!-- Needed for ucrtbased.dll when running a debug build. -->
-    <SDKReference Include="Microsoft.VCLibs, Version=14.0" Condition="'$(Configuration)' == 'Debug'" />
-  </ItemGroup>
+  <!-- In order to have the Microsoft.UniversalCRT.Debug SDK reference included in the AppX, we need to
+       set IncludeSDKRedistOutputGroup to true. -->
+  <Target Name="IncludeSDKRedistOutputGroup" BeforeTargets="GetPackagingOutputs" Condition="('$(OutputType)' == 'AppContainerExe' or '$(MSBuildProjectExtension)'=='.wapproj') and '$(Configuration)' == 'Debug'">
+    <PropertyGroup>
+      <IncludeSDKRedistOutputGroup>true</IncludeSDKRedistOutputGroup>
+    </PropertyGroup>
+  </Target>
 
   <!--
     WindowsAppContainer is the property that you can set in your .NET Desktop project to turn it into a UWP.
@@ -234,5 +237,17 @@
       </ProjectReferenceWithExtraMetadata>
     </ItemGroup>
   </Target>
+
+  <!-- NuGet restore is now supported for wapproj files, so we need to supply an AssetTargetFallback value
+       in order for that not to raise an error. -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.wapproj'">
+    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion)</AssetTargetFallback>
+  </PropertyGroup>
+
+  <!-- See https://github.com/microsoft/CsWinRT/issues/373 -->
+  <Target Name="ValidateNoPublishTrimmed" BeforeTargets="PrepareForBuild" Condition="'$(PublishTrimmed)'=='true'">
+    <Error Text="Publishing with IL trimming is not yet supported."/>
+  </Target>
+
 </Project>
 <!--/+:msbuild-conditional:noEmit -->

--- a/templates/WinUI/Features/ThemeSelection/Services/ThemeSelectorService.cs
+++ b/templates/WinUI/Features/ThemeSelection/Services/ThemeSelectorService.cs
@@ -16,8 +16,7 @@ namespace Param_RootNamespace.Services
 
         public async Task InitializeAsync()
         {
-            // Temporarily commenting out as workaround for issue https://github.com/microsoft/WindowsTemplateStudio/issues/3984
-            // Theme = await LoadThemeFromSettingsAsync();
+            Theme = await LoadThemeFromSettingsAsync();
             await Task.CompletedTask;
         }
 
@@ -26,9 +25,7 @@ namespace Param_RootNamespace.Services
             Theme = theme;
 
             await SetRequestedThemeAsync();
-
-            // Temporarily commenting out as workaround for issue https://github.com/microsoft/WindowsTemplateStudio/issues/3984
-            // await SaveThemeInSettingsAsync(Theme);
+            await SaveThemeInSettingsAsync(Theme);
         }
 
         public async Task SetRequestedThemeAsync()

--- a/templates/WinUI/Pages/ContentGrid/.template.config/template.json
+++ b/templates/WinUI/Pages/ContentGrid/.template.config/template.json
@@ -68,7 +68,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Toolkit.Uwp.UI.Controls",
-        "version": "8.0.0-preview3",
+        "version": "8.0.0-preview4",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true

--- a/templates/WinUI/Pages/ContentGrid/Param_ProjectName/ViewModels/wts.ItemNameViewModel.cs
+++ b/templates/WinUI/Pages/ContentGrid/Param_ProjectName/ViewModels/wts.ItemNameViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;

--- a/templates/WinUI/Pages/DataGrid/.template.config/template.json
+++ b/templates/WinUI/Pages/DataGrid/.template.config/template.json
@@ -59,7 +59,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Toolkit.Uwp.UI.Controls",
-        "version": "8.0.0-preview3",
+        "version": "8.0.0-preview4",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -70,7 +70,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Toolkit.Uwp.UI.Controls.DataGrid",
-        "version": "8.0.0-preview3",
+        "version": "8.0.0-preview4",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true

--- a/templates/WinUI/Pages/DataGrid/.template.config/template.json
+++ b/templates/WinUI/Pages/DataGrid/.template.config/template.json
@@ -58,17 +58,6 @@
       "manualInstructions": [],
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
-        "packageId": "Microsoft.Toolkit.Uwp.UI.Controls",
-        "version": "8.0.0-preview4",
-        "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
-      },
-      "continueOnError": true
-    },
-    {
-      "description": "Add nuget package",
-      "manualInstructions": [],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
         "packageId": "Microsoft.Toolkit.Uwp.UI.Controls.DataGrid",
         "version": "8.0.0-preview4",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"

--- a/templates/WinUI/Pages/DataGrid/Param_ProjectName/ViewModels/wts.ItemNameViewModel.cs
+++ b/templates/WinUI/Pages/DataGrid/Param_ProjectName/ViewModels/wts.ItemNameViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Param_RootNamespace.Contracts.ViewModels;
 using Param_RootNamespace.Core.Contracts.Services;

--- a/templates/WinUI/Pages/MasterDetail/.template.config/template.json
+++ b/templates/WinUI/Pages/MasterDetail/.template.config/template.json
@@ -65,7 +65,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Toolkit.Uwp.UI.Controls",
-        "version": "8.0.0-preview3",
+        "version": "8.0.0-preview4",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true

--- a/templates/WinUI/Pages/Settings/ViewModels/wts.ItemNameViewModel.cs
+++ b/templates/WinUI/Pages/Settings/ViewModels/wts.ItemNameViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows.Input;
 using Microsoft.UI.Xaml;
 using Windows.ApplicationModel;
 using Param_RootNamespace.Contracts.Services;

--- a/templates/WinUI/Pages/WebView/Contracts/Services/IWebViewService.cs
+++ b/templates/WinUI/Pages/WebView/Contracts/Services/IWebViewService.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using Microsoft.UI.Xaml.Controls;
-using Windows.Web;
+using Microsoft.Web.WebView2.Core;
 
 namespace Param_RootNamespace.Contracts.Services
 {
     public interface IWebViewService
     {
-        event EventHandler<WebErrorStatus> NavigationCompleted;
+        event EventHandler<CoreWebView2WebErrorStatus> NavigationCompleted;
 
         bool CanGoBack { get; }
 

--- a/templates/WinUI/Pages/WebView/Services/WebViewService.cs
+++ b/templates/WinUI/Pages/WebView/Services/WebViewService.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.UI.Xaml.Controls;
-using Windows.Web;
+using Microsoft.Web.WebView2.Core;
 using Param_RootNamespace.Contracts.Services;
 
 namespace Param_RootNamespace.Services
@@ -15,7 +15,7 @@ namespace Param_RootNamespace.Services
         public bool CanGoForward
             => _webView.CanGoForward;
 
-        public event EventHandler<WebErrorStatus> NavigationCompleted;
+        public event EventHandler<CoreWebView2WebErrorStatus> NavigationCompleted;
 
         public WebViewService()
         {
@@ -32,7 +32,7 @@ namespace Param_RootNamespace.Services
             _webView.NavigationCompleted -= OnWebViewNavigationCompleted;
         }
 
-        private void OnWebViewNavigationCompleted(WebView2 sender, WebView2NavigationCompletedEventArgs args)
+        private void OnWebViewNavigationCompleted(WebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
         {
             NavigationCompleted?.Invoke(this, args.WebErrorStatus);
         }

--- a/templates/WinUI/Pages/WebView/ViewModels/wts.ItemNameViewModel.cs
+++ b/templates/WinUI/Pages/WebView/ViewModels/wts.ItemNameViewModel.cs
@@ -2,7 +2,7 @@
 using System.Windows.Input;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
-using Windows.Web;
+using Microsoft.Web.WebView2.Core;
 using Param_RootNamespace.Contracts.Services;
 using Param_RootNamespace.Contracts.ViewModels;
 
@@ -72,7 +72,7 @@ namespace Param_RootNamespace.ViewModels
             WebViewService.NavigationCompleted -= OnNavigationCompleted;
         }
 
-        private void OnNavigationCompleted(object sender, WebErrorStatus webErrorStatus)
+        private void OnNavigationCompleted(object sender, CoreWebView2WebErrorStatus webErrorStatus)
         {
             IsLoading = false;
             OnPropertyChanged(nameof(BrowserBackCommand));

--- a/templates/WinUI/Projects/Default/.template.config/template.json
+++ b/templates/WinUI/Projects/Default/.template.config/template.json
@@ -86,7 +86,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.Xaml.Behaviors.WinUI.Managed",
-        "version" : "2.0.3-rc4",
+        "version" : "2.0.3-rc5",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -97,7 +97,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.WinUI",
-        "version": "3.0.0-preview3.201113.0",
+        "version": "3.0.0-preview4.210210.4",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true

--- a/templates/WinUI/Projects/Default/.template.config/template.json
+++ b/templates/WinUI/Projects/Default/.template.config/template.json
@@ -18,7 +18,8 @@
     "wts.platform": "WinUI",
     "wts.outputToParent": "true",
     "wts.version": "1.0.0",
-    "wts.displayOrder": "0"
+    "wts.displayOrder": "0",
+    "wts.licenses": "[Microsoft.WinUI](https://www.nuget.org/packages/Microsoft.WinUI/3.0.0-preview4.210210.4/License)"
   },
   "sourceName": "wts.ProjectName",
   "preferNameDirectory": true,

--- a/templates/WinUI/Projects/Default/.template.config/template.json
+++ b/templates/WinUI/Projects/Default/.template.config/template.json
@@ -18,8 +18,7 @@
     "wts.platform": "WinUI",
     "wts.outputToParent": "true",
     "wts.version": "1.0.0",
-    "wts.displayOrder": "0",
-    "wts.licenses": "[Microsoft.Extensions.Hosting](https://licenses.nuget.org/Apache-2.0)"
+    "wts.displayOrder": "0"
   },
   "sourceName": "wts.ProjectName",
   "preferNameDirectory": true,

--- a/templates/WinUI/Projects/Default/wts.ProjectName/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/Properties/PublishProfiles/win10-arm64.pubxml
@@ -11,6 +11,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
+    <!--
+    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
+    -->
   </PropertyGroup>
 </Project>

--- a/templates/WinUI/Projects/Default/wts.ProjectName/Properties/PublishProfiles/win10-x64.pubxml
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/Properties/PublishProfiles/win10-x64.pubxml
@@ -11,6 +11,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
+    <!--
+    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
+    -->
   </PropertyGroup>
 </Project>

--- a/templates/WinUI/Projects/Default/wts.ProjectName/Properties/PublishProfiles/win10-x86.pubxml
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/Properties/PublishProfiles/win10-x86.pubxml
@@ -11,6 +11,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
+   <!--
+    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
+    -->
   </PropertyGroup>
 </Project>

--- a/templates/WinUI/Projects/Default/wts.ProjectName/app.manifest
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/app.manifest
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity version="1.0.0.0" name="wts.ProjectName.app"/>
+
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <!-- The combination of below two tags have the following effect:
+           1) Per-Monitor for >= Windows 10 Anniversary Update
+           2) System < Windows 10 Anniversary Update
+      -->
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>

--- a/templates/WinUI/_comp/MVVMToolkit/Project.SplitView/ViewModels/ShellViewModel.cs
+++ b/templates/WinUI/_comp/MVVMToolkit/Project.SplitView/ViewModels/ShellViewModel.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using System;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Xaml.Navigation;
 

--- a/templates/WinUI/_comp/MVVMToolkit/Project/.template.config/template.json
+++ b/templates/WinUI/_comp/MVVMToolkit/Project/.template.config/template.json
@@ -15,7 +15,8 @@
       "wts.version": "1.0.0",
       "wts.compositionOrder": "0",
       "wts.compositionFilter": "$frontendframework == MVVMToolkit & wts.type == project",
-      "wts.licenses": "[Microsoft.Toolkit](https://github.com/Microsoft/WindowsCommunityToolkit/blob/master/license.md)"
+      "wts.licenses": "[Microsoft.Extensions.DependencyInjection](https://licenses.nuget.org/MIT)|[Microsoft.Toolkit](https://github.com/Microsoft/WindowsCommunityToolkit/blob/master/license.md)"
+
     },
     "sourceName": "wts.ItemName",
     "preferNameDirectory": true,


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
 - Update WinUI 3 Templates to WinUI 3 Preview 4
 -  Uncomment setting storage access from ThemeSelectionService
 - Remove not user using statements and add missing system using to some ViewModels

**Which issue does this PR relate to?**
Update WinUI3 Templates to Preview 4 #4064
WinUI 3 Apps crash after reading Theme from SettingsStorage #3984
Theme is not applied to NavView items on App Startup when assigning Dark or Light Theme #3384

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| Yes | No | Yes |