### PR TITLE
Exclude CA1416 warnings from project

### DIFF
--- a/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
+++ b/templates/WinUI/Projects/Default.Blank/wts.ProjectName/wts.ProjectName.csproj
@@ -9,6 +9,11 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
+  <!-- Workaround for https://github.com/dotnet/sdk/issues/17890 -->
+  <PropertyGroup>
+    <NoWarn>CA1416, $(NoWarn)</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/templates/WinUI/Projects/Default/wts.ProjectName/wts.ProjectName.csproj
+++ b/templates/WinUI/Projects/Default/wts.ProjectName/wts.ProjectName.csproj
@@ -9,6 +9,11 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
+  <!-- Workaround for https://github.com/dotnet/sdk/issues/17890 -->
+  <PropertyGroup>
+    <NoWarn>CA1416, $(NoWarn)</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/templates/WinUI/SC/StyleCop/Param_ProjectName/Param_ProjectName_postaction.csproj
+++ b/templates/WinUI/SC/StyleCop/Param_ProjectName/Param_ProjectName_postaction.csproj
@@ -3,9 +3,8 @@
     <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
   </PropertyGroup>
 <!--{[{-->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+  <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1701;1702;CA1416</NoWarn>
   </PropertyGroup>
 <!--}]}-->
 </Project>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Exclude CA1416 warnings from project

**Which issue does this PR relate to?**
#4314 Big number of warnings after compiling generated WinUI 3 app on VS 16.10

**Applies to the following platforms:**

| UWP              | WPF              | WinUI            |
| :--------------- | :--------------- | :----------------|
| No | No | Yes |

