### PR TITLE
Adjust test executionsets

### DIFF
--- a/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildToolkitMVVMProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Uwp/BuildToolkitMVVMProjectTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Templates.Test.Build.Uwp
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMToolkit, ProgrammingLanguages.CSharp, Platforms.Uwp)]
         [Trait("ExecutionSet", "Minimum")]
-        [Trait("ExecutionSet", "MinimumMVVMToolkit")]
+        [Trait("ExecutionSet", "BuildMvvmToolkit")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
         public async Task BuildAndTest_All_CheckWithStyleCop_G1_UwpAsync(string projectType, string framework, string platform, string language)

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildCodeBehindProjectTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
-        [Trait("ExecutionSet", "CodeBehindWpf")]
+        [Trait("ExecutionSet", "BuildCodeBehindWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyleWpf")]
         public async Task Build_All_CheckWithStyleCop_G1_WpfAsync(string projectType, string framework, string platform, string language)

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMBasicProjectTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMBasic, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
-        [Trait("ExecutionSet", "MVVMBasicWpf")]
+        [Trait("ExecutionSet", "BuildMVVMBasicWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyleWpf")]
         public async Task Build_All_CheckWithStyleCop_G1_WpfAsync(string projectType, string framework, string platform, string language)

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildMVVMLightProjectTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMLight, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
-        [Trait("ExecutionSet", "MVVMLightWpf")]
+        [Trait("ExecutionSet", "BuildMVVMLightWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyleWpf")]
         public async Task Build_All_CheckWithStyleCop_G1_WpfAsync(string projectType, string framework, string platform, string language)

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildPrismProjectTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.Prism, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
-        [Trait("ExecutionSet", "PrismWpf")]
+        [Trait("ExecutionSet", "BuildPrismWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyleWpf")]
         public async Task Build_All_CheckWithStyleCop_G1_WpfAsync(string projectType, string framework, string platform, string language)

--- a/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildToolkitMVVMProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/Wpf/BuildToolkitMVVMProjectTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Templates.Test.Build.Wpf
         [Theory]
         [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.MVVMToolkit, ProgrammingLanguages.CSharp, Platforms.Wpf)]
         [Trait("ExecutionSet", "MinimumWpf")]
-        [Trait("ExecutionSet", "MinimumMVVMToolkitWpf")]
+        [Trait("ExecutionSet", "BuildMVVMToolkitWpf")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyleWpf")]
         public async Task Build_All_CheckWithStyleCop_G1_WpfAsync(string projectType, string framework, string platform, string language)


### PR DESCRIPTION
**Quick summary of changes**
- Fix executionset name for WPF Build_All_CheckWithStyleCop_G1_WpfAsync tests
- Move Build_All_CheckWithStyleCop_G1* tests on MVVMToolkit from MinimumMVVMToolkit to BuildMvvmToolkit execution set

**Which issue does this PR relate to?**
#4223

