### PR TITLE
Remove fixed FrameworkReferences and related comments

### DIFF
--- a/templates/WinUI/Projects/Default.Blank/wts.ProjectName/App.xaml.cs
+++ b/templates/WinUI/Projects/Default.Blank/wts.ProjectName/App.xaml.cs
@@ -20,10 +20,6 @@ using Windows.Foundation.Collections;
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace Param_RootNamespace
 {
-    // TODO WTS: Please remove the fixed FrameworkReferences from the wts.ProjectName.csproj file
-    // once you have updated to .NET SDK 5.0.204 or 5.0.300.
-    // For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues
-
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>

--- a/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
+++ b/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
@@ -9,13 +9,6 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
-  <!-- TODO WTS: This is a temporary workaround as Project Reunion 0.5.7 requires WinRT.Runtime.dll version 1.2 or greater.
-  Please remove the fixed FrameworkReferences once you have updated to .NET SDK 5.0.204 or 5.0.300 (when available) which fixes this.
-  For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues -->
-  <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.16" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.16" />
-  </ItemGroup>
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/templates/WinUI/Projects/Default/wts.ProjectName/App.xaml.cs
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/App.xaml.cs
@@ -4,9 +4,6 @@ using Param_RootNamespace.Helpers;
 // To learn more about WinUI3, see: https://docs.microsoft.com/windows/apps/winui/winui3/.
 namespace Param_RootNamespace
 {
-    // TODO WTS: Please remove the fixed FrameworkReferences from the wts.ProjectName.csproj file
-    // once you have updated to .NET SDK 5.0.204 or 5.0.300.
-    // For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues
     public partial class App : Application
     {
         public static Window MainWindow { get; set; } = new Window() { Title = "AppDisplayName".GetLocalized() };

--- a/templates/WinUI/Projects/Default/wts.ProjectName/wts.ProjectName.csproj
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/wts.ProjectName.csproj
@@ -9,13 +9,6 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
-  <!-- TODO WTS: This is a temporary workaround as Project Reunion 0.5.7 requires WinRT.Runtime.dll version 1.2 or greater.
-  Please remove the fixed FrameworkReferences once you have updated to .NET SDK 5.0.204 or 5.0.300 (when available) which fixes this.
-  For more info see https://docs.microsoft.com/windows/apps/winui/winui3/#known-issues-->
-  <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.16" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.16" />
-  </ItemGroup>
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/templates/WinUI/SC/StyleCop/Param_ProjectName/Param_ProjectName_postaction.csproj
+++ b/templates/WinUI/SC/StyleCop/Param_ProjectName/Param_ProjectName_postaction.csproj
@@ -5,7 +5,7 @@
 <!--{[{-->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1701;1702;CS0618;CS8305</NoWarn>
+    <NoWarn>1701;1702;CA1416</NoWarn>
   </PropertyGroup>
 <!--}]}-->
 </Project>


### PR DESCRIPTION
**Quick summary of changes**
Remove fixed FrameworkReferences and related comments

**Which issue does this PR relate to?**
#4229 Remove FrameworkReference once .NET SDK 5.0.204 or 5.0.300 is available

**Applies to the following platforms:**

| UWP              | WPF              | WinUI            |
| :--------------- | :--------------- | :----------------|
| No | No | Yes |

