### PR TITLE
Fix winui tests

### DIFF
--- a/code/src/UI/Services/ProjectConfigInfoService.cs
+++ b/code/src/UI/Services/ProjectConfigInfoService.cs
@@ -239,8 +239,8 @@ namespace Microsoft.Templates.UI.Services
                     return ExistsFileInProjectPath("Views", "ShellWindow.xaml")
                         && FileContainsLine("Views", "ShellWindow.xaml", "<controls:HamburgerMenu");
                 case Platforms.WinUI:
-                    return ExistsFileInProjectPath("Views", "ShellWindow.xaml")
-                        && FileContainsLine("Views", "ShellWindow.xaml", "<NavigationView");
+                    return ExistsFileInProjectPath("Views", "ShellPage.xaml")
+                        && FileContainsLine("Views", "ShellPage.xaml", "<NavigationView");
                 default:
                     return false;
             }

--- a/code/test/Templates.Test/BaseGenAndBuildFixture.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildFixture.cs
@@ -403,7 +403,10 @@ namespace Microsoft.Templates.Test
                 var appModels = AppModels.GetAllAppModels().ToList();
                 foreach (var appModel in appModels)
                 {
-                    result.AddRange(GetTemplateOptions(frameworkFilter, language, platform, excludedItem, appModel));
+                    if (appModel == AppModels.Desktop)
+                    {
+                        result.AddRange(GetTemplateOptions(frameworkFilter, language, platform, excludedItem, appModel));
+                    }
                 }
             }
             else

--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -634,31 +634,17 @@ namespace Microsoft.Templates.Test
             switch (framework)
             {
                 case Frameworks.CodeBehind:
-                    result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
-                    break;
-
+                case Frameworks.None:
                 case Frameworks.MVVMBasic:
-                    result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
-                    break;
-
                 case Frameworks.MVVMLight:
-                    result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
-                    break;
-
                 case Frameworks.MVVMToolkit:
-                    result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
-                    break;
-
                 case Frameworks.CaliburnMicro:
+                case Frameworks.Prism:
                     result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
                     break;
 
                 case "LegacyFrameworks":
                     result = BuildRightClickWithLegacyFixture.GetProjectTemplates(platform, programmingLanguage);
-                    break;
-
-                case Frameworks.Prism:
-                    result = BuildTemplatesTestFixture.GetProjectTemplates(framework, programmingLanguage, platform);
                     break;
 
                 default:

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildTemplatesTestFixture.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildTemplatesTestFixture.cs
@@ -61,7 +61,10 @@ namespace Microsoft.Templates.Test
                         var appModels = AppModels.GetAllAppModels().ToList();
                         foreach (var appModel in appModels)
                         {
-                            result.AddRange(GetContextOptions(frameworkFilter, language, platform, appModel));
+                            if (appModel == AppModels.Desktop)
+                            {
+                                result.AddRange(GetContextOptions(frameworkFilter, language, platform, appModel));
+                            }
                         }
                     }
                     else

--- a/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildNoneProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildNoneProjectTests.cs
@@ -132,24 +132,5 @@ namespace Microsoft.Templates.Test.Build.WinUI
 
             AssertBuildProject(projectPath, projectName, platform);
         }
-
-        [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.None, ProgrammingLanguages.CSharp, Platforms.WinUI, "")]
-        [Trait("ExecutionSet", "BuildOneByOneNoneWinUI")]
-        [Trait("ExecutionSet", "_OneByOne")]
-        [Trait("Type", "BuildOneByOneNoneWinUI")]
-        public async Task Build_None_OneByOneItems_WinUIAsync(string itemName, string projectType, string framework, string platform, string itemId, string language, string appModel)
-        {
-            var context = new UserSelectionContext(language, platform)
-            {
-                ProjectType = projectType,
-                FrontEndFramework = framework,
-            };
-            context.AddAppModel(appModel);
-
-            var (ProjectPath, ProjecName) = await AssertGenerationOneByOneAsync(itemName, context, itemId, false);
-
-            AssertBuildProject(ProjectPath, ProjecName, platform);
-        }
     }
 }

