### PR TITLE
Update Nuget.Config

### DIFF
--- a/code/Nuget.Config
+++ b/code/Nuget.Config
@@ -6,7 +6,6 @@
   </packageRestore>
   <packageSources>
     <clear />
-	<add key="wct" value="https://pkgs.dev.azure.com/dotnet/WindowsCommunityToolkit/_packaging/WindowsCommunityToolkit-WinUI3/nuget/v3/index.json" />
     <add key="wts" value="https://winappstudio.pkgs.visualstudio.com/WTS/_packaging/wts/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
As the WindowsCommunity Toolkit for WinUI was updated to the release version available on nuget.org in https://github.com/microsoft/WindowsTemplateStudio/pull/4193 we can remove this feed.
