### PR TITLE
Details pages does not scroll using arrows

### DIFF
--- a/templates/Uwp/Pages/ContentGrid.CaliburnMicro/Views/ContentGridViewDetailPage.xaml
+++ b/templates/Uwp/Pages/ContentGrid.CaliburnMicro/Views/ContentGridViewDetailPage.xaml
@@ -29,7 +29,8 @@
         </VisualStateManager.VisualStateGroups>
 
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 x:Name="contentPanel">
                 <RelativePanel>

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind._VB/Views/ContentGridViewDetailPage.xaml
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind._VB/Views/ContentGridViewDetailPage.xaml
@@ -29,7 +29,8 @@
         </VisualStateManager.VisualStateGroups>
 
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 x:Name="contentPanel">
                 <RelativePanel>

--- a/templates/Uwp/Pages/ContentGrid.CodeBehind/Views/ContentGridViewDetailPage.xaml
+++ b/templates/Uwp/Pages/ContentGrid.CodeBehind/Views/ContentGridViewDetailPage.xaml
@@ -29,7 +29,8 @@
         </VisualStateManager.VisualStateGroups>
 
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 x:Name="contentPanel">
                 <RelativePanel>

--- a/templates/Uwp/Pages/ContentGrid.Prism/Param_ProjectName/Views/ContentGridViewDetailPage.xaml
+++ b/templates/Uwp/Pages/ContentGrid.Prism/Param_ProjectName/Views/ContentGridViewDetailPage.xaml
@@ -31,7 +31,8 @@
         </VisualStateManager.VisualStateGroups>
 
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 x:Name="contentPanel">
                 <RelativePanel>

--- a/templates/Uwp/Pages/ContentGrid._VB/Views/ContentGridViewDetailPage.xaml
+++ b/templates/Uwp/Pages/ContentGrid._VB/Views/ContentGridViewDetailPage.xaml
@@ -29,7 +29,8 @@
         </VisualStateManager.VisualStateGroups>
 
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 x:Name="contentPanel">
                 <RelativePanel>

--- a/templates/Uwp/Pages/ContentGrid/Views/ContentGridViewDetailPage.xaml
+++ b/templates/Uwp/Pages/ContentGrid/Views/ContentGridViewDetailPage.xaml
@@ -29,7 +29,8 @@
         </VisualStateManager.VisualStateGroups>
 
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 x:Name="contentPanel">
                 <RelativePanel>

--- a/templates/Uwp/Pages/MasterDetail.CaliburnMicro/Views/MasterDetailViewDetail/DetailsView.xaml
+++ b/templates/Uwp/Pages/MasterDetail.CaliburnMicro/Views/MasterDetailViewDetail/DetailsView.xaml
@@ -13,7 +13,8 @@
             Padding="{StaticResource DetailPageMargin}"
             HorizontalAlignment="Stretch"
             Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-            VerticalScrollMode="Enabled">
+            VerticalScrollMode="Enabled"
+            IsTabStop="True">
             <StackPanel HorizontalAlignment="Left">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                     <FontIcon

--- a/templates/Uwp/Pages/TwoPaneView.CodeBehind._VB/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView.CodeBehind._VB/Views/wts.ItemNameDetailControl.xaml
@@ -18,7 +18,7 @@
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
         VerticalScrollMode="Enabled"
-        IsTabStop="True"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal">
                 <FontIcon

--- a/templates/Uwp/Pages/TwoPaneView.CodeBehind._VB/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView.CodeBehind._VB/Views/wts.ItemNameDetailControl.xaml
@@ -86,7 +86,8 @@
                 Text="Order details:" />
             <ItemsControl
                 ItemsSource="{x:Bind SelectedItem.Details, Mode=OneWay}"
-                Margin="-12,0,0,0">
+                Margin="-12,0,0,0"
+                IsTabStop="False">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="models:SampleOrderDetail">
                         <Grid

--- a/templates/Uwp/Pages/TwoPaneView.CodeBehind._VB/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView.CodeBehind._VB/Views/wts.ItemNameDetailControl.xaml
@@ -17,7 +17,8 @@
         Padding="{StaticResource DetailPageMargin}"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        VerticalScrollMode="Enabled">
+        VerticalScrollMode="Enabled"
+        IsTabStop="True"
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal">
                 <FontIcon

