### PR TITLE
Issue4095 Update to Reunion 0.5 (C++)

### DIFF
--- a/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.BlankPage/Cpp.WinUI.BlankPage.vstemplate
+++ b/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.BlankPage/Cpp.WinUI.BlankPage.vstemplate
@@ -29,9 +29,9 @@
   <WizardData>
     <packages>
       <package id="Microsoft.Windows.CppWinRT" version="2.0.210211.2" />
-      <package id="Microsoft.ProjectReunion" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0-prerelease" />
+      <package id="Microsoft.ProjectReunion" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.Desktop.BlankWindow/Cpp.WinUI.Desktop.BlankWindow.vstemplate
+++ b/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.Desktop.BlankWindow/Cpp.WinUI.Desktop.BlankWindow.vstemplate
@@ -28,9 +28,9 @@
   <WizardData>
     <packages>
       <package id="Microsoft.Windows.CppWinRT" version="2.0.210211.2" />
-      <package id="Microsoft.ProjectReunion" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0-prerelease" />
+      <package id="Microsoft.ProjectReunion" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.TemplatedControl/Cpp.WinUI.TemplatedControl.vstemplate
+++ b/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.TemplatedControl/Cpp.WinUI.TemplatedControl.vstemplate
@@ -32,9 +32,9 @@
   <WizardData>
     <packages>
       <package id="Microsoft.Windows.CppWinRT" version="2.0.210211.2" />
-      <package id="Microsoft.ProjectReunion" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0-prerelease" />
+      <package id="Microsoft.ProjectReunion" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.UserControl/Cpp.WinUI.UserControl.vstemplate
+++ b/code/src/ItemTemplates/WinUI/Cpp/Cpp.WinUI.UserControl/Cpp.WinUI.UserControl.vstemplate
@@ -29,9 +29,9 @@
   <WizardData>
     <packages>
       <package id="Microsoft.Windows.CppWinRT" version="2.0.210211.2" />
-      <package id="Microsoft.ProjectReunion" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0-prerelease" />
+      <package id="Microsoft.ProjectReunion" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/code/src/ProjectTemplates/WinUI/Cpp/Cpp.WinUI.RuntimeComponent/Cpp.WinUI.RuntimeComponent.vstemplate
+++ b/code/src/ProjectTemplates/WinUI/Cpp/Cpp.WinUI.RuntimeComponent/Cpp.WinUI.RuntimeComponent.vstemplate
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Windows Runtime Component (WinUI; local)</Name>
-    <Description>A project for creating a C++/WinRT Windows Runtime Component (.winmd) for both Desktop and Universal Windows Platform (UWP) apps, based on the Windows UI Library (WinUI).</Description>
+    <Name>Windows Runtime Component (WinUI 3; local)</Name>
+    <Description>A project for creating a C++/WinRT Windows Runtime Component (.winmd) for both Desktop and Universal Windows Platform (UWP) apps, based on the Windows UI Library (WinUI 3).</Description>
     <Icon>windowsTemplateStudio_Logo_256x256.png</Icon>
     <TemplateID>Microsoft.Cpp.WinUI.RuntimeComponent.WindowsTemplateStudio.local</TemplateID>
     <ProjectType>VC</ProjectType>
@@ -54,9 +54,9 @@
     <MinSupportedVersion>10.0.17763.0</MinSupportedVersion>
     <packages repository="extension" repositoryId="Microsoft.ProjectReunion">
       <package id="Microsoft.Windows.CppWinRT" version="2.0.210211.2" />
-      <package id="Microsoft.ProjectReunion" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0-prerelease" />
-      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0-prerelease" />
+      <package id="Microsoft.ProjectReunion" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.Foundation" version="0.5.0" />
+      <package id="Microsoft.ProjectReunion.WinUI" version="0.5.0" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/code/src/ProjectTemplates/WinUI/Cpp/Cpp.WinUI.RuntimeComponent/Cpp.WinUI.RuntimeComponent.vstemplate
+++ b/code/src/ProjectTemplates/WinUI/Cpp/Cpp.WinUI.RuntimeComponent/Cpp.WinUI.RuntimeComponent.vstemplate
@@ -14,7 +14,6 @@
     <NumberOfParentCategoriesToRollUp>2</NumberOfParentCategoriesToRollUp>
     <TargetPlatformName>Windows</TargetPlatformName>
     <CreateInPlace>true</CreateInPlace>
