### PR TITLE
Move our templates higher in the New Project Dialog list

### DIFF
--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.cs-CZ.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.cs-CZ.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.de-DE.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.de-DE.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.es-ES.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.es-ES.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.fr-FR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.fr-FR.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.it-IT.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.it-IT.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.ja-JP.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.ja-JP.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.ko-KR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.ko-KR.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.pl-PL.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.pl-PL.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.pt-BR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.pt-BR.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.ru-RU.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.ru-RU.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.tr-TR.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.tr-TR.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.zh-CN.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.zh-CN.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>

--- a/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.zh-TW.vstemplate
+++ b/code/src/ProjectTemplates/CSharp.WinUI.Solution/CSharp.WinUI.Solution.zh-TW.vstemplate
@@ -7,7 +7,7 @@
     <Description>Windows Template Studio quickly builds a WinUI Desktop app, using a wizard-based UI to turn your needs into a foundation of Windows 10 patterns and best practices.</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <SortOrder>1000</SortOrder>
+    <SortOrder>10</SortOrder>
     <TemplateID>Microsoft.CSharp.WinUI.WindowsTemplateStudio.local</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>App</DefaultName>


### PR DESCRIPTION
**Quick summary of changes**
Setting sortOrder to move our templates higher in the New Project Dialog list

**Which issue does this PR relate to?**
#4100 Move our templates higher up in the New Project Dialog template list

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No | No |Yes|