--- a/templates/Uwp/Pages/TwoPaneView.CodeBehind/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView.CodeBehind/Views/wts.ItemNameDetailControl.xaml
@@ -86,7 +86,8 @@
                 Text="Order details:" />
             <ItemsControl
                 ItemsSource="{x:Bind SelectedItem.Details, Mode=OneWay}"
-                Margin="-12,0,0,0">
+                Margin="-12,0,0,0"
+                IsTabStop="False">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="models:SampleOrderDetail">
                         <Grid

--- a/templates/Uwp/Pages/TwoPaneView.CodeBehind/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView.CodeBehind/Views/wts.ItemNameDetailControl.xaml
@@ -17,7 +17,8 @@
         Padding="{StaticResource DetailPageMargin}"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        VerticalScrollMode="Enabled">
+        VerticalScrollMode="Enabled"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal">
                 <FontIcon

--- a/templates/Uwp/Pages/TwoPaneView.Prism/Param_ProjectName/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView.Prism/Param_ProjectName/Views/wts.ItemNameDetailControl.xaml
@@ -86,7 +86,8 @@
                 Text="Order details:" />
             <ItemsControl
                 ItemsSource="{x:Bind SelectedItem.Details, Mode=OneWay}"
-                Margin="-12,0,0,0">
+                Margin="-12,0,0,0"
+                IsTabStop="False">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="models:SampleOrderDetail">
                         <Grid

--- a/templates/Uwp/Pages/TwoPaneView.Prism/Param_ProjectName/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView.Prism/Param_ProjectName/Views/wts.ItemNameDetailControl.xaml
@@ -17,7 +17,8 @@
         Padding="{StaticResource DetailPageMargin}"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        VerticalScrollMode="Enabled">
+        VerticalScrollMode="Enabled"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal">
                 <FontIcon

--- a/templates/Uwp/Pages/TwoPaneView._VB/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView._VB/Views/wts.ItemNameDetailControl.xaml
@@ -86,7 +86,8 @@
                 Text="Order details:" />
             <ItemsControl
                 ItemsSource="{x:Bind SelectedItem.Details, Mode=OneWay}"
-                Margin="-12,0,0,0">
+                Margin="-12,0,0,0"
+                IsTabStop="False">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="models:SampleOrderDetail">
                         <Grid

--- a/templates/Uwp/Pages/TwoPaneView._VB/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView._VB/Views/wts.ItemNameDetailControl.xaml
@@ -17,7 +17,8 @@
         Padding="{StaticResource DetailPageMargin}"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        VerticalScrollMode="Enabled">
+        VerticalScrollMode="Enabled"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal">
                 <FontIcon

--- a/templates/Uwp/Pages/TwoPaneView/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView/Views/wts.ItemNameDetailControl.xaml
@@ -86,7 +86,8 @@
                 Text="Order details:" />
             <ItemsControl
                 ItemsSource="{x:Bind SelectedItem.Details, Mode=OneWay}"
-                Margin="-12,0,0,0">
+                Margin="-12,0,0,0"
+                IsTabStop="False">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="models:SampleOrderDetail">
                         <Grid

--- a/templates/Uwp/Pages/TwoPaneView/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/Pages/TwoPaneView/Views/wts.ItemNameDetailControl.xaml
@@ -17,7 +17,8 @@
         Padding="{StaticResource DetailPageMargin}"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        VerticalScrollMode="Enabled">
+        VerticalScrollMode="Enabled"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal">
                 <FontIcon

--- a/templates/Uwp/_comp/CaliburnMicro/Page.ContentGrid.Blank/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CaliburnMicro/Page.ContentGrid.Blank/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -37,7 +37,8 @@
             Grid.Row="1"
             Grid.Column="1"
 <!--}]}-->
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumRightMargin}"

--- a/templates/Uwp/_comp/CaliburnMicro/Page.ContentGrid.Blank/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CaliburnMicro/Page.ContentGrid.Blank/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -35,13 +35,15 @@
         <ScrollViewer
 <!--{[{-->
             Grid.Row="1"
-            Grid.Column="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Padding="{StaticResource SmallLeftMargin}"
 <!--}]}-->
             x:Name="contentScroll"
             IsTabStop="True">
             <StackPanel
 <!--{[{-->
-                Margin="{StaticResource MediumRightMargin}"
+                Margin="{StaticResource MediumLeftRightMargin}"
 <!--}]}-->
                 x:Name="contentPanel">
             </StackPanel>

