### PR TITLE
Refactor script that does template id replacements for different environments

### DIFF
--- a/_build/ProjectTemplate-SetPublishingData.ps1
+++ b/_build/ProjectTemplate-SetPublishingData.ps1
@@ -1,41 +1,28 @@
 [CmdletBinding()]
 Param(
   [Parameter(Mandatory=$True,Position=1)]
-  [string]$uwpname,
+  [string]$buildNumber,
 
   [Parameter(Mandatory=$True,Position=2)]
-  [string]$wpfname,
+  [AllowEmptyString()]
+  [string]$environmentname,
 
-  [Parameter(Mandatory=$True,Position=3)]
-  [string]$winuidesktopname,
-
-  [Parameter(Mandatory=$True,Position=4)]
-  [string]$winuiuwpname,
-
-  [Parameter(Mandatory=$True,Position=5)]
-  [string]$csharpuwptemplateId,
-
-  [Parameter(Mandatory=$True,Position=6)]
-  [string]$csharpwpftemplateId,
-
-  [Parameter(Mandatory=$True,Position=7)]
-  [string]$csharpwinuidesktoptemplateId,
-
-  [Parameter(Mandatory=$True,Position=8)]
-  [string]$csharpwinuiuwptemplateId,
-
-  [Parameter(Mandatory=$True,Position=9)]
-  [string]$cppwinuidesktoptemplateId,
-
-  [Parameter(Mandatory=$True,Position=10)]
-  [string]$cppwinuiuwptemplateId,
-
-  [Parameter(Mandatory=$True,Position=11)]
-  [string]$visualbasictemplateId,
-
-  [Parameter(Mandatory=$True,Position=12)]
-  [string]$buildNumber
+  [Parameter(Mandatory=$True, Position=3)]
+  [AllowEmptyString()]
+  [string]$environmentid
 )
+
+## EXPECTED VALUES: 
+##  buildnumber in format pipelinename_0.22.21082.01
+##  DEV: 
+##    environmentname: "; dev-nightly"
+##    environmentid:   ".dev"
+##  PRE: 
+##    environmentname: "; pre-release"
+##    environmentid:   ".pre"
+##  PRO: 
+##    environmentname: ""
+##    environmentid:   ""
 
 $VersionRegex = "(\d+)\.(\d+)\.(\d+)\.(\d+)"
 
@@ -49,82 +36,72 @@ else{
 	throw "Build format does not match the expected pattern (buildName_w.x.y.z)"
 }
 
