### PR TITLE
Add developer TODOs and update FrameworkReferences to 10.0.19041.16

### DIFF
--- a/templates/WinUI/Projects/Default.Blank/wts.ProjectName/App.xaml.cs
+++ b/templates/WinUI/Projects/Default.Blank/wts.ProjectName/App.xaml.cs
@@ -20,6 +20,10 @@ using Windows.Foundation.Collections;
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace Param_RootNamespace
 {
+    // TODO WTS: Please remove the fixed FrameworkReferences from the wts.ProjectName.csproj file
+    // once you updated to .NET SDK 5.0.204 or 5.0.300.
+    // For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues
+
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>

--- a/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
+++ b/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
@@ -8,9 +8,9 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
-  
+
   <!-- TODO WTS: This is a temporary workaround as Project Reunion 0.5.7 requires WinRT.Runtime.dll version 1.2 or greater.
-  Please remove the fixed FrameworkReferences once you updated to .NET SDK 5.0.204 or 5.0.300 (when available) which fixes this. 
+  Please remove the fixed FrameworkReferences once you updated to .NET SDK 5.0.204 or 5.0.300 (when available) which fixes this.
   For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues -->
   <ItemGroup>
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.16" />

--- a/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
+++ b/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
@@ -8,9 +8,13 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
+  
+  <!-- TODO WTS: This is a temporary workaround as Project Reunion 0.5.7 requires WinRT.Runtime.dll version 1.2 or greater.
+  Please remove the fixed FrameworkReferences once you updated to .NET SDK 5.0.204 or 5.0.300 (when available) which fixes this. 
+  For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues -->
   <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.16" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.16" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.16" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.16" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />

--- a/templates/WinUI/Projects/Default/wts.ProjectName/App.xaml.cs
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/App.xaml.cs
@@ -4,6 +4,9 @@ using Param_RootNamespace.Helpers;
 // To learn more about WinUI3, see: https://docs.microsoft.com/windows/apps/winui/winui3/.
 namespace Param_RootNamespace
 {
+    // TODO WTS: Please remove the fixed FrameworkReferences from the wts.ProjectName.csproj file
+    // once you updated to .NET SDK 5.0.204 or 5.0.300.
+    // For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues
     public partial class App : Application
     {
         public static Window MainWindow { get; set; } = new Window() { Title = "AppDisplayName".GetLocalized() };

--- a/templates/WinUI/Projects/Default/wts.ProjectName/wts.ProjectName.csproj
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/wts.ProjectName.csproj
@@ -8,9 +8,13 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
+
+  <!-- TODO WTS: This is a temporary workaround as Project Reunion 0.5.7 requires WinRT.Runtime.dll version 1.2 or greater.
+  Please remove the fixed FrameworkReferences once you updated to .NET SDK 5.0.204 or 5.0.300 (when available) which fixes this.
+  For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues-->
   <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.16" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.16" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.16" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.16" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
- Update FrameworkReferences to 10.0.19041.16
- Add developer TODOs

**Which issue does this PR relate to?**
#4229 Remove FrameworkReference once .NET 5.0.6 is available 

**Applies to the following platforms:**

| UWP              | WPF              | WinUI            |
| :--------------- | :--------------- | :----------------|
| No | No | Yes |