--- a/templates/Uwp/_comp/CaliburnMicro/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CaliburnMicro/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -7,7 +7,8 @@
         <VisualStateManager.VisualStateGroups>
         </VisualStateManager.VisualStateGroups>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumLeftRightMargin}"

--- a/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -33,7 +33,8 @@
             Grid.Row="1"
             Grid.Column="1"
 <!--}]}-->
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumRightMargin}"

--- a/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -31,13 +31,15 @@
         <ScrollViewer
 <!--{[{-->
             Grid.Row="1"
-            Grid.Column="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Padding="{StaticResource SmallLeftMargin}"
 <!--}]}-->
             x:Name="contentScroll"
             IsTabStop="True">
             <StackPanel
 <!--{[{-->
-                Margin="{StaticResource MediumRightMargin}"
+                Margin="{StaticResource MediumLeftRightMargin}"
 <!--}]}-->
                 x:Name="contentPanel">
             </StackPanel>

--- a/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -33,7 +33,8 @@
             Grid.Row="1"
             Grid.Column="1"
 <!--}]}-->
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumRightMargin}"

--- a/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -31,13 +31,15 @@
         <ScrollViewer
 <!--{[{-->
             Grid.Row="1"
-            Grid.Column="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Padding="{StaticResource SmallLeftMargin}"
 <!--}]}-->
             x:Name="contentScroll"
             IsTabStop="True">
             <StackPanel
 <!--{[{-->
-                Margin="{StaticResource MediumRightMargin}"
+                Margin="{StaticResource MediumLeftRightMargin}"
 <!--}]}-->
                 x:Name="contentPanel">
             </StackPanel>

--- a/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.SplitView.TabbedNav._VB/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.SplitView.TabbedNav._VB/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -7,7 +7,8 @@
         <VisualStateManager.VisualStateGroups>
         </VisualStateManager.VisualStateGroups>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumLeftRightMargin}"

--- a/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/CodeBehind/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -7,7 +7,8 @@
         <VisualStateManager.VisualStateGroups>
         </VisualStateManager.VisualStateGroups>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumLeftRightMargin}"

--- a/templates/Uwp/_comp/Prism/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/Prism/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -33,7 +33,8 @@
             Grid.Row="1"
             Grid.Column="1"
 <!--}]}-->
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumRightMargin}"

--- a/templates/Uwp/_comp/Prism/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/Prism/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -31,13 +31,15 @@
         <ScrollViewer
 <!--{[{-->
             Grid.Row="1"
-            Grid.Column="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Padding="{StaticResource SmallLeftMargin}"
 <!--}]}-->
             x:Name="contentScroll"
             IsTabStop="True">
             <StackPanel
 <!--{[{-->
-                Margin="{StaticResource MediumRightMargin}"
+                Margin="{StaticResource MediumLeftRightMargin}"
 <!--}]}-->
                 x:Name="contentPanel">
             </StackPanel>

--- a/templates/Uwp/_comp/Prism/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/Prism/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -7,7 +7,8 @@
         <VisualStateManager.VisualStateGroups>
         </VisualStateManager.VisualStateGroups>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumLeftRightMargin}"

--- a/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -33,7 +33,8 @@
             Grid.Row="1"
             Grid.Column="1"
 <!--}]}-->
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumRightMargin}"

--- a/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar._VB/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -31,13 +31,15 @@
         <ScrollViewer
 <!--{[{-->
             Grid.Row="1"
-            Grid.Column="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Padding="{StaticResource SmallLeftMargin}"
 <!--}]}-->
             x:Name="contentScroll"
             IsTabStop="True">
             <StackPanel
 <!--{[{-->
-                Margin="{StaticResource MediumRightMargin}"
+                Margin="{StaticResource MediumLeftRightMargin}"
 <!--}]}-->
                 x:Name="contentPanel">
             </StackPanel>

--- a/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -33,7 +33,8 @@
             Grid.Row="1"
             Grid.Column="1"
 <!--}]}-->
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumRightMargin}"