-## SET DATA IN PROJECT TEMPLATE 
-if($uwpname -and $wpfname){
-  Write-Host "Setting data in vs project template files"
 
-  $projectTemplates = Get-ChildItem -include "*.vstemplate" -recurse |  Where-Object{ 
+## SET DATA IN PROJECT and ITEM TEMPLATE 
+if(($environmentname -eq '' -and $environmentid -eq '') -or ($environmentname -like '; *' -and $environmentid -like '.*' )){
+  Write-Host "Setting data in vs project and item template files"
+ 
+  $languages = "\d*(de-DE).|(cs-CZ).|(es-ES).|(fr-FR).|(it-IT).|(ja-JP).|(ko-KR).|(pl-PL).|(pt-BR).|(ru-RU).|(tr-TR).|(zh-CN).|(zh-TW).\d*"
+
+
+  $vstemplates = Get-ChildItem -include "*.vstemplate" -recurse |  Where-Object{ 
         $_.FullName -notmatch "\\Templates\\" -and 
         $_.FullName -notmatch "\\debug\\" -and
         $_.FullName -notmatch "\\obj\\" -and
-        $_.FullName -match "\\ProjectTemplates\\"
+        ($_.FullName -match "\\ProjectTemplates\\" -or $_.FullName -match "\\ItemTemplates\\")
     }
 
-  if($projectTemplates){
-    foreach( $projectTemplate in $projectTemplates){
-      if(Test-Path($projectTemplate)){
-        [xml]$templateContent = Get-Content $projectTemplate
 
-        $templateContent.VSTemplate.TemplateContent.CustomParameters.CustomParameter[2].Value = $versionNumber
-        if($templateContent.VSTemplate.TemplateData.TemplateID -eq 'Microsoft.CSharp.UWP.WindowsTemplateStudio.local')
+
+  if($vstemplates){
+    foreach( $vstemplate in $vstemplates){
+      if(Test-Path($vstemplate)){
+        [xml]$templateContent = Get-Content $vstemplate
+        
+        Write-Host
+        Write-Host $($vstemplate.Name)
+        Write-Host "Orig values: $($templateContent.VSTemplate.TemplateData.Name), $($templateContent.VSTemplate.TemplateData.TemplateID), $versionNumber"        
+
+        if ($templateContent.VSTemplate.TemplateData.Name -like "*; local*" -and $templateContent.VSTemplate.TemplateData.TemplateID -like "*.local")
         {
-           $templateContent.VSTemplate.TemplateData.TemplateID = $csharpuwptemplateId
-           $templateContent.VSTemplate.TemplateData.Name = $uwpname
+            if ($vstemplate -match $languages) {
+                $rootTemplate = $vstemplate -replace $languages, ""
+                if (($origRootTemplateFile -eq '') -or ($rootTemplate -ne $origRootTemplateFile)){
+                    if(Test-Path($rootTemplate)){
+                    
+                        $origRootTemplateFile = $rootTemplate
+                        [xml]$roottemplateContent = Get-Content $rootTemplate
 
-           Write-Host "$projectTemplate - Name, TemplateId & Version applied ($uwpname, $csharpuwptemplateId, $versionNumber)"
+                        if ($roottemplateContent.VSTemplate.TemplateData.Name -ne $templateContent.VSTemplate.TemplateData.Name -or $roottemplateContent.VSTemplate.TemplateData.TemplateID -ne $templateContent.VSTemplate.TemplateData.TemplateID)
+                        {              
+                            throw "Localized template name or id differs from root template name or id"
+                        }
+                    }
+                    else
+                    {
+                        throw "Root template not found"
+                    }
+                }
+            }
 
+             ## Set version number
+            $templateContent.VSTemplate.TemplateContent.CustomParameters.CustomParameter[2].Value = $versionNumber
+
+            #Replace template name
+            $templateContent.VSTemplate.TemplateData.Name = $templateContent.VSTemplate.TemplateData.Name -replace "; local", "$environmentname"
+
+            #Replace template id
+            $templateContent.VSTemplate.TemplateData.TemplateID = $templateContent.VSTemplate.TemplateData.TemplateID -replace ".local", $environmentid
+
+            Write-Host "New values:  $($templateContent.VSTemplate.TemplateData.Name), $($templateContent.VSTemplate.TemplateData.TemplateID), $versionNumber"                   
+
+            $templateContent.Save($vstemplate) 
+           
         }
-
-        if($templateContent.VSTemplate.TemplateData.TemplateID -eq 'Microsoft.CSharp.WPF.WindowsTemplateStudio.local')
+        else
         {
-           $templateContent.VSTemplate.TemplateData.TemplateID = $csharpwpftemplateId
-           $templateContent.VSTemplate.TemplateData.Name = $wpfname
-
-           Write-Host "$projectTemplate - Name, TemplateId & Version applied ($wpfname, $csharpwpftemplateId, $versionNumber)"
+            throw "Template Name must include '; local' and Template ID must include '.local'"
         }
-
-        if($templateContent.VSTemplate.TemplateData.TemplateID -eq 'Microsoft.CSharp.WinUI.Desktop.WindowsTemplateStudio.local')
-        {
-           $templateContent.VSTemplate.TemplateData.TemplateID = $csharpwinuidesktoptemplateId
-           $templateContent.VSTemplate.TemplateData.Name = $winuidesktopname
-
-           Write-Host "$projectTemplate - Name, TemplateId & Version applied ($winuidesktopname, $csharpwinuidesktoptemplateId, $versionNumber)"
-        }
-		
-		if($templateContent.VSTemplate.TemplateData.TemplateID -eq 'Microsoft.CSharp.WinUI.Uwp.WindowsTemplateStudio.local')
-        {
-           $templateContent.VSTemplate.TemplateData.TemplateID = $csharpwinuiuwptemplateId
-           $templateContent.VSTemplate.TemplateData.Name = $winuiuwpname
-
-           Write-Host "$projectTemplate - Name, TemplateId & Version applied ($winuiuwpname, $csharpwinuitemplateuwpId, $versionNumber)"
-        }
-
-        if($templateContent.VSTemplate.TemplateData.TemplateID -eq 'Microsoft.Cpp.WinUI.Desktop.WindowsTemplateStudio.local')
-        {
-           $templateContent.VSTemplate.TemplateData.TemplateID = $cppwinuidesktoptemplateId
-           $templateContent.VSTemplate.TemplateData.Name = $winuidesktopname
-
-           Write-Host "$projectTemplate - Name, TemplateId & Version applied ($winuidesktopname, $cppwinuidesktoptemplateId, $versionNumber)"
-        }
-
-        if($templateContent.VSTemplate.TemplateData.TemplateID -eq 'Microsoft.Cpp.WinUI.UWP.WindowsTemplateStudio.local')
-        {
-           $templateContent.VSTemplate.TemplateData.TemplateID = $cppwinuiuwptemplateId
-           $templateContent.VSTemplate.TemplateData.Name = $winuiuwpname
-
-           Write-Host "$projectTemplate - Name, TemplateId & Version applied ($winuiuwpname, $cppwinuiuwptemplateId, $versionNumber)"
-        }
-
-        if($templateContent.VSTemplate.TemplateData.TemplateID -eq 'Microsoft.VisualBasic.UWP.WindowsTemplateStudio.local')
-        {
-           $templateContent.VSTemplate.TemplateData.TemplateID = $visualbasictemplateId
-           $templateContent.VSTemplate.TemplateData.Name = $uwpname
-
-           Write-Host "$projectTemplate - Name, TemplateId & Version applied ($uwpname, $visualbasictemplateId, $versionNumber)"
-
-        }
-
-        $templateContent.Save($projectTemplate) 
 
       }
     }
@@ -134,5 +111,5 @@ if($uwpname -and $wpfname){
   }
 }
 else{
-  throw "Name is mandatory."
+  throw "Invalid environmentname or environmentid"
 }


### PR DESCRIPTION
**Quick summary of changes**

Refactor script to do replacements in template names and ids based on the passed environment configuration instead of passing more template ids and names.

The convention is that the "`.local`" in the vstemplate id and the "`; local`" in the vstemplate name should be replaced by the environment name and id passed as parameters.

**Which issue does this PR relate to?**
#4144, #4146