--- a/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildNoneProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/WinUI/BuildNoneProjectTests.cs
@@ -15,19 +15,19 @@ using Xunit;
 namespace Microsoft.Templates.Test.Build.WinUI
 {
     [Collection("BuildTemplateTestCollection")]
-    public class BuildCodeBehindProjectTests : BaseGenAndBuildTests
+    public class BuildNoneBehindProjectTests : BaseGenAndBuildTests
     {
-        public BuildCodeBehindProjectTests(BuildTemplatesTestFixture fixture)
-            : base(fixture, null, Frameworks.CodeBehind)
+        public BuildNoneBehindProjectTests(BuildTemplatesTestFixture fixture)
+            : base(fixture, null, Frameworks.None)
         {
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.WinUI)]
-        [Trait("ExecutionSet", "BuildCodeBehindWinUI")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.None, ProgrammingLanguages.CSharp, Platforms.WinUI)]
+        [Trait("ExecutionSet", "BuildNoneBehindWinUI")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildProjects")]
-        public async Task Build_EmptyProject_CodeBehindAsync(string projectType, string framework, string platform, string language, string appModel)
+        public async Task Build_EmptyProject_NoneAsync(string projectType, string framework, string platform, string language, string appModel)
         {
             var context = new UserSelectionContext(language, platform)
             {
@@ -45,8 +45,8 @@ namespace Microsoft.Templates.Test.Build.WinUI
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.WinUI)]
-        [Trait("ExecutionSet", "BuildCodeBehindWinUI")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.None, ProgrammingLanguages.CSharp, Platforms.WinUI)]
+        [Trait("ExecutionSet", "BuildNoneWinUI")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildAllPagesAndFeatures")]
         [Trait("Type", "BuildRandomNames")]
@@ -74,9 +74,9 @@ namespace Microsoft.Templates.Test.Build.WinUI
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.WinUI)]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.None, ProgrammingLanguages.CSharp, Platforms.WinUI)]
         [Trait("ExecutionSet", "MinimumWinUI")]
-        [Trait("ExecutionSet", "MinimumCodeBehindWinUI")]
+        [Trait("ExecutionSet", "MinimumNoneWinUI")]
         [Trait("ExecutionSet", "_CIBuild")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "CodeStyle")]
@@ -107,8 +107,8 @@ namespace Microsoft.Templates.Test.Build.WinUI
 
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.WinUI)]
-        [Trait("ExecutionSet", "BuildCodeBehindWinUI")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetProjectTemplatesForBuild), Frameworks.None, ProgrammingLanguages.CSharp, Platforms.WinUI)]
+        [Trait("ExecutionSet", "BuildNoneWinUI")]
         [Trait("ExecutionSet", "_Full")]
         [Trait("Type", "BuildRightClick")]
         public async Task Build_Empty_AddRightClick_WinUIAsync(string projectType, string framework, string platform, string language, string appModel)
@@ -134,11 +134,11 @@ namespace Microsoft.Templates.Test.Build.WinUI
         }
 
         [Theory]
-        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.CodeBehind, ProgrammingLanguages.CSharp, Platforms.WinUI, "")]
-        [Trait("ExecutionSet", "BuildOneByOneCodeBehindWinUI")]
+        [MemberData(nameof(BaseGenAndBuildTests.GetPageAndFeatureTemplatesForBuild), Frameworks.None, ProgrammingLanguages.CSharp, Platforms.WinUI, "")]
+        [Trait("ExecutionSet", "BuildOneByOneNoneWinUI")]
         [Trait("ExecutionSet", "_OneByOne")]
-        [Trait("Type", "BuildOneByOneCodeBehindWinUI")]
-        public async Task Build_CodeBehind_OneByOneItems_WinUIAsync(string itemName, string projectType, string framework, string platform, string itemId, string language, string appModel)
+        [Trait("Type", "BuildOneByOneNoneWinUI")]
+        public async Task Build_None_OneByOneItems_WinUIAsync(string itemName, string projectType, string framework, string platform, string itemId, string language, string appModel)
         {
             var context = new UserSelectionContext(language, platform)
             {

--- a/code/test/Templates.Test/Frameworks.cs
+++ b/code/test/Templates.Test/Frameworks.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Templates.Test
 
         public const string MVVMToolkit = "MVVMToolkit";
 
+        public const string None = "None";
+
         public const string Prism = "Prism";
     }
 }

