### PR TITLE
[WPF] Update nuget packages in generated code

### DIFF
--- a/templates/Wpf/Features/ToastNotifications/.template.config/template.json
+++ b/templates/Wpf/Features/ToastNotifications/.template.config/template.json
@@ -56,7 +56,7 @@
         "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
         "args": {
           "packageId": "Microsoft.Toolkit.Uwp.Notifications",
-          "version": "7.0.1",
+          "version": "7.0.2",
           "projectPath": "Param_ProjectName.csproj"
         },
         "continueOnError": true

--- a/templates/Wpf/Projects/Default.Prism/.template.config/template.json
+++ b/templates/Wpf/Projects/Default.Prism/.template.config/template.json
@@ -83,7 +83,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Prism.Unity",
-        "version": "8.0.0.1909",
+        "version": "8.1.97",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -94,7 +94,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Extensions.Configuration",
-        "version": "3.1.14",
+        "version": "3.1.16",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -105,7 +105,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Extensions.Configuration.Binder",
-        "version": "3.1.14",
+        "version": "3.1.16",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -116,7 +116,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Extensions.Configuration.CommandLine",
-        "version": "3.1.14",
+        "version": "3.1.16",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -127,7 +127,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Extensions.Configuration.Json",
-        "version": "3.1.14",
+        "version": "3.1.16",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -138,7 +138,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "MahApps.Metro",
-        "version": "2.4.4",
+        "version": "2.4.6",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Projects/Default/.template.config/template.json
+++ b/templates/Wpf/Projects/Default/.template.config/template.json
@@ -87,7 +87,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.Extensions.Hosting",
-        "version": "3.1.14",
+        "version": "3.1.16",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true
@@ -98,7 +98,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "MahApps.Metro",
-        "version": "2.4.4",
+        "version": "2.4.6",
         "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Testing/UnitTests.App.MSTest/.template.config/template.json
+++ b/templates/Wpf/Testing/UnitTests.App.MSTest/.template.config/template.json
@@ -60,7 +60,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.9.4",
+        "version" : "16.10.0",
         "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj"
       },
       "continueOnError": true
@@ -71,7 +71,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "MSTest.TestAdapter",
-        "version" : "2.2.3",
+        "version" : "2.2.4",
         "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj"
       },
       "continueOnError": true
@@ -82,7 +82,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "MSTest.TestFramework",
-        "version" : "2.2.3",
+        "version" : "2.2.4",
         "projectPath": "Param_ProjectName.Tests.MSTest\\Param_ProjectName.Tests.MSTest.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Testing/UnitTests.App.NUnit/.template.config/template.json
+++ b/templates/Wpf/Testing/UnitTests.App.NUnit/.template.config/template.json
@@ -60,7 +60,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.9.4",
+        "version" : "16.10.0",
         "projectPath": "Param_ProjectName.Tests.NUnit\\Param_ProjectName.Tests.NUnit.csproj"
       },
       "continueOnError": true
@@ -71,7 +71,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "NUnit3TestAdapter",
-        "version" : "3.17.0",
+        "version" : "4.0.0",
         "projectPath": "Param_ProjectName.Tests.NUnit\\Param_ProjectName.Tests.NUnit.csproj"
       },
       "continueOnError": true
@@ -82,7 +82,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "NUnit",
-        "version" : "3.13.1",
+        "version" : "3.13.2",
         "projectPath": "Param_ProjectName.Tests.NUnit\\Param_ProjectName.Tests.NUnit.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Testing/UnitTests.App.xUnit/.template.config/template.json
+++ b/templates/Wpf/Testing/UnitTests.App.xUnit/.template.config/template.json
@@ -60,7 +60,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.9.4",
+        "version" : "16.10.0",
         "projectPath": "Param_ProjectName.Tests.xUnit\\Param_ProjectName.Tests.xUnit.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Testing/UnitTests.Core.MSTest/.template.config/template.json
+++ b/templates/Wpf/Testing/UnitTests.Core.MSTest/.template.config/template.json
@@ -46,7 +46,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.9.4",
+        "version" : "16.10.0",
         "projectPath": "Param_ProjectName.Core.Tests.MSTest\\Param_ProjectName.Core.Tests.MSTest.csproj"
       },
       "continueOnError": true
@@ -57,7 +57,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "MSTest.TestAdapter",
-        "version" : "2.2.3",
+        "version" : "2.2.4",
         "projectPath": "Param_ProjectName.Core.Tests.MSTest\\Param_ProjectName.Core.Tests.MSTest.csproj"
       },
       "continueOnError": true
@@ -68,7 +68,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "MSTest.TestFramework",
-        "version" : "2.2.3",
+        "version" : "2.2.4",
         "projectPath": "Param_ProjectName.Core.Tests.MSTest\\Param_ProjectName.Core.Tests.MSTest.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Testing/UnitTests.Core.NUnit/.template.config/template.json
+++ b/templates/Wpf/Testing/UnitTests.Core.NUnit/.template.config/template.json
@@ -46,7 +46,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "nunit",
-        "version" : "3.13.1",
+        "version" : "3.13.2",
         "projectPath": "Param_ProjectName.Core.Tests.NUnit\\Param_ProjectName.Core.Tests.NUnit.csproj"
       },
       "continueOnError": true