-    <PreviewImage>windowsTemplateStudio_Logo_256x256.png</PreviewImage>
     <AppIdFilter>blend</AppIdFilter>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
     <LanguageTag>cpp</LanguageTag>

--- a/code/test/Templates.Test/BaseGenAndBuildFixture.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildFixture.cs
@@ -424,6 +424,7 @@ namespace Microsoft.Templates.Test
                         var itemTemplates = GenContext.ToolBox.Repo.GetAll()
                             .Where(t =>
                             (t.GetFrontEndFrameworkList().Contains(framework) || t.GetFrontEndFrameworkList().Contains(All))
+                            && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                             && t.GetTemplateType().IsItemTemplate()
                             && t.GetPlatform() == platform
                             && t.GetLanguage() == language

--- a/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildCodeBehindProjectTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Templates.Test.Build.WinUI
 
             var projectPath = await AssertGenerateRightClickAsync(projectName, context, true);
 
-            AssertBuildProject(projectPath, projectName, platform);       
+            AssertBuildProject(projectPath, projectName, platform);
         }
 
         [Theory]

--- a/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildCodeBehindProjectTests.cs
@@ -113,6 +113,12 @@ namespace Microsoft.Templates.Test.Build.WinUI
         [Trait("Type", "BuildRightClick")]
         public async Task Build_Empty_AddRightClick_WinUIAsync(string projectType, string framework, string platform, string language, string appModel)
         {
+            //Skip Blank Desktop projects, as there is no right click here
+            if (projectType == "Blank" && appModel == "Desktop")
+            {
+                return;
+            }
+
             var projectName = $"{ShortProjectType(projectType)}AllRC";
 
             var context = new UserSelectionContext(language, platform)
@@ -124,7 +130,7 @@ namespace Microsoft.Templates.Test.Build.WinUI
 
             var projectPath = await AssertGenerateRightClickAsync(projectName, context, true);
 
-            AssertBuildProject(projectPath, projectName, platform);
+            AssertBuildProject(projectPath, projectName, platform);       
         }
 
         [Theory]

--- a/templates/WinUI/Features/MSIX.Cpp/Param_ProjectName (Package)/Param_ProjectName (Package).wapproj
+++ b/templates/WinUI/Features/MSIX.Cpp/Param_ProjectName (Package)/Param_ProjectName (Package).wapproj
@@ -42,7 +42,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
-    <AppxTargetsLocation Condition="'$(AppxTargetsLocation)'==''">$(MSBuildThisFileDirectory)build\</AppxTargetsLocation>
+    <EntryPointProjectUniqueName>..\Param_ProjectName\Param_ProjectName.vcxproj</EntryPointProjectUniqueName>
   </PropertyGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -63,28 +63,14 @@
       <SkipGetTargetFrameworkProperties>True</SkipGetTargetFrameworkProperties>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <!--PackageReference.GeneratePathProperty does not support NUGET_PACKAGES env var...-->
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(NUGET_PACKAGES)</NuGetPackageRoot>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(UserProfile)\.nuget\packages</NuGetPackageRoot>
-    <PkgMicrosoft_ProjectReunion Condition="'$(PkgMicrosoft_ProjectReunion)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion', '0.5.0-prerelease'))</PkgMicrosoft_ProjectReunion>
-    <PkgMicrosoft_ProjectReunion Condition="!Exists($(PkgMicrosoft_ProjectReunion))">$(SolutionDir)packages\Microsoft.ProjectReunion.0.5.0-prerelease\</PkgMicrosoft_ProjectReunion>
-    <PkgMicrosoft_ProjectReunion_WinUI Condition="'$(PkgMicrosoft_ProjectReunion_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.ProjectReunion.WinUI', '0.5.0-prerelease'))</PkgMicrosoft_ProjectReunion_WinUI>
-    <PkgMicrosoft_ProjectReunion_WinUI Condition="!Exists($(PkgMicrosoft_ProjectReunion_WinUI))">$(SolutionDir)packages\Microsoft.ProjectReunion.WinUI.0.5.0-prerelease\</PkgMicrosoft_ProjectReunion_WinUI>
-    <Microsoft_ProjectReunion_AppXReference_props>$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_ProjectReunion)', 'build'))Microsoft.ProjectReunion.AppXReference.props</Microsoft_ProjectReunion_AppXReference_props>
-    <Microsoft_WinUI_AppX_targets>$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_ProjectReunion_WinUI)', 'build'))Microsoft.WinUI.AppX.targets</Microsoft_WinUI_AppX_targets>
-    <EntryPointProjectUniqueName>..\Param_ProjectName\Param_ProjectName.vcxproj</EntryPointProjectUniqueName>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ProjectReunion" Version="[0.5.0-prerelease]" GeneratePathProperty="true">
-      <ExcludeAssets>all</ExcludeAssets>
+    <PackageReference Include="Microsoft.ProjectReunion" Version="[0.5.0]">
+      <IncludeAssets>build</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[0.5.0-prerelease]" GeneratePathProperty="true">
-      <ExcludeAssets>all</ExcludeAssets>
+    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[0.5.0]">
+      <IncludeAssets>build</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
-  <Import Project="$(Microsoft_ProjectReunion_AppXReference_props)" />
-  <Import Project="$(Microsoft_WinUI_AppX_targets)" />
 </Project>
 <!--/+:msbuild-conditional:noEmit -->