--- a/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/_shared/Page.ContentGrid.Blank.MenuBar/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -31,13 +31,15 @@
         <ScrollViewer
 <!--{[{-->
             Grid.Row="1"
-            Grid.Column="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Padding="{StaticResource SmallLeftMargin}"
 <!--}]}-->
             x:Name="contentScroll"
             IsTabStop="True">
             <StackPanel
 <!--{[{-->
-                Margin="{StaticResource MediumRightMargin}"
+                Margin="{StaticResource MediumLeftRightMargin}"
 <!--}]}-->
                 x:Name="contentPanel">
             </StackPanel>

--- a/templates/Uwp/_comp/_shared/Page.ContentGrid.SplitView.TabbedNav._VB/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/_shared/Page.ContentGrid.SplitView.TabbedNav._VB/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -7,7 +7,8 @@
         <VisualStateManager.VisualStateGroups>
         </VisualStateManager.VisualStateGroups>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumLeftRightMargin}"

--- a/templates/Uwp/_comp/_shared/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
+++ b/templates/Uwp/_comp/_shared/Page.ContentGrid.SplitView.TabbedNav/Views/wts.ItemNameDetailPage_postaction.xaml
@@ -7,7 +7,8 @@
         <VisualStateManager.VisualStateGroups>
         </VisualStateManager.VisualStateGroups>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
 <!--{[{-->
                 Margin="{StaticResource MediumLeftRightMargin}"

--- a/templates/Uwp/_comp/_shared/Page.MasterDetail._VB/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/_comp/_shared/Page.MasterDetail._VB/Views/wts.ItemNameDetailControl.xaml
@@ -12,7 +12,8 @@
         Padding="{StaticResource DetailPageMargin}"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        VerticalScrollMode="Enabled">
+        VerticalScrollMode="Enabled"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                 <FontIcon

--- a/templates/Uwp/_comp/_shared/Page.MasterDetail/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/Uwp/_comp/_shared/Page.MasterDetail/Views/wts.ItemNameDetailControl.xaml
@@ -12,7 +12,8 @@
         Padding="{StaticResource DetailPageMargin}"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        VerticalScrollMode="Enabled">
+        VerticalScrollMode="Enabled"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                 <FontIcon

--- a/templates/WinUI/Pages/ContentGrid/Param_ProjectName/Views/wts.ItemNameDetailPage.xaml
+++ b/templates/WinUI/Pages/ContentGrid/Param_ProjectName/Views/wts.ItemNameDetailPage.xaml
@@ -30,7 +30,8 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
-        <ScrollViewer>
+        <ScrollViewer
+            IsTabStop="True">
             <StackPanel
                 Margin="{StaticResource MediumLeftRightMargin}"
                 x:Name="contentPanel">

--- a/templates/WinUI/Pages/MasterDetail/Param_ProjectName/Views/wts.ItemNameDetailControl.xaml
+++ b/templates/WinUI/Pages/MasterDetail/Param_ProjectName/Views/wts.ItemNameDetailControl.xaml
@@ -10,7 +10,8 @@
         HorizontalAlignment="Stretch"
         VerticalScrollMode="Enabled"
         Padding="{StaticResource DetailPageMargin}"
-        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+        IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                 <FontIcon

--- a/templates/Wpf/Pages/ContentGrid.CodeBehind/Param_ProjectName/Views/wts.ItemNameDetailPage.xaml
+++ b/templates/Wpf/Pages/ContentGrid.CodeBehind/Param_ProjectName/Views/wts.ItemNameDetailPage.xaml
@@ -8,7 +8,8 @@
     d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 Margin="{StaticResource MediumLeftTopRightBottomMargin}">
                 <Grid>

--- a/templates/Wpf/Pages/ContentGrid/Param_ProjectName/Views/wts.ItemNameDetailPage.xaml
+++ b/templates/Wpf/Pages/ContentGrid/Param_ProjectName/Views/wts.ItemNameDetailPage.xaml
@@ -8,7 +8,8 @@
     d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
         <ScrollViewer
-            x:Name="contentScroll">
+            x:Name="contentScroll"
+            IsTabStop="True">
             <StackPanel
                 Margin="{StaticResource MediumLeftTopRightBottomMargin}">
                 <Grid>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
- Add tag IsTabStop to allow arrow scrolling on MasterDetail and ContentGrid
- Modify postaction template generations on MasterDetail and ContentGrid

**Which issue does this PR relate to?**
Details pages does not scroll using arrows #4062

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| Yes | Yes |Yes |

