### PR TITLE
remove VCRTForwarders nuget reference from winUI preview 4

### DIFF
--- a/code/Nuget.Config
+++ b/code/Nuget.Config
@@ -6,6 +6,7 @@
   </packageRestore>
   <packageSources>
     <clear />
+	<add key="wct" value="https://pkgs.dev.azure.com/dotnet/WindowsCommunityToolkit/_packaging/WindowsCommunityToolkit-WinUI3/nuget/v3/index.json" />
     <add key="wts" value="https://winappstudio.pkgs.visualstudio.com/WTS/_packaging/wts/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/templates/WinUI/Projects/Default/.template.config/template.json
+++ b/templates/WinUI/Projects/Default/.template.config/template.json
@@ -102,17 +102,6 @@
       "continueOnError": true
     },
     {
-      "description": "Add nuget package",
-      "manualInstructions": [ ],
-      "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
-      "args": {
-        "packageId": "Microsoft.VCRTForwarders.140",
-        "version": "1.0.6",
-        "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
-      },
-      "continueOnError": true
-    },
-    {
       "description": "Add reference to core project",
       "manualInstructions": [ ],
       "actionId": "849AAEB8-487D-45B3-94B9-77FA74E83A01",


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
 - Remove nuget package VCRTForwarders
 - Incude WindowsCommunityToolkit nuget in PackageSources

**Which issue does this PR relate to?**
 #4113 Remove nuget package VCRTForwarders from WinUI3 templates

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No | No |Yes |
