### PR TITLE
Don't save or refresh theme when not changed [WinUI3]

### DIFF
--- a/templates/WinUI/Pages/Settings/ViewModels/wts.ItemNameViewModel.cs
+++ b/templates/WinUI/Pages/Settings/ViewModels/wts.ItemNameViewModel.cs
@@ -38,8 +38,11 @@ namespace Param_RootNamespace.ViewModels
                     _switchThemeCommand = new RelayCommand<ElementTheme>(
                         async (param) =>
                         {
-                            ElementTheme = param;
-                            await _themeSelectorService.SetThemeAsync(param);
+                            if (ElementTheme != param)
+                            {
+                                ElementTheme = param;
+                                await _themeSelectorService.SetThemeAsync(param);
+                            }
                         });
                 }
 


### PR DESCRIPTION

# PR checklist

**Quick summary of changes**

Don't refresh UI or save selected theme when it hasn't changed. (Because user clicks already selected option.)

**Which issue does this PR relate to?**

For #4130

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No | No |Yes |

**Anything that requires particular review or attention?**

no

**Do all automated tests pass?**

yes

**Have automated tests been added for new features?**

n/a

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

n/a

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/WindowsTemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/WPF/getting-started-endusers.md) getting started doc.

n/a

**Have you raised issues for any needed follow-on work?**

n/a

**Have docs been updated?**

n/a

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**

n/a