--- a/templates/WinUI/Projects/Default.Desktop._Cpp/.template.config/template.json
+++ b/templates/WinUI/Projects/Default.Desktop._Cpp/.template.config/template.json
@@ -20,7 +20,7 @@
     "wts.outputToParent": "true",
     "wts.version": "1.0.0",
     "wts.displayOrder": "0",
-    "wts.licenses": "[Microsoft.ProjectReunion](https://www.nuget.org/packages/Microsoft.ProjectReunion/0.5.0-prerelease/License)|[Microsoft.Windows.CppWinRT](https://www.nuget.org/packages/Microsoft.Windows.CppWinRT/2.0.210211.2/License)"
+    "wts.licenses": "[Microsoft.ProjectReunion](https://www.nuget.org/packages/Microsoft.ProjectReunion/0.5.0/License)|[Microsoft.Windows.CppWinRT](https://www.nuget.org/packages/Microsoft.Windows.CppWinRT/2.0.210211.2/License)"
   },
   "sourceName": "wts.ProjectName",
   "preferNameDirectory": true,
@@ -97,7 +97,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.ProjectReunion",
-        "version": "0.5.0-prerelease",
+        "version": "0.5.0",
         "projectPath": "Param_ProjectName\\Param_ProjectName.vcxproj"
       },
       "continueOnError": true
@@ -108,7 +108,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.ProjectReunion.Foundation",
-        "version": "0.5.0-prerelease",
+        "version": "0.5.0",
         "projectPath": "Param_ProjectName\\Param_ProjectName.vcxproj"
       },
       "continueOnError": true
@@ -119,7 +119,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.ProjectReunion.WinUI",
-        "version": "0.5.0-prerelease",
+        "version": "0.5.0",
         "projectPath": "Param_ProjectName\\Param_ProjectName.vcxproj"
       },
       "continueOnError": true

--- a/templates/WinUI/Projects/Default.Desktop._Cpp/wts.ProjectName/App.xaml.cpp
+++ b/templates/WinUI/Projects/Default.Desktop._Cpp/wts.ProjectName/App.xaml.cpp
@@ -21,7 +21,6 @@ using namespace Param_RootNamespace::implementation;
 App::App()
 {
     InitializeComponent();
-    Suspending({ this, &App::OnSuspending });
 
 //-:cnd:noEmit
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
@@ -46,16 +45,4 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
 {
     window = make<MainWindow>();
     window.Activate();
-}
-
-/// <summary>
-/// Invoked when application execution is being suspended.  Application state is saved
-/// without knowing whether the application will be terminated or resumed with the contents
-/// of memory still intact.
-/// </summary>
-/// <param name="sender">The source of the suspend request.</param>
-/// <param name="e">Details about the suspend request.</param>
-void App::OnSuspending([[maybe_unused]] IInspectable const& sender, [[maybe_unused]] Windows::ApplicationModel::SuspendingEventArgs const& e)
-{
-    // Save application state and stop any background activity
 }


### PR DESCRIPTION
**Quick summary of changes**
- Updated WinUI 3 templates to Reunion 0.5 (C++)
- Fix WinUI Right click and OneByOne Tests

**Which issue does this PR relate to?**
#4095 Update WinUI 3 templates to Reunion 0.5 

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
|No | No |Yes |