--- a/code/test/Templates.Test/Templates.Test.csproj
+++ b/code/test/Templates.Test/Templates.Test.csproj
@@ -86,7 +86,7 @@
     <Compile Include="BuildTemplatesTests\Uwp\BuildCaliburnMicroProjectTests.cs" />
     <Compile Include="BuildTemplatesTests\Uwp\BuildCodeBehindProjectTests.cs" />
     <Compile Include="BuildFixture.cs" />
-    <Compile Include="BuildTemplatesTests\WinUI\BuildCodeBehindProjectTests.cs" />
+    <Compile Include="BuildTemplatesTests\WinUI\BuildNoneProjectTests.cs" />
     <Compile Include="BuildTemplatesTests\Wpf\BuildToolkitMVVMProjectTests.cs" />
     <Compile Include="BuildTemplatesTests\WinUI\BuildMVVMToolkitProjectTests.cs" />
     <Compile Include="BuildTemplatesTests\Wpf\BuildCodeBehindProjectTests.cs" />

--- a/docs/getting-started-developers.md
+++ b/docs/getting-started-developers.md
@@ -89,7 +89,7 @@ The following list shows which tests are executed in which build. Within the Tem
     - ExecutionSet=MinimumMVVMToolkitWPF
     - ExecutionSet=MinimumPrismWPF
     - ExecutionSet=MinimumMVVMToolkitWinUI
-    - ExecutionSet=MinimumCodeBehindWinUI
+    - ExecutionSet=MinimumNoneWinUI
     - ExecutionSet=TemplateValidation
 
 - VSO 'CIBuild' Build (CI):
@@ -128,7 +128,7 @@ The following list shows which tests are executed in which build. Within the Tem
     - ExecutionSet=BuildMVVMLightWpf
     - ExecutionSet=BuildRightClickWithLegacyWpf
     - ExecutionSet=BuildMVVMToolkitWinUI
-    - ExecutionSet=BuildCodeBehindWinUI
+    - ExecutionSet=BuildNoneWinUI
 
 - VSO 'Templates.Test.OneByOne' Build (OneByOne Tests):
   - Templates.Test
@@ -144,7 +144,6 @@ The following list shows which tests are executed in which build. Within the Tem
     - ExecutionSet=BuildOneByOneMVVMLightWpf
     - ExecutionSet=BuildOneByOnePrismWpf
     - ExecutionSet=BuildOneByOneMVVMToolkitWinUI
-    - ExecutionSet=BuildOneByOneCodeBehindWinUI
 
 - VSO 'Templates.Test.Wack' Build (Wack Tests):
     - Templates.Test

--- a/templates/WinUI/Features/MSIX/Param_ProjectName (Package)/Param_ProjectName (Package).wapproj
+++ b/templates/WinUI/Features/MSIX/Param_ProjectName (Package)/Param_ProjectName (Package).wapproj
@@ -36,7 +36,6 @@
   <PropertyGroup>
     <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
     <PathToXAMLWinRTImplementations>Param_ProjectName\</PathToXAMLWinRTImplementations>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
   </PropertyGroup>
 
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
@@ -45,6 +44,7 @@
     <ProjectGuid>378ed3d7-d630-4039-8b8e-93310ba6b05e</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>..\Param_ProjectName\Param_ProjectName.csproj</EntryPointProjectUniqueName>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
- The AssetTargetFallback property needs to be defined after the definition of the TargetPlatformVersion property as the former has a dependency on the latter.
- Update automated tests with latest changes: 
  - Remove tests for Uwp templates
  - Use Framework None instead of CodeBehind
  - Rename ShellWindow to ShellPage

**Which issue does this PR relate to?**
- #4197 Review + Re-enable WinUI Template Tests

**Applies to the following platforms:**

| UWP              | WPF              | WinUI           |
| :--------------- | :--------------- | :---------------|
| No | No | Yes |