@@ -57,7 +57,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "NUnit3TestAdapter",
-        "version" : "3.17.0",
+        "version" : "4.0.0",
         "projectPath": "Param_ProjectName.Core.Tests.NUnit\\Param_ProjectName.Core.Tests.NUnit.csproj"
       },
       "continueOnError": true
@@ -68,7 +68,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.9.4",
+        "version" : "16.10.0",
         "projectPath": "Param_ProjectName.Core.Tests.NUnit\\Param_ProjectName.Core.Tests.NUnit.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Testing/UnitTests.Core.xUnit/.template.config/template.json
+++ b/templates/Wpf/Testing/UnitTests.Core.xUnit/.template.config/template.json
@@ -68,7 +68,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.9.4",
+        "version" : "16.10.0",
         "projectPath": "Param_ProjectName.Core.Tests.xUnit\\Param_ProjectName.Core.Tests.xUnit.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/Testing/WinAppDriver/.template.config/template.json
+++ b/templates/Wpf/Testing/WinAppDriver/.template.config/template.json
@@ -65,7 +65,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.NET.Test.Sdk",
-        "version" : "16.9.4",
+        "version" : "16.10.0",
         "projectPath": "Param_ProjectName.Tests.WinAppDriver\\Param_ProjectName.Tests.WinAppDriver.csproj"
       },
       "continueOnError": true
@@ -76,7 +76,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "MSTest.TestAdapter",
-        "version" : "2.2.3",
+        "version" : "2.2.4",
         "projectPath": "Param_ProjectName.Tests.WinAppDriver\\Param_ProjectName.Tests.WinAppDriver.csproj"
       },
       "continueOnError": true
@@ -87,7 +87,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "MSTest.TestFramework",
-        "version" : "2.2.3",
+        "version" : "2.2.4",
         "projectPath": "Param_ProjectName.Tests.WinAppDriver\\Param_ProjectName.Tests.WinAppDriver.csproj"
       },
       "continueOnError": true

--- a/templates/Wpf/_comp/MVVMToolkit/Project/.template.config/template.json
+++ b/templates/Wpf/_comp/MVVMToolkit/Project/.template.config/template.json
@@ -62,7 +62,7 @@
         "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
         "args": {
           "packageId" : "Microsoft.Toolkit.Mvvm",
-          "version" : "7.0.1",
+          "version" : "7.0.2",
           "projectPath": "Param_ProjectName.csproj"
         },
         "continueOnError": true

--- a/templates/Wpf/_comp/_shared/Project.Ribbon/.template.config/template.json
+++ b/templates/Wpf/_comp/_shared/Project.Ribbon/.template.config/template.json
@@ -15,7 +15,7 @@
       "wts.version": "1.0.0",
       "wts.compositionOrder": "0",
       "wts.compositionFilter": "$projectType == Ribbon & $frontendframework == MVVMBasic|MVVMLight|MVVMToolkit & wts.type == project",
-      "wts.licenses": "[Fluent.Ribbon](https://www.nuget.org/packages/Fluent.Ribbon/7.0.0/license)"
+      "wts.licenses": "[Fluent.Ribbon](https://www.nuget.org/packages/Fluent.Ribbon/8.0.3/License)"
     },
     "sourceName": "wts.ItemName",
     "preferNameDirectory": true,
@@ -66,7 +66,7 @@
         "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
         "args": {
           "packageId": "Fluent.Ribbon",
-          "version": "8.0.2",
+          "version": "8.0.3",
           "projectPath": "Param_ProjectName.csproj"
         },
         "continueOnError": true

--- a/templates/Wpf/_comp/_shared/Service.IdentityCommon/.template.config/template.json
+++ b/templates/Wpf/_comp/_shared/Service.IdentityCommon/.template.config/template.json
@@ -89,7 +89,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId" : "Microsoft.Identity.Client",
-        "version" : "4.29.0",
+        "version" : "4.32.1",
         "projectPath": "Param_ProjectName.Core\\Param_ProjectName.Core.csproj"
       },
       "continueOnError": true


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Update WPF nuget packages to latests versions

**Which issue does this PR relate to?**
Update nuget packages in generated code #4346

**Applies to the following platforms:**

| UWP              | WPF              | WinUI            |
| :--------------- | :--------------- | :----------------|
| No | Yes | No |

**Anything that requires particular review or attention?**

_Updated packages_

MahApps.Metro 2.4.6
Microsoft.Extensions.Hosting 3.1.16
Microsoft.Extensions.Configuration 3.1.16
Microsoft.Extensions.Configuration.Binder 3.1.16
Microsoft.Extensions.Configuration.CommandLine 3.1.16
Microsoft.Extensions.Configuration.Json 3.1.16
Microsoft.Identity.Client 4.32.1
Microsoft.NET.Test.Sdk 16.10.0
Microsoft.Toolkit.Mvvm 7.0.2
Microsoft.Toolkit.Uwp.Notifications 7.0.2
MSTest.TestAdapter 2.2.4
MSTest.TestFramework 2.2.4
NUnit 3.13.2
NUnit3TestAdapter 4.0.0
Prism.Unity 8.1.97
Fluent.Ribbon 8.0.3

_Not-updated packages_

Microsoft.VCRTForwarders
Microsoft.NETCore.UniversalWindowsPlatform (Default on VS2019 for UWP Projects)
