### PR TITLE
Add rightclick options for WinUI UWP projects

### DIFF
--- a/code/src/UI/Services/ProjectConfigInfoService.cs
+++ b/code/src/UI/Services/ProjectConfigInfoService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Templates.UI.Services
         // Framework
         public const string MVVMBasic = "MVVMBasic";
         public const string MVVMLight = "MVVMLight";
-        public const string CodeBehid = "CodeBehind";
+        public const string CodeBehind = "CodeBehind";
         public const string CaliburnMicro = "CaliburnMicro";
         public const string Prism = "Prism";
         public const string MvvmToolkit = "MVVMToolkit";
@@ -101,17 +101,17 @@ namespace Microsoft.Templates.UI.Services
 
         public string InferPlatform()
         {
-            if (IsUwp())
+            if (IsWinUI())
+            {
+                return Platforms.WinUI;
+            }
+            else if (IsUwp())
             {
                 return Platforms.Uwp;
             }
             else if (IsWpf())
             {
                 return Platforms.Wpf;
-            }
-            else if (IsWinUI())
-            {
-                return Platforms.WinUI;
             }
 
             throw new Exception(StringRes.ErrorUnableResolvePlatform);
@@ -177,7 +177,7 @@ namespace Microsoft.Templates.UI.Services
             }
             else if (IsCodeBehind(platform))
             {
-                return CodeBehid;
+                return CodeBehind;
             }
             else if (IsCaliburnMicro(platform))
             {
@@ -208,7 +208,9 @@ namespace Microsoft.Templates.UI.Services
                         && !FileContainsLine("Views", "ShellWindow.xaml", "<controls:HamburgerMenu")
                         && !FileContainsLine("Views", "ShellWindow.xaml", "<Fluent:Ribbon x:Name=\"ribbonControl\" Grid.Row=\"0\">");
                 case Platforms.WinUI:
-                    return IsCppProject();
+                    return !(ExistsFileInProjectPath("Views", "ShellWindow.xaml")
+                        || ExistsFileInProjectPath("Views", "ShellPage.xaml")
+                        || IsCppProject());
                 default:
                     return false;
             }
@@ -363,7 +365,23 @@ namespace Microsoft.Templates.UI.Services
 
                     return false;
                 case Platforms.WinUI:
-                    return IsCppProject();
+                    if (IsCSharpProject())
+                    {
+                        var codebehindFile = Directory.GetFiles(Path.Combine(_shell.GetActiveProjectPath()), "*.xaml.cs", SearchOption.AllDirectories).FirstOrDefault();
+                        if (!string.IsNullOrEmpty(codebehindFile))
+                        {
+                            var fileContent = File.ReadAllText(codebehindFile);
+                            return !fileContent.Contains("ViewModel");
+                        }
+                    }
+
+                    if (IsCppProject())
+                    {
+                        return true;
+                    }
+
+                    return false;
+
                 default:
                     return false;
             }

--- a/code/src/UI/VisualStudio/RightClickActions.cs
+++ b/code/src/UI/VisualStudio/RightClickActions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Templates.UI.VisualStudio
             new RightClickAvailability(Platforms.Uwp, ProgrammingLanguages.VisualBasic) { TemplateTypes = new List<TemplateType>() { TemplateType.Page, TemplateType.Feature, TemplateType.Service, TemplateType.Testing } },
             new RightClickAvailability(Platforms.Wpf, ProgrammingLanguages.CSharp) { TemplateTypes = new List<TemplateType>() { TemplateType.Page, TemplateType.Feature, TemplateType.Testing } },
             new RightClickAvailability(Platforms.WinUI, ProgrammingLanguages.CSharp, AppModels.Desktop) { TemplateTypes = new List<TemplateType>() { TemplateType.Page, TemplateType.Feature } },
+            new RightClickAvailability(Platforms.WinUI, ProgrammingLanguages.CSharp, AppModels.Uwp) { TemplateTypes = new List<TemplateType>() { TemplateType.Page } },
             new RightClickAvailability(Platforms.WinUI, ProgrammingLanguages.Cpp, AppModels.Desktop) { TemplateTypes = new List<TemplateType>() { TemplateType.Page } },
             new RightClickAvailability(Platforms.WinUI, ProgrammingLanguages.Cpp, AppModels.Uwp) { TemplateTypes = new List<TemplateType>() { TemplateType.Page } },
         };
@@ -65,10 +66,6 @@ namespace Microsoft.Templates.UI.VisualStudio
         public void AddNewPage()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            if (!_shell.GetActiveProjectIsWts())
-            {
-                return;
-            }
 
             try
             {
@@ -86,10 +83,6 @@ namespace Microsoft.Templates.UI.VisualStudio
         public void AddNewFeature()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            if (!_shell.GetActiveProjectIsWts())
-            {
-                return;
-            }
 
             try
             {
@@ -107,10 +100,6 @@ namespace Microsoft.Templates.UI.VisualStudio
         public void AddNewService()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            if (!_shell.GetActiveProjectIsWts())
-            {
-                return;
-            }
 
             try
             {
@@ -128,10 +117,6 @@ namespace Microsoft.Templates.UI.VisualStudio
         public void AddNewTesting()
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            if (!_shell.GetActiveProjectIsWts())
-            {
-                return;
-            }
 
             try
             {

--- a/templates/WinUI/_comp/MVVMToolkit/Project/Services/NavigationService.cs
+++ b/templates/WinUI/_comp/MVVMToolkit/Project/Services/NavigationService.cs
@@ -69,6 +69,7 @@ namespace Param_RootNamespace.Services
                 {
                     navigationAware.OnNavigatedFrom();
                 }
+
                 return true;
             }
 


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
- Add rightclick options for C# WinUI UWP projects
- Add infer methods for Project Type Blank and Framework Codebehind for C# WinUI projects

**Which issue does this PR relate to?**
#4042 

